### PR TITLE
fix loop when parameter is null in ddt tests

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestReporter.java
@@ -27,7 +27,7 @@ public interface AcceptanceTestReporter {
     /**
      * Generate reports for a given acceptance test run.
      */
-    File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws IOException;
+    File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws Exception;
     
     /**
      * Define the output directory in which the reports will be written.

--- a/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -117,7 +118,7 @@ public class ReportService {
             });
         }
         generateJUnitTestResults(testOutcomes);
-        waitForReportGenerationToFinish(remainingReportCount);
+        waitForReportGenerationToFinish(executorService, remainingReportCount);
         LOGGER.info("Reports generated in: " + (System.currentTimeMillis() - t0) + " ms");
 
     }
@@ -133,8 +134,8 @@ public class ReportService {
         }
     }
 
-    private void waitForReportGenerationToFinish(AtomicInteger reportCount) {
-        while (reportCount.get() > 0) {
+    private void waitForReportGenerationToFinish(ExecutorService executorService, AtomicInteger reportCount) {
+        while (reportCount.get() > 0 && ((ThreadPoolExecutor) executorService).getActiveCount() != 0){
             try {
                 Thread.sleep(50);
             } catch (InterruptedException e) {
@@ -175,7 +176,7 @@ public class ReportService {
             LOGGER.info(reporter + ": Generating report for test outcome: " + testOutcome.getCompleteName());
             reporter.setOutputDirectory(outputDirectory);
             reporter.generateReportFor(testOutcome, allTestOutcomes);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new ReportGenerationFailedError(
                     "Failed to generate reports using " + reporter, e);
         }

--- a/serenity-core/src/main/java/net/thucydides/core/reports/TestOutcomeAdaptorReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/TestOutcomeAdaptorReporter.java
@@ -20,7 +20,7 @@ public class TestOutcomeAdaptorReporter extends ThucydidesReporter {
 
     private final Optional<File> NO_SOURCE_FILE = Optional.absent();
 
-    public void generateReports() throws IOException {
+    public void generateReports() throws Exception {
         generateReports(NO_SOURCE_FILE);
     }
 
@@ -35,11 +35,11 @@ public class TestOutcomeAdaptorReporter extends ThucydidesReporter {
      * @param sourceDirectory
      * @throws IOException
      */
-    public void generateReportsFrom(File sourceDirectory) throws IOException {
+    public void generateReportsFrom(File sourceDirectory) throws Exception {
         generateReports(Optional.fromNullable(sourceDirectory));
     }
 
-    public void generateReports(Optional<File> sourceDirectory) throws IOException {
+    public void generateReports(Optional<File> sourceDirectory) throws Exception {
         setupOutputDirectoryIfRequired();
         for (TestOutcomeAdaptor adaptor : adaptors) {
             List<TestOutcome> outcomes = sourceDirectory.isPresent() ?
@@ -54,7 +54,7 @@ public class TestOutcomeAdaptorReporter extends ThucydidesReporter {
         }
     }
 
-    private void generateReportsFor(List<TestOutcome> outcomes) throws IOException {
+    private void generateReportsFor(List<TestOutcome> outcomes) throws Exception {
         TestOutcomes allOutcomes = TestOutcomes.of(outcomes);
         for (TestOutcome outcome : allOutcomes.getOutcomes()) {
             if (shouldGenerate(OutcomeFormat.XML)) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -54,7 +54,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
     /**
      * Generate an XML report for a given test run.
      */
-    public File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws IOException {
+    public File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws Exception {
         TestOutcome storedTestOutcome = testOutcome.withQualifier(qualifier);
         Preconditions.checkNotNull(outputDirectory);
         XStream xstream = new XStream();
@@ -74,8 +74,8 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
             writer = new OutputStreamWriter(outputStream, Charset.forName("UTF-8"));
             xstream.toXML(storedTestOutcome, writer);
             LOGGER.info("XML report generated ({} bytes) {}",report.getAbsolutePath(),report.length());
-        } catch(IOException failedToWriteReport) {
-            throw failedToWriteReport;
+        } catch(Exception failedToWriteReport) {
+            throw new Exception(failedToWriteReport);
         } finally {
             writer.flush();
             writer.close();


### PR DESCRIPTION
When one of ddt parameters is null, we do not catch the exception(NullPointerException) and the process(create report) hangs.
The second thread is waiting creating report(waitForReportGenerationToFinish), but this will not happen.