### PR TITLE
Pull request for desabling retries in smoke-tests

### DIFF
--- a/serenity-smoketests/src/test/java/net/serenitybdd/demos/todos/features/filter_my_todos/FilterTodosByStatus.java
+++ b/serenity-smoketests/src/test/java/net/serenitybdd/demos/todos/features/filter_my_todos/FilterTodosByStatus.java
@@ -37,7 +37,7 @@ public class FilterTodosByStatus {
         joe.has(openedTheTodoApplication);
     }
 
-    static int tries = 1;
+    //static int tries = 1;
     @Test
     public void filter_by_active_tasks() {
         givenThat(joe).has(addedSomeItems.called("Buy the milk", "Buy Petrol"));
@@ -46,7 +46,8 @@ public class FilterTodosByStatus {
         when(joe).attemptsTo(FilterItems.byStatus(Active));
 
         then(joe).should(seeThat(theDisplayedItems, contains("Buy Petrol")));
-        assertThat(tries++).isGreaterThanOrEqualTo(3);
+        //todo move to external build test
+        //assertThat(tries++).isGreaterThanOrEqualTo(3);
     }
 
     @Test

--- a/serenity-smoketests/src/test/resources/serenity.conf
+++ b/serenity-smoketests/src/test/resources/serenity.conf
@@ -11,7 +11,7 @@ serenity {
   test.root = "net.serenitybdd.demos.todos.features"
 }
 max.retries = 3
-junit.retry.tests = true
+junit.retry.tests = false
 
 
 #browserstack.url = "http://${BROWSERSTAK_USERNAME}:${BROWSERSTACK_APIKEY}@hub.browserstack.com/wd/hub"


### PR DESCRIPTION
**Problem:**
during run smoke-tests with enabling retries - ant build fail

**Reason:**
when some test method fail and call of it retired - ant/gradle/mvn builds fails, because actually some methods are fail, and reports will contain same method fired several time - some failed, and last green. Serenity report will contains correct information, about actual result for testing. If same method will be run several times because of fail and on lat one try this test method will run successful - this test in serenity report will be green

**Solution:**
disabling retrying in smoke-tests and disabling methods prepared for "first run fail, second successful" (test case for retrying logic)