### PR TITLE
feat: the phantomjs ssl-property can now be set using the PHANTOMJS_S…

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -696,7 +696,12 @@ public enum ThucydidesSystemProperty {
      * Keep the Thucydides session data between tests.
      * Normally, the session data is cleared between tests.
      */
-    THUCYDIDES_MAINTAIN_SESSION;
+    THUCYDIDES_MAINTAIN_SESSION,
+
+    /**
+     * Path to PhantomJS SSL support
+     */
+    PHANTOMJS_SSL_PROTOCOL;
 
     private String propertyName;
     public static final int DEFAULT_HEIGHT = 700;

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/phantomjs/PhantomJSCapabilityEnhancer.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/phantomjs/PhantomJSCapabilityEnhancer.java
@@ -26,12 +26,29 @@ public class PhantomJSCapabilityEnhancer {
         ArrayList<String> cliArgs = Lists.newArrayList();
         setSecurityOptions(cliArgs);
         setLoggingOptions(cliArgs);
+
         if (StringUtils.isNotEmpty(ThucydidesSystemProperty.THUCYDIDES_PROXY_HTTP.from(environmentVariables))) {
             setProxyOptions(cliArgs);
         }
         if (StringUtils.isNotEmpty(ThucydidesSystemProperty.WEBDRIVER_REMOTE_URL.from(environmentVariables))) {
             setRemoteOptions(cliArgs);
         }
+        if (StringUtils.isNotEmpty(ThucydidesSystemProperty.PHANTOMJS_SSL_PROTOCOL.from(environmentVariables))) {
+            String sslSupport = ThucydidesSystemProperty.PHANTOMJS_SSL_PROTOCOL.from(environmentVariables);
+            if (sslSupport.equals("sslv2") ||
+                    sslSupport.equals("sslv3") ||
+                    sslSupport.equals("tlsv1") ||
+                    sslSupport.equals("any")) {
+                cliArgs.add("--ssl-protocol=" + sslSupport);
+            }
+            else {
+                cliArgs.add("--ssl-protocol=any");
+            }
+        }
+        else {
+            cliArgs.add("--ssl-protocol=any");
+        }
+
         capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, cliArgs.toArray(new String[]{}));
     }
 
@@ -80,7 +97,6 @@ public class PhantomJSCapabilityEnhancer {
 
     private void setSecurityOptions(ArrayList<String> cliArgs ) {
         cliArgs.add("--web-security=false");
-        cliArgs.add("--ssl-protocol=any");
         cliArgs.add("--ignore-ssl-errors=true");
     }
 


### PR DESCRIPTION
The phantomjs ssl-property can now be set using the PHANTOMJS_SSL_PROPERTY environment variable, like the PHANTOMJS_BINARY_PATH. Possible options are 'sslv2', 'sslv3', 'tlsv1' and 'any'.