### PR TITLE
refactor: Corrects throwning of IOException, instead of Exception

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestReporter.java
@@ -27,7 +27,7 @@ public interface AcceptanceTestReporter {
     /**
      * Generate reports for a given acceptance test run.
      */
-    File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws Exception;
+    File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws IOException;
     
     /**
      * Define the output directory in which the reports will be written.

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -54,7 +54,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
     /**
      * Generate an XML report for a given test run.
      */
-    public File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws Exception {
+    public File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws IOException {
         TestOutcome storedTestOutcome = testOutcome.withQualifier(qualifier);
         Preconditions.checkNotNull(outputDirectory);
         XStream xstream = new XStream();
@@ -74,8 +74,6 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
             writer = new OutputStreamWriter(outputStream, Charset.forName("UTF-8"));
             xstream.toXML(storedTestOutcome, writer);
             LOGGER.info("XML report generated ({} bytes) {}",report.getAbsolutePath(),report.length());
-        } catch(Exception failedToWriteReport) {
-            throw new Exception(failedToWriteReport);
         } finally {
             writer.flush();
             writer.close();


### PR DESCRIPTION
Before there was an compilation issue, in the module `serenity-junit`, as an Exception was not catched / rethrown (class: `net.thucydides.junit.runners.WhenGeneratingTestReports`).

Also it was not logical to throw an Exception, from the interface `net.thucydides.core.reports.AcceptanceTestReporter`. So changed it, to throw an IOException, as all underlaying implementations are all file based, an possibly can throw some IOException.

Only needed to fix, the implementation `net.thucydides.core.reports.xml.XMLTestOutcomeReporter` as otehr implementation did already only throw IOException.