### PR TITLE
130_issue: reading serenity.properties fix. 

### DIFF
--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -13,8 +13,8 @@ class SerenityPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        def configuration = loadProperties()
-        project.extensions.create("serenity", new SerenityPluginExtension())
+        def configuration = loadProperties(project)
+        project.extensions.create("serenity", SerenityPluginExtension)
         if(configuration."serenity.outputDirectory"){
             project.serenity.outputDirectory = configuration."serenity.outputDirectory"
             project.serenity.sourceDirectory = configuration."serenity.outputDirectory"
@@ -79,7 +79,7 @@ class SerenityPlugin implements Plugin<Project> {
         new File(project.projectDir, project.serenity.outputDirectory)
     }
 
-    def loadProperties(){
+    def loadProperties(def project){
         def configuration = new Properties()
         def serenityProperties = project.rootDir.toPath().resolve("serenity.properties")
         if(Files.exists(serenityProperties)){

--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -5,6 +5,8 @@ import net.thucydides.core.reports.html.HtmlAggregateStoryReporter
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+import java.nio.file.Files
+
 class SerenityPlugin implements Plugin<Project> {
 
     File reportDirectory
@@ -12,7 +14,16 @@ class SerenityPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         if(!project.extensions.findByName("serenity")) {
-            project.extensions.create("serenity", SerenityPluginExtension)
+            project.extensions.add("serenity", new SerenityPluginExtension())
+            def serenityProperties = project.rootDir.toPath().resolve("serenity.properties")
+            if(Files.exists(serenityProperties)){
+                def properties = new Properties()
+                serenityProperties.withInputStream {
+                    properties.load(it)
+                }
+                project.serenity.outputDirectory = properties."serenity.outputDirectory"
+                project.serenity.sourceDirectory = project.serenity.outputDirectory
+            }
         }
 
         reportDirectory = prepareReportDirectory(project)

--- a/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/WhenUsingTheGradlePlugin.groovy
+++ b/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/WhenUsingTheGradlePlugin.groovy
@@ -113,17 +113,12 @@ class WhenUsingTheGradlePlugin extends Specification {
             def folders = properties."serenity.outputDirectory".split "\\|/"
             folders.each { reports = reports.resolve(it) }
 
-            def configs = new SerenityPluginExtension(
-                outputDirectory: properties."serenity.outputDirectory"
-            )
-            project.extensions.add "serenity", configs
-
         when: "project build and aggregation plugin called"
             project.apply plugin: 'java'
             plugin.apply(project)
             ["compileJava", "processResources", "classes",
              "assemble", "compileTestJava", "processTestResources", "testClasses",
-             "test", "aggregate"
+             "test", "aggregate", "checkOutcomes"
             ].each {
                 project.getTasksByName(it, false).first().execute()
             }


### PR DESCRIPTION
Problem:
  Issue  #130 was returned, reports collects, but in default directory, not in serenity.outputDirectory

Reason:
 It seams that some values aren't read from sererenity.properties, and because of way of tasing gradle builds under 2.5 builds - I miss it. 

Solution:
 Read serenity.properties file as Property file. Updated test for emulating such behaving. This pull request depends on #181 - because it fix general build fail of master. 


