### PR TITLE
Upgrade javassist version to match transitive dep. #16

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     compile "junit:junit:4.11"
     compile "javax.validation:validation-api:1.1.0.Final"
     compile "org.hibernate:hibernate-validator:5.1.1.Final"
-    compile "javassist:javassist:3.9.0.GA"
+    compile "javassist:javassist:3.12.1.GA"
     compile "javax.el:javax.el-api:2.2.4"
     compile "org.glassfish.web:javax.el:2.2.4"
 


### PR DESCRIPTION
core's version was 3.9.0.GA; reflections version is 3.12.1.GA