### PR TITLE
Pull request for updating SerenityRest to log all types of input

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
@@ -4,8 +4,13 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.config.EncoderConfig;
+import com.jayway.restassured.config.ObjectMapperConfig;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.internal.RestAssuredResponseImpl;
+import com.jayway.restassured.internal.http.CharsetExtractor;
+import com.jayway.restassured.internal.mapping.ObjectMapping;
+import com.jayway.restassured.internal.serialization.SerializationSupport;
 import com.jayway.restassured.response.Response;
 import com.jayway.restassured.response.ValidatableResponse;
 import com.jayway.restassured.specification.RequestSpecification;
@@ -116,12 +121,44 @@ public class SerenityRest {
         switch (name) {
             case "content" :
             case "body" :
-                registerContent(args[0].toString());
+                registerContent(convent(args));
                 break;
             case "contentType":
                 registerContentType(args[0].toString());
                 break;
         }
+    }
+
+    private static String convent(Object[] args) {
+        String convented = "";
+        if (args != null) {
+            final Object object = args[0];
+            if (!SerializationSupport.isSerializableCandidate(object)) {
+                convented = object.toString();
+            }
+            ObjectMapperConfig config = ObjectMapperConfig.objectMapperConfig();
+            ObjectMapping.serialize(object, getContentType(), findEncoderCharsetOrReturnDefault(getContentType()), null, config);
+        } else {
+            convented = "null";
+        }
+        return convented;
+    }
+
+    private static String findEncoderCharsetOrReturnDefault(String contentType) {
+        String charset = CharsetExtractor.getCharsetFromContentType(contentType);
+        if (charset == null) {
+            final EncoderConfig cfg = new EncoderConfig();
+            charset = cfg.defaultContentCharset();
+        }
+        return charset;
+    }
+
+    private static String getContentType() {
+        String type = currentQueryPayload().getContentType();
+        if (type == null) {
+            type = ContentType.ANY.toString();
+        }
+        return type;
     }
 
     private static void registerContentType(String contentType) {


### PR DESCRIPTION
Problem: 
 in #197 issue was reported about problems of logging rest request body if source not string but map for example

Reason:
 It seems that we call toString() and that's all - as result objects appeared in serenity logs not like Json/xml but string. 

Solution:
 Rewriting mechanism of serializing  to take content type from current request and serialize input according to contentType from input object. Tests aren't provided, in current structure very hard test testOutcome under serenity-rest-assured module - all tested manually. 


