### PR TITLE
Updating core module for #16.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
         classpath 'org.ajoberstar:gradle-git:0.12.0'
         classpath 'org.pegdown:pegdown:1.4.1'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.7'
     }
 }
 
@@ -15,6 +16,12 @@ import org.pegdown.PegDownProcessor
 import groovy.text.SimpleTemplateEngine
 
 apply plugin: 'org.ajoberstar.release-base'
+
+allprojects {
+    apply plugin: 'project-report'
+    apply plugin: 'com.github.ben-manes.versions'
+}
+
 release {
     grgit = Grgit.open(project.file('.'))
     versionStrategy Strategies.FINAL

--- a/build.gradle
+++ b/build.gradle
@@ -164,8 +164,12 @@ subprojects {
 
 
     dependencies {
+        compile "com.google.guava:guava:18.0"
         compile "com.google.inject:guice:3.0"
+        compile "commons-codec:commons-codec:1.9"
+        compile "org.objenesis:objenesis:2.1"
         compile "org.slf4j:slf4j-api:1.6.4"
+        compile "xml-apis:xml-apis:1.4.01"
         testCompile "ch.qos.logback:logback-classic:1.0.13"
         testCompile "junit:junit:4.11"
         testCompile "org.hamcrest:hamcrest-integration:1.3"

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ subprojects {
         compile "com.google.inject:guice:3.0"
         compile "commons-codec:commons-codec:1.9"
         compile "org.objenesis:objenesis:2.1"
-        compile "org.slf4j:slf4j-api:1.6.4"
+        compile "org.slf4j:slf4j-api:1.7.5"
         compile "xml-apis:xml-apis:1.4.01"
         testCompile "ch.qos.logback:logback-classic:1.0.13"
         testCompile "junit:junit:4.11"

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,45 @@ apply plugin: 'org.ajoberstar.release-base'
 allprojects {
     apply plugin: 'project-report'
     apply plugin: 'com.github.ben-manes.versions'
+
+    configurations.all {
+        resolutionStrategy {
+            // fail fast on dependency convergence problems
+            failOnVersionConflict()
+
+            // force versions to fix dependency convergence problems
+            // when updating this list, update Serenity's declared deps if exists
+            // TODO make work for generated Maven POM... 
+            // it's working for gradle build, but also had to exclude old transitives for generated POM
+            force 'asm:asm:3.3.1',
+                'com.fasterxml.jackson.core:jackson-annotations:2.4.3',
+                'com.google.code.gson:gson:2.3',
+                'com.google.guava:guava:18.0',
+                'com.google.inject.extensions:guice-multibindings:3.0',
+                'com.google.inject.extensions:guice-servlet:3.0',
+                'com.google.inject:guice:3.0',
+                'com.thoughtworks.xstream:xstream:1.4.1',
+                'commons-codec:commons-codec:1.9',
+                'commons-collections:commons-collections:3.2.1',
+                'commons-io:commons-io:2.4',
+                'commons-logging:commons-logging:1.1.3',
+                'joda-time:joda-time:2.2',
+                'org.apache.commons:commons-lang3:3.3.2',
+                'org.apache.httpcomponents:httpclient:4.3.4',
+                'org.apache.httpcomponents:httpmime:4.3.3',
+                'org.bouncycastle:bcprov-jdk15on:1.48',
+                'org.codehaus.groovy:groovy-all:2.3.6',
+                'org.codehaus.jackson:jackson-core-asl:1.7.1',
+                'org.codehaus.jackson:jackson-mapper-asl:1.7.1',
+                'org.eclipse.jetty:jetty-http:8.1.15.v20140411',
+                'org.freemarker:freemarker:2.3.21',
+                'org.objenesis:objenesis:2.1',
+                'org.seleniumhq.selenium:selenium-api:2.44.0',
+                'org.slf4j:slf4j-api:1.7.5',
+                'xalan:xalan:2.7.1',
+                'xml-apis:xml-apis:1.4.01'
+        }
+    }
 }
 
 release {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     compile "org.apache.commons:commons-lang3:3.0.1"
     compile "net.sf.flexjson:flexjson:2.1"
     compile "joda-time:joda-time:2.0"
-    compile "net.sourceforge.htmlunit:htmlunit:2.9"
+    compile "net.sourceforge.htmlunit:htmlunit:2.15"
     compile "org.freemarker:freemarker:2.3.21"
     compile("org.fluentlenium:fluentlenium-core:0.10.2") {
         exclude group: 'org.seleniumhq.selenium', module:'selenium-java'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -20,7 +20,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-annotations:2.4.3"
     compile "com.fasterxml.jackson.core:jackson-databind:2.4.3"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-joda:2.4.3"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:2.4.3"
+    compile ("com.fasterxml.jackson.datatype:jackson-datatype-guava:2.4.3") {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
 
     compile ("cglib:cglib:2.2.2") {
         exclude group: 'asm', module: 'asm'
@@ -47,11 +49,14 @@ dependencies {
     }
 
     compile "net.sf.opencsv:opencsv:2.0"
-    compile "commons-beanutils:commons-beanutils-core:1.8.3"
+    compile ("commons-beanutils:commons-beanutils-core:1.8.3") {
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
 
     compile ("com.googlecode.lambdaj:lambdaj:2.3.3") {
         exclude group: 'org.hamcrest', module: 'hamcrest-all'
         exclude group: 'cglib', module: 'cglib-nodep'
+        exclude group: 'org.objenesis', module: 'objenesis'
     }
     compile "com.google.guava:guava:18.0"
     compile "joda-time:joda-time:2.0"
@@ -60,7 +65,9 @@ dependencies {
     compile "commons-collections:commons-collections:3.2.1"
     compile "net.sf.flexjson:flexjson:2.1"
     compile "org.freemarker:freemarker:2.3.19"
-    compile "net.sourceforge.jexcelapi:jxl:2.6.12"
+    compile ("net.sourceforge.jexcelapi:jxl:2.6.12") {
+        exclude group: 'log4j', module: 'log4j'
+    }
     compile "asm:asm:3.3.1"
     compile "org.springframework:spring-test:3.2.3.RELEASE" // optional
     compile "org.springframework:spring-context:3.2.3.RELEASE" // optional
@@ -70,11 +77,16 @@ dependencies {
     compile 'org.hamcrest:hamcrest-library:1.3'
     compile "com.thoughtworks.xstream:xstream:1.4.1"
     compile "commons-collections:commons-collections:3.2.1"
-    compile "org.apache.httpcomponents:httpclient:4.3.4"
+    compile ("org.apache.httpcomponents:httpclient:4.3.4") {
+        exclude group: 'commons-codec', module: 'commons-codec'
+    }
     compile "org.apache.commons:commons-lang3:3.0.1"
     compile "net.sf.flexjson:flexjson:2.1"
     compile "joda-time:joda-time:2.0"
-    compile "net.sourceforge.htmlunit:htmlunit:2.15"
+    compile ("net.sourceforge.htmlunit:htmlunit:2.15") {
+        exclude group: 'commons-logging', module: 'commons-logging'
+        exclude group: 'xml-apis', module: 'xml-apis'
+    }
     compile "org.freemarker:freemarker:2.3.21"
     compile("org.fluentlenium:fluentlenium-core:0.10.2") {
         exclude group: 'org.seleniumhq.selenium', module:'selenium-java'
@@ -88,6 +100,9 @@ dependencies {
     compile "org.hibernate:hibernate-validator:5.1.1.Final"
     compile "javax.el:javax.el-api:2.2.4"
     compile "org.glassfish.web:javax.el:2.2.4"
+
+    compile "org.objenesis:objenesis:2.1"
+    compile "xml-apis:xml-apis:1.4.01"
 
     testCompile project(':serenity-sample-alternative-resources')
     testCompile project(':serenity-test-utils')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile "com.google.guava:guava:18.0"
     compile "joda-time:joda-time:2.0"
     compile "com.thoughtworks.xstream:xstream:1.4.1"
-    compile "org.apache.commons:commons-lang3:3.1"
+    compile "org.apache.commons:commons-lang3:3.3.2"
     compile "commons-collections:commons-collections:3.2.1"
     compile "net.sf.flexjson:flexjson:2.1"
     compile "org.freemarker:freemarker:2.3.19"

--- a/serenity-smoketests/build.gradle
+++ b/serenity-smoketests/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     compile "net.thucydides:thucydides-jbehave-plugin:${thucydidesJBehaveVersion}"
     compile "org.slf4j:slf4j-simple:1.6.1"
     compile "com.googlecode.lambdaj:lambdaj:2.3.3"
-    compile "org.codehaus.groovy:groovy-all:2.2.1"
+    compile "org.codehaus.groovy:groovy-all:2.3.6"
     compile 'joda-time:joda-time:2.4'
     testCompile "org.easytesting:fest-assert-core:2.0M10"
     testCompile "junit:junit:4.11"

--- a/serenity-test-utils/build.gradle
+++ b/serenity-test-utils/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile("org.hamcrest:hamcrest-core:1.3")
     compile("xmlunit:xmlunit:1.3")
 
-    compile("org.slf4j:slf4j-api:1.6.4")
+    compile("org.slf4j:slf4j-api:1.7.5")
 
     testCompile("junit:junit:4.11")
 }


### PR DESCRIPTION
Note that the failOnVersionConflict() added to top build now fails the build when dependency convergence problems exist.  This will keep the gradle build clean and alert to new dep problems.

I only processed core and cucumber modules.  Need to do rest of them - some of them probably fail with this.

With these and the cucumber module changes, the example pom builds clean of transitive dep problems (still catches on a duplicate classes issue across deps; probably need to config client module to ignore them).