### PR TITLE
Pull request for updating test in serenity_core (ThucydidesWebDriverSupport init)

### DIFF
--- a/serenity-core/src/test/java/net/thucydides/core/steps/WhenRecordingStepExecutionResults.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/WhenRecordingStepExecutionResults.java
@@ -22,6 +22,7 @@ import net.thucydides.core.util.FileSystemUtils;
 import net.thucydides.core.util.MockEnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
+import net.thucydides.core.webdriver.ThucydidesWebDriverSupport;
 import net.thucydides.core.webdriver.ThucydidesWebdriverManager;
 import org.junit.*;
 import org.mockito.Mock;
@@ -111,15 +112,16 @@ public class WhenRecordingStepExecutionResults {
         environmentVariables = new MockEnvironmentVariables();
         configuration = new SystemPropertiesConfiguration(environmentVariables);
 
-        stepListener = new BaseStepListener(FirefoxDriver.class, outputDirectory, configuration);
-
         driver = mock(FirefoxDriver.class);
 
-        ThucydidesWebdriverManager.inThisTestThread().closeAllDrivers();
-        ThucydidesWebdriverManager.inThisTestThread().registerDriverCalled("firefox").forDriver(driver);
-
         when(driver.getCurrentUrl()).thenReturn("http://www.google.com");
+        when(driver.toString()).thenReturn("firefox");
         when(driver.getScreenshotAs(any(OutputType.class))).thenReturn(screenshot1).thenReturn(screenshot2);
+
+        ThucydidesWebDriverSupport.closeAllDrivers();
+        ThucydidesWebDriverSupport.useDriver(driver);
+
+        stepListener = new BaseStepListener(FirefoxDriver.class, outputDirectory, configuration);
 
         StepEventBus.getEventBus().registerListener(stepListener);
     }
@@ -721,7 +723,7 @@ public class WhenRecordingStepExecutionResults {
         StepEventBus.getEventBus().testStarted("app_should_work");
 
         StepsInSomeOtherPlace steps = stepFactory.getStepLibraryFor(StepsInSomeOtherPlace.class);
-        steps.step_one();              
+        steps.step_one();
         steps.step_that_fails();
         String stringValue = steps.returnFoo();
         steps.step_two();

--- a/serenity-core/src/test/java/net/thucydides/core/steps/WhenRecordingStepExecutionResults.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/WhenRecordingStepExecutionResults.java
@@ -104,7 +104,6 @@ public class WhenRecordingStepExecutionResults {
         File screenshot1File = FileSystemUtils.getResourceAsFile("screenshots/google_page_1.png");
         File screenshot2File = FileSystemUtils.getResourceAsFile("screenshots/google_page_2.png");
 
-
         screenshot1 = Files.readAllBytes(screenshot1File.toPath());
         screenshot2 = Files.readAllBytes(screenshot2File.toPath());
         stepFactory = new StepFactory(pages);
@@ -119,7 +118,9 @@ public class WhenRecordingStepExecutionResults {
         when(driver.getScreenshotAs(any(OutputType.class))).thenReturn(screenshot1).thenReturn(screenshot2);
 
         ThucydidesWebDriverSupport.closeAllDrivers();
+        ThucydidesWebDriverSupport.initialize(driver.toString());
         ThucydidesWebDriverSupport.useDriver(driver);
+        assertThat(ThucydidesWebDriverSupport.getCurrentDriverName(),is(driver.toString()));
 
         stepListener = new BaseStepListener(FirefoxDriver.class, outputDirectory, configuration);
 


### PR DESCRIPTION
This pull request contains:

updating of one test, witch should be updated after this [commit](https://github.com/serenity-bdd/serenity-core/commit/8fedb5437877646684a733cd134427652f9b19ad)
Problem was with updating BaseStepListener, and it internal usage of ThucydidesWebDriverManager. Some of tests fail because of not-initialized browser during test init.

Solution - change way for initializing ThucydidesWebDriverManager by using ThucydidesWebDriverSupport.