### PR TITLE
fix: Improved error reporting for provided drivers

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
@@ -247,7 +247,7 @@ public class WebDriverFactory {
         try {
             return sourceConfig.getDriverSource().newDriver();
         } catch (Exception e) {
-            throw new RuntimeException("Could not instantiate the custom webdriver provider of type " + sourceConfig.getDriverName());
+            throw new RuntimeException("Could not instantiate the custom webdriver provider of type " + sourceConfig.getDriverName(), e);
         }
     }
 


### PR DESCRIPTION
DriverSources may implement some non-trivial logic, so it is very handy
for debugging to include in stack trace exception occurred while tried to
initialize new webdriver. Especially in multi-node test environment
configurations.