### PR TITLE
Pull requst for updating tests for screenshots

### DIFF
--- a/serenity-core/src/test/groovy/net/serenitybdd/core/photography/integration/WhenAPhotographerTakesLotsOfScreenshots.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/photography/integration/WhenAPhotographerTakesLotsOfScreenshots.groovy
@@ -27,7 +27,9 @@ class WhenAPhotographerTakesLotsOfScreenshots extends Specification {
             Darkroom.waitUntilClose();
             driver.quit()
         then:
-            photos.each { photo -> Files.exists(photo.pathToScreenshot) }
+            photos.findAll {
+                photo -> Files.exists(photo.pathToScreenshot)
+            }.size() == 11
     }
 
     def "should handle multiple screenshots in parallel"() {
@@ -56,8 +58,9 @@ class WhenAPhotographerTakesLotsOfScreenshots extends Specification {
             threads.forEach { it.join() }
         then:
             photos.size() == 100
-            photos.each { photo -> Files.exists(photo.pathToScreenshot) }
-
+            photos.findAll {
+                photo -> Files.exists(photo.pathToScreenshot)
+            }.size() == 100
     }
     WebDriver driver;
     Path screenshotDirectory;


### PR DESCRIPTION
Problem:
  During investigation reason of #173 was found error - these tests not fail even if dirs not exists. These test should fail in same time as WhenAPhotographerTakesScreenshots tests

Reason:
 We should check amount of screenshots that exists

Solution:
 updated way of checking if all screenshots exists in collections. 