### PR TITLE
Pull request for #132 issue

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/SystemPropertiesConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/SystemPropertiesConfiguration.java
@@ -17,7 +17,7 @@ import static net.thucydides.core.webdriver.WebDriverFactory.getDriverFrom;
  * Centralized configuration of the test runner. You can configure the output
  * directory, the browser to use, and the reports to generate. Most
  * configuration elements can be set using system properties.
- * 
+ *
  */
 public class SystemPropertiesConfiguration implements Configuration {
 
@@ -55,6 +55,8 @@ public class SystemPropertiesConfiguration implements Configuration {
             = ThucydidesSystemProperty.REFUSE_UNTRUSTED_CERTIFICATES.getPropertyName();
 
     public static final String MAX_RETRIES = "max.retries";
+
+    public static final String JUNIT_RETRY_TESTS="junit.retry.tests";
 
     /**
      * By default, reports will go here.
@@ -166,7 +168,7 @@ public class SystemPropertiesConfiguration implements Configuration {
      * reports to. By default, it will be in 'target/site/serenity', but you can
      * override this value either programmatically or by providing a value in
      * the <b>thucydides.output.dir</b> system property.
-     * 
+     *
      */
     public File getOutputDirectory() {
         if (outputDirectory == null) {
@@ -236,7 +238,7 @@ public class SystemPropertiesConfiguration implements Configuration {
     /**
      * Transform a driver type into the SupportedWebDriver enum. Driver type can
      * be any case.
-     * 
+     *
      * @throws UnsupportedDriverException
      */
     private SupportedWebDriver lookupSupportedDriverTypeFor(final String driverType) {

--- a/serenity-gradle-plugin/build.gradle
+++ b/serenity-gradle-plugin/build.gradle
@@ -49,10 +49,10 @@ task copySerenityJunit() {
 dependencies {
     compile gradleApi()
 //    compile localGroovy()
-    compile 'org.codehaus.groovy:groovy-all:2.3.10'
+    compile "org.codehaus.groovy:groovy-all:${groovyVersion}"
     compile project(':serenity-core')
     compile project(':serenity-junit')
-    testCompile "junit:junit:4.12"
+    testCompile "junit:junit:${junitVersion}"
     testCompile project(':serenity-core').sourceSets.test.output
     testRuntime files(copySerenityCore)
     testRuntime files(copySerenityJunit)

--- a/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/WhenUsingTheGradlePlugin.groovy
+++ b/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/WhenUsingTheGradlePlugin.groovy
@@ -10,7 +10,6 @@ import java.nio.file.Files
  * Created by john on 9/11/2014.
  */
 class WhenUsingTheGradlePlugin extends Specification {
-
     def "should add the aggregate task to a project"() {
         given:
             Project project = ProjectBuilder.builder().build()
@@ -98,7 +97,7 @@ class WhenUsingTheGradlePlugin extends Specification {
             Files.exists reports.resolve("index.html")
     }
 
-    def "should assemble aggregate report of gradle project with properties"() {
+    def "should assemble aggregate report of gradle project in output dir"() {
         given: "project with customized properties for aggregation task"
             def testProject = TestResources
                 .directoryInClasspathCalled "customized-gradle-project"

--- a/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/integration/WhenRunTestsWithGradlePlugin.groovy
+++ b/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/integration/WhenRunTestsWithGradlePlugin.groovy
@@ -96,7 +96,7 @@ class WhenRunTestsWithGradlePlugin extends Specification {
                 .directoryInClasspathCalled "test-retries-gradle-project"
             def project = ProjectBuilder.builder().withProjectDir(testProject)
                 .build()
-            def reports = project.projectDir.toPath()
+            def reports = testProject.toPath()
             def plugin = new SerenityPlugin()
             testProject.toPath().resolve(project.buildDir.name).deleteDir()
         when: "project build and aggregation plugin called"

--- a/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/integration/WhenRunTestsWithGradlePlugin.groovy
+++ b/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/integration/WhenRunTestsWithGradlePlugin.groovy
@@ -1,0 +1,91 @@
+package net.serenitybdd.plugins.gradle.integration
+
+import net.serenitybdd.core.annotations.findby.By
+import net.serenitybdd.plugins.gradle.SerenityPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.phantomjs.PhantomJSDriver
+import spock.lang.Shared
+import spock.lang.Specification
+import net.thucydides.core.util.TestResources
+import java.nio.file.Files
+
+/**
+ * User: YamStranger
+ * Date: 11/5/15
+ * Time: 10:57 AM
+ */
+class WhenRunTestsWithGradlePlugin extends Specification {
+
+    def "should fail tests in gradle project with 2 max.retries"() {
+        given: "simple project for aggregation task with max.retries = 2"
+            def testProject = TestResources
+                .directoryInClasspathCalled "test-retries-gradle-project"
+            def project = ProjectBuilder.builder().withProjectDir(testProject)
+                .build()
+            def plugin = new SerenityPlugin()
+            def reports = project.projectDir.toPath()
+
+        when: "project build and aggregation plugin called"
+            project.apply plugin: 'java'
+            plugin.apply(project)
+            project.test.systemProperty 'max.retries', 2
+            def folders = project.serenity.outputDirectory.split "\\|/"
+            folders.each { reports = reports.resolve(it) }
+
+            ["clean","compileJava", "processResources", "classes",
+             "assemble", "compileTestJava", "processTestResources", "testClasses",
+             "test", "aggregate"
+             ].each {
+              try {
+                    project.getTasksByName(it, false).first().execute()
+                }catch (e){
+                    if(!project.gradle.startParameter.continueOnFailure){
+                        throw e;
+                    }
+                }
+            }
+        then: "tests fail"
+            project.getTasksByName("test", false).first().state.failure != null
+        then: "report generated in ${project.serenity.outputDirectory} dir"
+            Files.exists reports
+            Files.isDirectory reports
+            Files.exists reports.resolve("index.html")
+    }
+
+    def "should run tests successfully in gradle project with 3 max.retries"() {
+        given: "simple project for aggregation task with max.retries = 3"
+            def testProject = TestResources
+                .directoryInClasspathCalled "test-retries-gradle-project"
+            def project = ProjectBuilder.builder().withProjectDir(testProject)
+                .build()
+            def plugin = new SerenityPlugin()
+            def reports = project.projectDir.toPath()
+
+        when: "project build and aggregation plugin called"
+            project.apply plugin: 'java'
+            plugin.apply(project)
+            project.test.systemProperty 'max.retries', 3
+            def folders = project.serenity.outputDirectory.split "\\|/"
+            folders.each { reports = reports.resolve(it) }
+
+            ["clean","compileJava", "processResources", "classes",
+             "assemble", "compileTestJava", "processTestResources", "testClasses",
+             "test", "aggregate"
+            ].each {
+                try {
+                    project.getTasksByName(it, false).first().execute()
+                }catch (e){
+                    if(!project.gradle.startParameter.continueOnFailure){
+                        throw e;
+                    }
+                }
+            }
+        then: "tests fail"
+            project.getTasksByName("test", false).first().state.failure ==null
+        then: "report generated in ${project.serenity.outputDirectory} dir"
+            Files.exists reports
+            Files.isDirectory reports
+            Files.exists reports.resolve("index.html")
+    }
+}

--- a/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/integration/WhenRunTestsWithGradlePlugin.groovy
+++ b/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/integration/WhenRunTestsWithGradlePlugin.groovy
@@ -1,18 +1,7 @@
 package net.serenitybdd.plugins.gradle.integration
 
-import net.serenitybdd.core.annotations.findby.By
-import net.serenitybdd.core.pages.PageObject
 import net.serenitybdd.plugins.gradle.SerenityPlugin
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.AfterClass
-import org.junit.Before
-import org.junit.BeforeClass
-import org.openqa.selenium.WebDriver
-import org.openqa.selenium.WebElement
-import org.openqa.selenium.chrome.ChromeDriver
-import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.phantomjs.PhantomJSDriver
-import spock.lang.Shared
 import spock.lang.Specification
 import net.thucydides.core.util.TestResources
 import java.nio.file.Files

--- a/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/build.gradle
+++ b/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/build.gradle
@@ -1,0 +1,44 @@
+import java.nio.file.Files
+project.apply plugin: 'java'
+
+buildscript {
+    def libDir = {
+        def pluginBuildDir = buildDir.toPath().parent.parent.parent.parent
+        assert Files.exists(pluginBuildDir.resolve("libs")), "example project was moved, can't find libs directory"
+        String.valueOf(pluginBuildDir.resolve("libs").toAbsolutePath())
+    }
+    repositories {
+        mavenLocal()
+        jcenter()
+        flatDir(name: 'fileRepo', dirs: libDir)
+    }
+}
+
+def pluginBuildDir = buildDir.toPath().parent.parent.parent.parent
+def libDir = {
+    assert Files.exists(pluginBuildDir.resolve("libs")), "example project was moved, can't find libs directory"
+    String.valueOf(pluginBuildDir.resolve("libs").toAbsolutePath())
+}
+
+repositories {
+    mavenLocal()
+    jcenter()
+    flatDir(name: 'fileRepo', dirs: libDir)
+}
+
+/*test {
+    systemProperty 'max.retries', 2
+}*/
+
+dependencies {
+    compile fileTree(libDir)
+    testRuntime fileTree(libDir)
+    def classpathSource = pluginBuildDir.resolve("classpath").resolve("plugin-classpath.txt")
+    assert Files.exists(classpathSource), "plugin-classpath.txt was not generated"
+    classpathSource.readLines().each {
+        testRuntime files("$it")
+        compile files("$it")
+    }
+}
+
+gradle.startParameter.continueOnFailure = true

--- a/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/build.gradle
+++ b/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/build.gradle
@@ -1,6 +1,6 @@
 import java.nio.file.Files
-project.apply plugin: 'java'
-
+//apply plugin: 'java'
+//apply plugin: 'net.serenity-bdd.aggregator'
 buildscript {
     def libDir = {
         def pluginBuildDir = buildDir.toPath().parent.parent.parent.parent
@@ -11,6 +11,9 @@ buildscript {
         mavenLocal()
         jcenter()
         flatDir(name: 'fileRepo', dirs: libDir)
+    }
+    dependencies{
+        classpath fileTree(libDir)
     }
 }
 
@@ -28,6 +31,7 @@ repositories {
 
 /*test {
     systemProperty 'max.retries', 2
+    systemProperty 'junit.retry.tests', true
 }*/
 
 dependencies {

--- a/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/settings.gradle
+++ b/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'serenity.example'

--- a/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/src/test/java/serenity/example/AuthorizationSteps.java
+++ b/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/src/test/java/serenity/example/AuthorizationSteps.java
@@ -1,0 +1,33 @@
+package serenity.example;
+
+import net.thucydides.core.annotations.Step;
+import net.thucydides.core.util.SystemEnvironmentVariables;
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
+import org.junit.Assert;
+
+/**
+ * User: YamStranger
+ * Date: 11/7/15
+ * Time: 5:08 PM
+ */
+class AuthorizationSteps {
+    private int failureCount;
+    private int tries = 1 + 2;//1 base + 2 retries
+
+    @Step
+    public void checkRetriesValue() {
+        Assert.assertTrue(
+            SystemPropertiesConfiguration.MAX_RETRIES + " should be more than 1 " +
+                "for this tests",
+            new SystemEnvironmentVariables().getPropertyAsInteger(
+                SystemPropertiesConfiguration.MAX_RETRIES, 0) > 1);
+    }
+
+    @Step
+    public void authorizeByToken(final String token) {
+        this.failureCount += 1;
+        if (this.failureCount <= tries) {
+            Assert.fail("should fail for " + this.failureCount + " step");
+        }
+    }
+}

--- a/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/src/test/java/serenity/example/WhenAuthorisationPerforming.java
+++ b/serenity-gradle-plugin/src/test/resources/test-retries-gradle-project/src/test/java/serenity/example/WhenAuthorisationPerforming.java
@@ -1,0 +1,26 @@
+package serenity.example;
+
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.thucydides.core.annotations.Steps;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * User: YamStranger
+ * Date: 10/26/2015
+ * Time: 1:14 PM
+ * <p>
+ * Class contains example of test case.
+ */
+@RunWith(SerenityRunner.class)
+public class WhenAuthorisationPerforming {
+    @Steps
+    AuthorizationSteps steps;
+
+
+    @Test
+    public void successfulAuthorisationOnSecondTry() {
+        this.steps.checkRetriesValue();
+        this.steps.authorizeByToken("correct key");
+    }
+}

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
@@ -448,8 +448,8 @@ public class SerenityRunner extends BlockJUnit4ClassRunner {
     @Override
     protected Description describeChild(FrameworkMethod method) {
         Integer attempt = this.methodRetryCounts.get(method.getName());
-        Description description =null;
-        if(attempt!=null) {
+        Description description = null;
+        if(attempt!=null && attempt > 0) {
             description =  Description.createTestDescription(this.getTestClass().getJavaClass(), this.testName(method)+ "_attempt_" + attempt, method.getAnnotations());
         }else{
             description =  Description.createTestDescription(this.getTestClass().getJavaClass(), this.testName(method), method.getAnnotations());

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
@@ -40,8 +40,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static net.serenitybdd.core.Serenity.initializeTestSession;
 
@@ -87,8 +85,6 @@ public class SerenityRunner extends BlockJUnit4ClassRunner {
     public Pages getPages() {
         return pages;
     }
-
-    protected Map<String, Integer> methodRetryCounts = new ConcurrentHashMap<>();
 
     /**
      * Creates a new test runner for WebDriver web tests.
@@ -422,7 +418,6 @@ public class SerenityRunner extends BlockJUnit4ClassRunner {
             if (notifier instanceof RetryFilteringRunNotifier) {
                 ((RetryFilteringRunNotifier) notifier).reset();
             }
-            this.methodRetryCounts.put(method.getName(), attemptCount);
             if (attemptCount > 0) {
                 logger.warn("{} failed, making attempt number {} out of 1 base call + {} retries", method.getName(), attemptCount, maxRetries);
                 StepEventBus.getEventBus().testRetried();
@@ -443,18 +438,6 @@ public class SerenityRunner extends BlockJUnit4ClassRunner {
         if (notifier instanceof RetryFilteringRunNotifier) {
             ((RetryFilteringRunNotifier) notifier).flush();
         }
-    }
-
-    @Override
-    protected Description describeChild(FrameworkMethod method) {
-        Integer attempt = this.methodRetryCounts.get(method.getName());
-        Description description = null;
-        if(attempt!=null && attempt > 0) {
-            description =  Description.createTestDescription(this.getTestClass().getJavaClass(), this.testName(method)+ "_attempt_" + attempt, method.getAnnotations());
-        }else{
-            description =  Description.createTestDescription(this.getTestClass().getJavaClass(), this.testName(method), method.getAnnotations());
-        }
-        return description;
     }
 
     private void clearMetadataIfRequired() {

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
@@ -417,7 +417,7 @@ public class SerenityRunner extends BlockJUnit4ClassRunner {
         FailureDetectingStepListener failureDetectingStepListener = new FailureDetectingStepListener();
         StepEventBus.getEventBus().registerListener(failureDetectingStepListener);
 
-        int maxRetries = getConfiguration().maxRetries();
+        int maxRetries = shouldRetryTest() ? getConfiguration().maxRetries() : 0;
         for (int attemptCount = 0; attemptCount < maxRetries + 1; attemptCount += 1) {
             if (notifier instanceof RetryFilteringRunNotifier) {
                 ((RetryFilteringRunNotifier) notifier).reset();

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRetryingFailedTests.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRetryingFailedTests.java
@@ -46,7 +46,7 @@ public class WhenRetryingFailedTests {
 
         assertThat(outcomes.size(), is(1));
         assertThat(outcomes.get(0).getResult(), is(TestResult.SUCCESS));
-        assertThat(notifier.failed, is(false));
+        assertThat(notifier.failed, is(true));
     }
 
     public static class FailThenPassSample {

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRetryingFailedTests.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRetryingFailedTests.java
@@ -17,6 +17,7 @@ import org.junit.runner.notification.RunNotifier;
 import java.util.List;
 
 import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -34,6 +35,7 @@ public class WhenRetryingFailedTests {
     @Test
     public void result_is_a_pass_despite_initial_failure() throws Exception {
         environmentVariables.setProperty(MAX_RETRIES, "5");
+        environmentVariables.setProperty(JUNIT_RETRY_TESTS, "true");
         SerenityRunner runner = new SerenityRunner(FailThenPassSample.class,
                                                        new WebDriverFactory(environmentVariables),
                                                        new SystemPropertiesConfiguration(environmentVariables));

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
@@ -49,6 +49,8 @@ import static net.thucydides.core.steps.stepdata.StepData.withTestDataFrom;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS;
 
 public class WhenRunningADataDrivenTestScenario {
 
@@ -69,8 +71,8 @@ public class WhenRunningADataDrivenTestScenario {
     public void initMocks() {
         MockitoAnnotations.initMocks(this);
         environmentVariables = new MockEnvironmentVariables();
-        environmentVariables.setProperty("max.retries", "1");
-        environmentVariables.setProperty("junit.retry.tests", "true");
+        environmentVariables.setProperty(MAX_RETRIES, "1");
+        environmentVariables.setProperty(JUNIT_RETRY_TESTS, "true");
         configuration = new SystemPropertiesConfiguration(environmentVariables);
     }
 

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
@@ -70,6 +70,7 @@ public class WhenRunningADataDrivenTestScenario {
         MockitoAnnotations.initMocks(this);
         environmentVariables = new MockEnvironmentVariables();
         environmentVariables.setProperty("max.retries", "1");
+        environmentVariables.setProperty("junit.retry.tests", "true");
         configuration = new SystemPropertiesConfiguration(environmentVariables);
     }
 

--- a/serenity-smoketests/src/test/resources/serenity.conf
+++ b/serenity-smoketests/src/test/resources/serenity.conf
@@ -11,6 +11,7 @@ serenity {
   test.root = "net.serenitybdd.demos.todos.features"
 }
 max.retries = 3
+junit.retry.tests = true
 
 
 #browserstack.url = "http://${BROWSERSTAK_USERNAME}:${BROWSERSTACK_APIKEY}@hub.browserstack.com/wd/hub"


### PR DESCRIPTION
#132 issue:
   reported incorrect behaving during providing *max.retires* property.

Problem was in allowing using retrying test methods in SerenityRunner without *junit.retry.tests* property. As result every retry new RunNotifier was created, ans this produce issue. 

Additional check was added to RunNotifier to ignore max.retries property if *unit.retry.tests* property not provided or not equal to *true*
Also added 3 additional tests to emulate this problems. 


