### PR TITLE
Pull requst for fixing #128 issue

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.internal.RestAssuredResponseImpl;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
@@ -61,7 +62,7 @@ public class SerenityRest {
     public static ValidatableResponse and() {
         return then();
     }
-    
+
     public static ValidatableResponse then() {
         assert(currentResponse.get() != null);
         return currentResponse.get().then();
@@ -227,7 +228,9 @@ public class SerenityRest {
     }
 
     private static boolean shouldRecordResponseBodyFor(Response result) {
-        return result.getContentType().endsWith("/json") || result.getContentType().endsWith("/xml") || result.getContentType().endsWith("/text");
+        ContentType type=ContentType.fromContentType(result.contentType());
+        return type!=null && (ContentType.JSON == type || ContentType.XML == type
+            || ContentType.TEXT == type);
     }
 
     private static void notifyGetOrDelete(Object[] args, RestMethod method) {

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/integration/WhenRunningHttpsRestTestsThroughSerenity.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/integration/WhenRunningHttpsRestTestsThroughSerenity.groovy
@@ -1,0 +1,58 @@
+package net.serenitybdd.rest.integration
+
+import com.jayway.restassured.http.ContentType
+import net.serenitybdd.core.rest.RestQuery
+import net.thucydides.core.model.TestResult
+import net.thucydides.core.steps.BaseStepListener
+import net.thucydides.core.steps.StepEventBus
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+import static com.jayway.restassured.RestAssured.given
+import static net.serenitybdd.core.rest.RestMethod.GET
+import static net.serenitybdd.rest.SerenityRest.rest
+import static org.hamcrest.Matchers.equalTo
+
+/**
+ * User: YamStranger
+ * Date: 11/11/15
+ * Time: 2:09 AM
+ */
+class WhenRunningHttpsRestTestsThroughSerenity {
+    @Rule
+    TemporaryFolder temporaryFolder
+
+    File outputDirectory
+    BaseStepListener stepListener
+
+    def setup() {
+        outputDirectory = temporaryFolder.newFolder()
+        stepListener = new BaseStepListener(outputDirectory)
+        StepEventBus.eventBus.registerListener(stepListener)
+    }
+    def cleanup() {
+        StepEventBus.eventBus.testFinished()
+    }
+
+
+    def "Should record RestAssured get() method calls"() {
+        given:
+            def mockListener = Mock(BaseStepListener)
+            StepEventBus.eventBus.registerListener(mockListener)
+            StepEventBus.eventBus.testStarted("rest")
+            def url = "https://api.github.com/repos/serenity-bdd/serenity-core"
+        when:
+            rest().given().relaxedHTTPSValidation()
+            .when()
+            .get(url);
+        then: "The JSON request should be recorded in the test steps"
+            1 * mockListener.recordRestQuery({
+                RestQuery query -> query.method == GET  &&
+                    query.path == url &&
+                    query.statusCode == 200 &&
+                    query.responseBody !=null &&
+                    query.responseBody.contains("26201720")
+            })
+    }
+
+}

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/integration/WhenRunningHttpsRestTestsThroughSerenity.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/integration/WhenRunningHttpsRestTestsThroughSerenity.groovy
@@ -54,5 +54,4 @@ class WhenRunningHttpsRestTestsThroughSerenity {
                     query.responseBody.contains("26201720")
             })
     }
-
 }


### PR DESCRIPTION
**Problem:**
 In #128 reported: During usage SerenityRest for testing rest API by HTTPS protocol - response and status doesn't available in Serenity Aggregation report

**Reason:**
  According to [RFC1341](http://tools.ietf.org/html/rfc1341) Content type [can contains](http://www.w3.org/Protocols/rfc1341/4_Content-Type.html) optional parameter after sub-type. Our code not ready for it. 

**Solution:**
Updated method for checking if response body suitable for recording, based on ContentType. Also added additional test where GET request using HTTPS is send to github and checks id of current repo. [Limits](https://developer.github.com/v3/#rate-limiting) for requests without auntification 60 per hour, it should be enough 