### PR TITLE
Fixing Java warnings - Redundant cast

### DIFF
--- a/serenity-demo/src/main/java/net/serenity_bdd/demo/steps/GoogleSearchSteps.java
+++ b/serenity-demo/src/main/java/net/serenity_bdd/demo/steps/GoogleSearchSteps.java
@@ -26,13 +26,13 @@ public class GoogleSearchSteps extends ScenarioSteps {
 
     @Step
     public void searchFor(String term) {
-        GoogleHomePage page = (GoogleHomePage) getPages().currentPageAt(GoogleHomePage.class);
+        GoogleHomePage page = getPages().currentPageAt(GoogleHomePage.class);
         page.searchFor(term);
     }
     
     @Step
     public void resultListShouldContain(String term) {
-        GoogleResultsPage page = (GoogleResultsPage) getPages().currentPageAt(GoogleResultsPage.class);
+        GoogleResultsPage page = getPages().currentPageAt(GoogleResultsPage.class);
         List<String> resultHeadings = page.getResultTitles();
         assertThat(resultHeadings, hasItem(containsString(term)));
     }


### PR DESCRIPTION
    GoogleSearchSteps.java:27: warning: [cast] redundant cast to GoogleHomePage
        GoogleHomePage page = (GoogleHomePage) getPages().currentPageAt(GoogleHomePage.class);
    GoogleSearchSteps.java:33: warning: [cast] redundant cast to GoogleResultsPage
        GoogleResultsPage page = (GoogleResultsPage) getPages().currentPageAt(GoogleResultsPage.class);