### PR TITLE
fix: cglib dependency conflict from guice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ subprojects {
         compile("com.google.inject:guice:3.0") {
             exclude group:"org.ow2.asm", module:"asm"
             exclude group:"asm", module:"asm"
-            exclude group:"cglib", module:"cglib"
+            exclude group:"org.sonatype.sisu.inject", module:"cglib"
         }
 
         compile ('cglib:cglib:3.1') {


### PR DESCRIPTION
This fixed the problem described at https://groups.google.com/forum/#!topic/thucydides-users/AsdBfFV8qHc.
```
+--- net.serenity-bdd:serenity-core:1.1.21
|    |    +--- com.google.guava:guava:18.0
|    |    +--- com.google.inject:guice:3.0
|    |    |    +--- javax.inject:javax.inject:1
|    |    |    +--- aopalliance:aopalliance:1.0
|    |    |    \--- org.sonatype.sisu.inject:cglib:2.2.1-v20090111 -> cglib:cglib:3.1
|    |    +--- cglib:cglib:3.1
```