### PR TITLE
Pull request for adding photographer test fix

### DIFF
--- a/serenity-core/src/test/groovy/net/serenitybdd/core/photography/integration/WhenAPhotographerTakesScreenshots.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/photography/integration/WhenAPhotographerTakesScreenshots.groovy
@@ -131,7 +131,8 @@ class WhenAPhotographerTakesScreenshots extends Specification {
 
     def cleanup() {
         println "Test duration: " + (System.currentTimeMillis() - startTime) + " ms"
-        driver.quit()
+        if (driver){
+            driver.quit()
+        }
     }
-
 }


### PR DESCRIPTION
Problem:
 null pointer during execution quit for webDriver

Reason: 
 sometimes this test fail, and driver equal to null.

Solution:
 Added additional check before cleanup. If webDriver equal to null - it means that nothing to clean. 
 