### PR TITLE
Pull requst for 184_issue: logging for PATCH operation added

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/rest/RestMethod.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/rest/RestMethod.java
@@ -3,7 +3,7 @@ package net.serenitybdd.core.rest;
 import com.google.common.base.Optional;
 
 public enum RestMethod {
-    GET, POST, PUT, DELETE;
+    GET, POST, PUT, DELETE, PATCH;
 
     private static final Optional<RestMethod> NOT_A_REST_METHOD = Optional.absent();
 

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
@@ -141,6 +141,7 @@ public class SerenityRest {
                 break;
             case POST:
             case PUT:
+            case PATCH:
                 notifyPostOrPut(args, methodType);
                 break;
         }

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/integration/WhenRunningRestTestsThroughSerenity.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/integration/WhenRunningRestTestsThroughSerenity.groovy
@@ -92,6 +92,22 @@ class WhenRunningRestTestsThroughSerenity extends Specification {
                                                                   query.contentType == "application/json"})
     }
 
+    def "Should record RestAssured patch() method calls"() {
+        given:
+        def mockListener = Mock(BaseStepListener)
+        StepEventBus.eventBus.registerListener(mockListener)
+        StepEventBus.eventBus.testStarted("rest")
+        and:
+        def updateContent = """{"id": 1007, "name": "doggie", "status": "not_available"}"""
+        when:
+        rest().given().contentType("application/json").content(updateContent).patch("http://petstore.swagger.io/v2/pet/{id}","1007")
+
+        then: "The JSON request should be recorded in the test steps"
+        1 * mockListener.recordRestQuery({ RestQuery query -> query.toString() == "PATCH http://petstore.swagger.io/v2/pet/1007" &&
+            query.content == updateContent  &&
+            query.contentType == "application/json"})
+    }
+
     def "Should record RestAssured put() method calls"() {
         given:
             def samplePet = """{"id": 1003, "name": "doggie", "photoUrls": [], "status": "available"}"""


### PR DESCRIPTION
**Problem**
   in #184 issue reported that in REST-assured PATCH requests are not logged in serenity report

**Reason**
 not implemented

**Solution**
updated implementation for logging. Added tests for this type of request. 