### PR TITLE
serenity-spring support for @ContextHierarchy and meta-annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,9 @@ buildscript {
     }
 }
 
-import org.ajoberstar.grgit.*
-import org.ajoberstar.gradle.git.release.opinion.Strategies
-import org.pegdown.PegDownProcessor
-import groovy.text.SimpleTemplateEngine
 
+import org.ajoberstar.gradle.git.release.opinion.Strategies
+import org.ajoberstar.grgit.Grgit
 
 apply plugin: 'org.ajoberstar.release-base'
 
@@ -23,7 +21,7 @@ ext {
     groovyVersion = '2.3.9'
     junitVersion = '4.11'
     hamcrestVersion = '1.3'
-    springVersion = '3.2.12.RELEASE'
+    springVersion = '4.1.6.RELEASE'
     guavaVersion = '18.0'
     restAssuredVersion = '2.4.1'
 }
@@ -39,7 +37,7 @@ allprojects {
 
             // force versions to fix dependency convergence problems
             // when updating this list, update Serenity's declared deps if exists
-            // TODO make work for generated Maven POM... 
+            // TODO make work for generated Maven POM...
             // it's working for gradle build, but also had to exclude old transitives for geio.appiumnerated POM
             force  'com.thoughtworks.xstream:xstream:1.4.5',
                    'commons-collections:commons-collections:3.2.1',

--- a/serenity-spring/src/main/java/net/serenitybdd/core/di/SpringDependencyInjector.java
+++ b/serenity-spring/src/main/java/net/serenitybdd/core/di/SpringDependencyInjector.java
@@ -1,6 +1,7 @@
 package net.serenitybdd.core.di;
 
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestContextManager;
 
 public class SpringDependencyInjector implements DependencyInjector {
@@ -24,7 +25,7 @@ public class SpringDependencyInjector implements DependencyInjector {
     public void reset() {}
 
     private boolean annotatedWithSpringContext(Object target) {
-        return (target.getClass().getAnnotation(ContextConfiguration.class) != null);
+        return (target.getClass().getAnnotation(ContextConfiguration.class) != null) || (target.getClass().getAnnotation(ContextHierarchy.class) != null);
     }
 
     private boolean springIsOnClasspath() {

--- a/serenity-spring/src/main/java/net/serenitybdd/core/di/SpringDependencyInjector.java
+++ b/serenity-spring/src/main/java/net/serenitybdd/core/di/SpringDependencyInjector.java
@@ -1,5 +1,6 @@
 package net.serenitybdd.core.di;
 
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestContextManager;
@@ -25,7 +26,8 @@ public class SpringDependencyInjector implements DependencyInjector {
     public void reset() {}
 
     private boolean annotatedWithSpringContext(Object target) {
-        return (target.getClass().getAnnotation(ContextConfiguration.class) != null) || (target.getClass().getAnnotation(ContextHierarchy.class) != null);
+
+        return (AnnotationUtils.findAnnotation(target.getClass(), ContextConfiguration.class) != null) || (AnnotationUtils.findAnnotation(target.getClass(), ContextHierarchy.class) != null);
     }
 
     private boolean springIsOnClasspath() {

--- a/serenity-spring/src/test/groovy/net/serenitybdd/core/di/WhenInjectingSpringComponents.groovy
+++ b/serenity-spring/src/test/groovy/net/serenitybdd/core/di/WhenInjectingSpringComponents.groovy
@@ -1,10 +1,9 @@
 package net.serenitybdd.core.di
-
 import net.serenitybdd.core.di.samples.FlatScenarioStepsWithBrokenSpringDependencies
+import net.serenitybdd.core.di.samples.FlatScenarioStepsWithSpringContextHierarchyDependencies
 import net.serenitybdd.core.di.samples.FlatScenarioStepsWithSpringDependencies
 import net.thucydides.core.pages.Pages
 import net.thucydides.core.steps.di.ClasspathDependencyInjectorService
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import spock.lang.Specification
 
 class WhenInjectingSpringComponents extends Specification {
@@ -16,6 +15,17 @@ class WhenInjectingSpringComponents extends Specification {
         given:
             SpringDependencyInjector dependencyInjector = new SpringDependencyInjector();
             FlatScenarioStepsWithSpringDependencies steps = new FlatScenarioStepsWithSpringDependencies(pages);
+        when:
+            dependencyInjector.injectDependenciesInto(steps);
+        then:
+            steps.widgetService != null && steps.catalogService != null
+    }
+
+    def "should inject Spring dependencies into a step library class when using ContextHierarchy"() {
+
+        given:
+            SpringDependencyInjector dependencyInjector = new SpringDependencyInjector();
+            FlatScenarioStepsWithSpringContextHierarchyDependencies steps = new FlatScenarioStepsWithSpringContextHierarchyDependencies(pages);
         when:
             dependencyInjector.injectDependenciesInto(steps);
         then:

--- a/serenity-spring/src/test/groovy/net/serenitybdd/core/di/WhenInjectingSpringComponents.groovy
+++ b/serenity-spring/src/test/groovy/net/serenitybdd/core/di/WhenInjectingSpringComponents.groovy
@@ -2,6 +2,8 @@ package net.serenitybdd.core.di
 import net.serenitybdd.core.di.samples.FlatScenarioStepsWithBrokenSpringDependencies
 import net.serenitybdd.core.di.samples.FlatScenarioStepsWithSpringContextHierarchyDependencies
 import net.serenitybdd.core.di.samples.FlatScenarioStepsWithSpringDependencies
+import net.serenitybdd.core.di.samples.FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies
+import net.serenitybdd.core.di.samples.FlatScenarioStepsWithSpringMetaAnnotationDependencies
 import net.thucydides.core.pages.Pages
 import net.thucydides.core.steps.di.ClasspathDependencyInjectorService
 import spock.lang.Specification
@@ -21,11 +23,33 @@ class WhenInjectingSpringComponents extends Specification {
             steps.widgetService != null && steps.catalogService != null
     }
 
+    def "should inject Spring dependencies into a step library class when using meta ContextConfiguration annotations"() {
+
+        given:
+            SpringDependencyInjector dependencyInjector = new SpringDependencyInjector();
+            FlatScenarioStepsWithSpringMetaAnnotationDependencies steps = new FlatScenarioStepsWithSpringMetaAnnotationDependencies(pages);
+        when:
+            dependencyInjector.injectDependenciesInto(steps);
+        then:
+            steps.widgetService != null && steps.catalogService != null
+    }
+
     def "should inject Spring dependencies into a step library class when using ContextHierarchy"() {
 
         given:
             SpringDependencyInjector dependencyInjector = new SpringDependencyInjector();
             FlatScenarioStepsWithSpringContextHierarchyDependencies steps = new FlatScenarioStepsWithSpringContextHierarchyDependencies(pages);
+        when:
+            dependencyInjector.injectDependenciesInto(steps);
+        then:
+            steps.widgetService != null && steps.catalogService != null
+    }
+
+    def "should inject Spring dependencies into a step library class when using meta ContextHierarchy annotations"() {
+
+        given:
+            SpringDependencyInjector dependencyInjector = new SpringDependencyInjector();
+            FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies steps = new FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies(pages);
         when:
             dependencyInjector.injectDependenciesInto(steps);
         then:

--- a/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/FlatScenarioStepsWithSpringContextHierarchyDependencies.java
+++ b/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/FlatScenarioStepsWithSpringContextHierarchyDependencies.java
@@ -1,0 +1,151 @@
+package net.serenitybdd.core.di.samples;
+
+import net.serenitybdd.core.Serenity;
+import net.thucydides.core.annotations.Pending;
+import net.thucydides.core.annotations.Step;
+import net.thucydides.core.annotations.StepGroup;
+import net.thucydides.core.annotations.Title;
+import net.thucydides.core.pages.Pages;
+import net.thucydides.core.steps.ScenarioSteps;
+
+import org.junit.Ignore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+
+import javax.annotation.Resource;
+
+@ContextHierarchy(@ContextConfiguration(locations = "/spring/config.xml"))
+public class FlatScenarioStepsWithSpringContextHierarchyDependencies extends ScenarioSteps {
+
+    @Autowired
+    public WidgetService widgetService;
+
+
+    @Resource
+    public CatalogService catalogService;
+
+    public FlatScenarioStepsWithSpringContextHierarchyDependencies(Pages pages) {
+        super(pages);
+    }
+
+    @Step
+    public void step_one(){
+    }
+
+    @Step
+    public void step_two() {
+    }
+
+    @Step
+    public void step_three() {
+    }
+
+    @Step
+    public void nested_step_one(){
+    }
+
+    @Step
+    public void nested_step_two() {
+    }
+
+    @Step
+
+    public void nested_step_three() {
+    }
+
+    @Step
+    public void failingStep() {
+        throw new AssertionError("Step failed");
+    }
+
+    @Ignore
+    @Step
+    public void ignoredStep() {}
+
+    @Pending
+    @Step
+    public void pendingStep() {}
+
+    @Pending
+    @Step
+    public void pending_group() {
+        step_three();
+        step_two();
+        step_one();
+    }
+
+    @Title("A step with a title")
+    @Step
+    public void step_with_title() {}
+
+    @Ignore
+    @Step
+    public void ignored_group() {
+        step_three();
+        step_two();
+        step_one();
+    }
+
+    @Step
+    public void grouped_steps() {
+        nested_step_one();
+        nested_step_two();
+        nested_step_one();
+        nested_step_two();
+    }
+
+    @Step
+    public void deeply_grouped_steps() {
+        step_one();
+        step_two();
+        grouped_steps();
+        step_two();
+        step_one();
+    }
+
+    @Step
+    public void stepWithLongName() {}
+
+    @Step
+    public void stepWithParameters(String name) {}
+
+    @Step
+    public void step_with_long_name_and_underscores() {}
+
+    @StepGroup("Annotated step group title")
+    public void a_step_group() {
+        stepWithLongName();
+        step_with_long_name_and_underscores();
+    }
+
+    @Step
+    public void a_plain_step_group() {
+        stepWithLongName();
+        step_with_long_name_and_underscores();
+    }
+
+    @Step
+    public void stepCausingANullPointerException() {
+        String nullValue = null;
+        nullValue.length();
+    }
+
+    public void unannotatedStepCausingANullPointerException() {
+        String nullValue = null;
+        nullValue.length();
+    }
+
+    @Step
+    public void programmaticallyIgnoredStep() {
+        Serenity.ignoredStep("This test should be skipped");
+
+    }
+
+    @Step
+    public void programmaticallyPendingStep() {
+        Serenity.pendingStep("This test should be skipped");
+
+    }
+
+}

--- a/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies.java
+++ b/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies.java
@@ -1,0 +1,149 @@
+package net.serenitybdd.core.di.samples;
+
+import net.serenitybdd.core.Serenity;
+import net.thucydides.core.annotations.Pending;
+import net.thucydides.core.annotations.Step;
+import net.thucydides.core.annotations.StepGroup;
+import net.thucydides.core.annotations.Title;
+import net.thucydides.core.pages.Pages;
+import net.thucydides.core.steps.ScenarioSteps;
+
+import org.junit.Ignore;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.Resource;
+
+@MetaContextHierarchy
+public class FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies extends ScenarioSteps {
+
+    @Autowired
+    public WidgetService widgetService;
+
+
+    @Resource
+    public CatalogService catalogService;
+
+    public FlatScenarioStepsWithSpringMetaAnnotationContextHierarchyDependencies(Pages pages) {
+        super(pages);
+    }
+
+    @Step
+    public void step_one(){
+    }
+
+    @Step
+    public void step_two() {
+    }
+
+    @Step
+    public void step_three() {
+    }
+
+    @Step
+    public void nested_step_one(){
+    }
+
+    @Step
+    public void nested_step_two() {
+    }
+
+    @Step
+
+    public void nested_step_three() {
+    }
+
+    @Step
+    public void failingStep() {
+        throw new AssertionError("Step failed");
+    }
+
+    @Ignore
+    @Step
+    public void ignoredStep() {}
+
+    @Pending
+    @Step
+    public void pendingStep() {}
+
+    @Pending
+    @Step
+    public void pending_group() {
+        step_three();
+        step_two();
+        step_one();
+    }
+
+    @Title("A step with a title")
+    @Step
+    public void step_with_title() {}
+
+    @Ignore
+    @Step
+    public void ignored_group() {
+        step_three();
+        step_two();
+        step_one();
+    }
+
+    @Step
+    public void grouped_steps() {
+        nested_step_one();
+        nested_step_two();
+        nested_step_one();
+        nested_step_two();
+    }
+
+    @Step
+    public void deeply_grouped_steps() {
+        step_one();
+        step_two();
+        grouped_steps();
+        step_two();
+        step_one();
+    }
+
+    @Step
+    public void stepWithLongName() {}
+
+    @Step
+    public void stepWithParameters(String name) {}
+
+    @Step
+    public void step_with_long_name_and_underscores() {}
+
+    @StepGroup("Annotated step group title")
+    public void a_step_group() {
+        stepWithLongName();
+        step_with_long_name_and_underscores();
+    }
+
+    @Step
+    public void a_plain_step_group() {
+        stepWithLongName();
+        step_with_long_name_and_underscores();
+    }
+
+    @Step
+    public void stepCausingANullPointerException() {
+        String nullValue = null;
+        nullValue.length();
+    }
+
+    public void unannotatedStepCausingANullPointerException() {
+        String nullValue = null;
+        nullValue.length();
+    }
+
+    @Step
+    public void programmaticallyIgnoredStep() {
+        Serenity.ignoredStep("This test should be skipped");
+
+    }
+
+    @Step
+    public void programmaticallyPendingStep() {
+        Serenity.pendingStep("This test should be skipped");
+
+    }
+
+}

--- a/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/FlatScenarioStepsWithSpringMetaAnnotationDependencies.java
+++ b/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/FlatScenarioStepsWithSpringMetaAnnotationDependencies.java
@@ -1,0 +1,149 @@
+package net.serenitybdd.core.di.samples;
+
+import net.serenitybdd.core.Serenity;
+import net.thucydides.core.annotations.Pending;
+import net.thucydides.core.annotations.Step;
+import net.thucydides.core.annotations.StepGroup;
+import net.thucydides.core.annotations.Title;
+import net.thucydides.core.pages.Pages;
+import net.thucydides.core.steps.ScenarioSteps;
+
+import org.junit.Ignore;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.Resource;
+
+@MetaContextConfiguration
+public class FlatScenarioStepsWithSpringMetaAnnotationDependencies extends ScenarioSteps {
+
+    @Autowired
+    public WidgetService widgetService;
+
+
+    @Resource
+    public CatalogService catalogService;
+
+    public FlatScenarioStepsWithSpringMetaAnnotationDependencies(Pages pages) {
+        super(pages);
+    }
+
+    @Step
+    public void step_one(){
+    }
+
+    @Step
+    public void step_two() {
+    }
+
+    @Step
+    public void step_three() {
+    }
+
+    @Step
+    public void nested_step_one(){
+    }
+
+    @Step
+    public void nested_step_two() {
+    }
+
+    @Step
+
+    public void nested_step_three() {
+    }
+
+    @Step
+    public void failingStep() {
+        throw new AssertionError("Step failed");
+    }
+
+    @Ignore
+    @Step
+    public void ignoredStep() {}
+
+    @Pending
+    @Step
+    public void pendingStep() {}
+
+    @Pending
+    @Step
+    public void pending_group() {
+        step_three();
+        step_two();
+        step_one();
+    }
+
+    @Title("A step with a title")
+    @Step
+    public void step_with_title() {}
+
+    @Ignore
+    @Step
+    public void ignored_group() {
+        step_three();
+        step_two();
+        step_one();
+    }
+
+    @Step
+    public void grouped_steps() {
+        nested_step_one();
+        nested_step_two();
+        nested_step_one();
+        nested_step_two();
+    }
+
+    @Step
+    public void deeply_grouped_steps() {
+        step_one();
+        step_two();
+        grouped_steps();
+        step_two();
+        step_one();
+    }
+
+    @Step
+    public void stepWithLongName() {}
+
+    @Step
+    public void stepWithParameters(String name) {}
+
+    @Step
+    public void step_with_long_name_and_underscores() {}
+
+    @StepGroup("Annotated step group title")
+    public void a_step_group() {
+        stepWithLongName();
+        step_with_long_name_and_underscores();
+    }
+
+    @Step
+    public void a_plain_step_group() {
+        stepWithLongName();
+        step_with_long_name_and_underscores();
+    }
+
+    @Step
+    public void stepCausingANullPointerException() {
+        String nullValue = null;
+        nullValue.length();
+    }
+
+    public void unannotatedStepCausingANullPointerException() {
+        String nullValue = null;
+        nullValue.length();
+    }
+
+    @Step
+    public void programmaticallyIgnoredStep() {
+        Serenity.ignoredStep("This test should be skipped");
+
+    }
+
+    @Step
+    public void programmaticallyPendingStep() {
+        Serenity.pendingStep("This test should be skipped");
+
+    }
+
+}

--- a/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/MetaContextConfiguration.java
+++ b/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/MetaContextConfiguration.java
@@ -1,0 +1,20 @@
+package net.serenitybdd.core.di.samples;
+
+
+import org.springframework.test.context.ContextConfiguration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@ContextConfiguration(locations = "/spring/config.xml")
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MetaContextConfiguration {
+
+}

--- a/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/MetaContextHierarchy.java
+++ b/serenity-spring/src/test/java/net/serenitybdd/core/di/samples/MetaContextHierarchy.java
@@ -1,0 +1,20 @@
+package net.serenitybdd.core.di.samples;
+
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Inherited
+@ContextHierarchy(@ContextConfiguration(locations = "/spring/config.xml"))
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface MetaContextHierarchy {
+
+}

--- a/serenity-spring/src/test/java/net/thucydides/junit/spring/samples/dao/HibernateUserDAO.java
+++ b/serenity-spring/src/test/java/net/thucydides/junit/spring/samples/dao/HibernateUserDAO.java
@@ -19,7 +19,7 @@ public class HibernateUserDAO implements UserDAO {
 	}
 
 	public List<User> findAll() {
-		return hibernateTemplate.find("from User");
+		return (List<User>) hibernateTemplate.find("from User");
 	}
 
     public void remove(User user) {


### PR DESCRIPTION
These commits provide support for serenity-bdd/serenity-core#76.

Note that meta-annotation support for @ContextConfiguration and @ContextHierarchy was only introduced in spring 4.0, which necessitates a bump to the version of spring in use. However that bump has no impact on the existing production code base and only necessitates a simple change to HibernateTemplate use in HibernateDAO to handle the wildcard return type via an explicit unchecked cast.

