### PR TITLE
Better way to fix THUCYDIDES-253

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/ProvidedDriver.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/ProvidedDriver.java
@@ -1,6 +1,5 @@
 package net.thucydides.core.webdriver;
 
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 
-public abstract class ProvidedDriver implements WebDriver, JavascriptExecutor {}
+public abstract class ProvidedDriver implements WebDriver {}

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFacade.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFacade.java
@@ -91,6 +91,9 @@ public class WebDriverFacade implements WebDriver, TakesScreenshot, HasInputDevi
     }
 
     public Class<? extends WebDriver>  getDriverClass() {
+        if (driverClass.isAssignableFrom(SupportedWebDriver.PROVIDED.getWebdriverClass())) {
+            return getProxiedDriver().getClass();
+        }
         return driverClass;
     }
 

--- a/serenity-core/src/test/java/net/thucydides/core/webdriver/WhenUsingAProvidedDriver.java
+++ b/serenity-core/src/test/java/net/thucydides/core/webdriver/WhenUsingAProvidedDriver.java
@@ -1,0 +1,44 @@
+package net.thucydides.core.webdriver;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openqa.selenium.WebDriver;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WhenUsingAProvidedDriver {
+
+
+    @Mock
+    WebDriver driver;
+
+    @Mock
+    WebDriverFactory factory;
+
+    MockWebDriverFacade facade;
+
+    class MockWebDriverFacade extends WebDriverFacade {
+        MockWebDriverFacade() {
+            super(ProvidedDriver.class, factory);
+        }
+
+        @Override
+        public WebDriver getProxiedDriver() {
+            return driver;
+        }
+
+    }
+
+    @Before
+    public void setup() {
+        facade = new MockWebDriverFacade();
+    }
+
+    @Test
+    public void the_web_driver_facade_should_expose_the_proxied_driver_class() {
+        Assert.assertEquals(facade.getDriverClass(), driver.getClass());
+    }
+}


### PR DESCRIPTION
Better way to fix THUCYDIDES-253. The method that checks if the driver is javascript enabled looks at the driver class returned from WebDriverFacade and in the case, it will see that ProvidedDriver implements JavascriptExecutor but when it tries to execute javascript on the proxied driver that does not necessarily have to implement JavascriptExecutor, then it can throw an exception. This proposed fix checks if the driverclass in the WebDriverFacade is a provided driver, if it is, then the correct driver class it should look at is contained in the proxied driver.