### PR TITLE
Pull request  for adding log and auth wrappers for serenity-rest-assured

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/AuthenticationSpecificationWrapper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/AuthenticationSpecificationWrapper.java
@@ -1,0 +1,122 @@
+package net.serenitybdd.rest.decorators;
+
+import com.jayway.restassured.authentication.CertificateAuthSettings;
+import com.jayway.restassured.authentication.FormAuthConfig;
+import com.jayway.restassured.authentication.OAuthSignature;
+import com.jayway.restassured.specification.AuthenticationSpecification;
+import com.jayway.restassured.specification.PreemptiveAuthSpec;
+import com.jayway.restassured.specification.RequestSpecification;
+
+/**
+ * User: YamStranger
+ * Date: 11/29/15
+ * Time: 11:48 PM
+ */
+class AuthenticationSpecificationWrapper extends BaseWrapper<AuthenticationSpecification>
+    implements AuthenticationSpecification {
+
+    public AuthenticationSpecificationWrapper(final AuthenticationSpecification auth,
+                                              final ThreadLocal<RequestSpecification> instrumented,
+                                              final RestDecorator decorator) {
+        super(auth, instrumented, decorator);
+    }
+
+    @Override
+    public RequestSpecification basic(final String userName,
+                                      final String password) {
+        this.core.basic(userName, password);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification digest(final String userName,
+                                       final String password) {
+        this.core.digest(userName, password);
+        return this.specification.get();
+
+    }
+
+    @Override
+    public RequestSpecification certificate(final String certURL,
+                                            final String password) {
+        this.core.certificate(certURL, password);
+        return this.specification.get();
+
+    }
+
+    @Override
+    public RequestSpecification certificate(final String certURL,
+                                            final String password,
+                                            final CertificateAuthSettings settings) {
+        this.core.certificate(certURL, password, settings);
+        return this.specification.get();
+    }
+
+    @Override
+    @Deprecated
+    public RequestSpecification certificate(final String certURL,
+                                            final String password,
+                                            final String keystoreType, int port) {
+        this.core.certificate(certURL, password, keystoreType, port);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification oauth(final String consumerKey,
+                                      final String consumerSecret,
+                                      final String accessToken,
+                                      final String secretToken) {
+        this.core.oauth(consumerKey, consumerSecret, accessToken, secretToken);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification oauth(final String consumerKey,
+                                      final String consumerSecret,
+                                      final String accessToken,
+                                      final String secretToken,
+                                      OAuthSignature signature) {
+        this.core.oauth(consumerKey, consumerSecret, accessToken, secretToken,
+            signature);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification oauth2(final String accessToken) {
+        this.core.oauth2(accessToken);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification oauth2(final String accessToken,
+                                       final OAuthSignature signature) {
+        this.core.oauth2(accessToken, signature);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification none() {
+        this.core.none();
+        return this.specification.get();
+    }
+
+    @Override
+    public PreemptiveAuthSpec preemptive() {
+        return this.decorator.decorate(this.core.preemptive());
+    }
+
+    @Override
+    public RequestSpecification form(final String userName,
+                                     final String password) {
+        this.core.form(userName, password);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification form(final String userName,
+                                     final String password,
+                                     final FormAuthConfig config) {
+        this.core.form(userName, password, config);
+        return this.specification.get();
+    }
+}

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/BaseWrapper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/BaseWrapper.java
@@ -1,0 +1,22 @@
+package net.serenitybdd.rest.decorators;
+
+import com.jayway.restassured.specification.RequestSpecification;
+
+/**
+ * User: YamStranger
+ * Date: 11/30/15
+ * Time: 12:25 AM
+ */
+public abstract class BaseWrapper<T> {
+    protected final T core;
+    protected final ThreadLocal<RequestSpecification> specification;
+    protected final RestDecorator decorator;
+
+    public BaseWrapper(final T spec,
+                       final ThreadLocal<RequestSpecification> instrumented,
+                       final RestDecorator decorator) {
+        this.core = spec;
+        this.specification = instrumented;
+        this.decorator = decorator;
+    }
+}

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/PreemptiveAuthSpecWrapper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/PreemptiveAuthSpecWrapper.java
@@ -1,0 +1,26 @@
+package net.serenitybdd.rest.decorators;
+
+import com.jayway.restassured.specification.PreemptiveAuthSpec;
+import com.jayway.restassured.specification.RequestSpecification;
+
+/**
+ * User: YamStranger
+ * Date: 11/30/15
+ * Time: 12:18 AM
+ */
+public class PreemptiveAuthSpecWrapper extends BaseWrapper<PreemptiveAuthSpec>
+    implements PreemptiveAuthSpec {
+
+    public PreemptiveAuthSpecWrapper(final PreemptiveAuthSpec auth,
+                                     final ThreadLocal<RequestSpecification> instrumented,
+                                     final RestDecorator decorator) {
+        super(auth, instrumented, decorator);
+    }
+
+    @Override
+    public RequestSpecification basic(final String username,
+                                      final String password) {
+        this.core.basic(username, password);
+        return this.specification.get();
+    }
+}

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/RequestLogSpecificationWrapper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/RequestLogSpecificationWrapper.java
@@ -1,0 +1,111 @@
+package net.serenitybdd.rest.decorators;
+
+import com.jayway.restassured.filter.log.LogDetail;
+import com.jayway.restassured.specification.RequestLogSpecification;
+import com.jayway.restassured.specification.RequestSpecification;
+
+/**
+ * User: YamStranger
+ * Date: 11/29/15
+ * Time: 10:41 PM
+ */
+class RequestLogSpecificationWrapper extends BaseWrapper<RequestLogSpecification>
+    implements RequestLogSpecification {
+
+    RequestLogSpecificationWrapper(final RequestLogSpecification log,
+                                   final ThreadLocal<RequestSpecification> instrumented,
+                                   final RestDecorator decorator) {
+        super(log, instrumented, decorator);
+    }
+
+    @Override
+    public RequestSpecification params() {
+        this.core.params();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification parameters() {
+        this.core.parameters();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification path() {
+        this.core.path();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification method() {
+        this.core.method();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification body() {
+        this.core.body();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification body(boolean shouldPrettyPrint) {
+        this.core.body(shouldPrettyPrint);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification all(boolean shouldPrettyPrint) {
+        this.core.all(shouldPrettyPrint);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification everything(boolean shouldPrettyPrint) {
+        this.core.everything(shouldPrettyPrint);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification all() {
+        this.core.all();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification everything() {
+        this.core.everything();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification headers() {
+        this.core.headers();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification cookies() {
+        this.core.cookies();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification ifValidationFails() {
+        this.core.ifValidationFails();
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification ifValidationFails(final LogDetail logDetail) {
+        this.core.ifValidationFails(logDetail);
+        return this.specification.get();
+    }
+
+    @Override
+    public RequestSpecification ifValidationFails(final LogDetail logDetail,
+                                                  boolean shouldPrettyPrint) {
+        this.core.ifValidationFails(logDetail, shouldPrettyPrint);
+        return this.specification.get();
+    }
+}

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/RestDecorator.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/RestDecorator.java
@@ -1,0 +1,31 @@
+package net.serenitybdd.rest.decorators;
+
+import com.jayway.restassured.specification.AuthenticationSpecification;
+import com.jayway.restassured.specification.PreemptiveAuthSpec;
+import com.jayway.restassured.specification.RequestLogSpecification;
+import com.jayway.restassured.specification.RequestSpecification;
+
+/**
+ * User: YamStranger
+ * Date: 11/29/15
+ * Time: 10:40 PM
+ */
+public class RestDecorator {
+    private final ThreadLocal<RequestSpecification> instrumented;
+
+    public RestDecorator(final ThreadLocal<RequestSpecification> instrumented) {
+        this.instrumented = instrumented;
+    }
+
+    public AuthenticationSpecification decorate(final AuthenticationSpecification spec) {
+        return new AuthenticationSpecificationWrapper(spec, this.instrumented, this);
+    }
+
+    public RequestLogSpecification decorate(final RequestLogSpecification spec) {
+        return new RequestLogSpecificationWrapper(spec, this.instrumented, this);
+    }
+
+    public PreemptiveAuthSpec decorate(final PreemptiveAuthSpec spec) {
+        return new PreemptiveAuthSpecWrapper(spec, this.instrumented, this);
+    }
+}

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenExecutingWrappedMethods.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenExecutingWrappedMethods.groovy
@@ -1,0 +1,79 @@
+package net.serenitybdd.rest
+
+import net.serenitybdd.core.rest.RestQuery
+import net.thucydides.core.steps.BaseStepListener
+import net.thucydides.core.steps.StepEventBus
+import spock.lang.Ignore
+import spock.lang.Specification
+
+import static net.serenitybdd.rest.SerenityRest.rest
+
+/**
+ * User: YamStranger
+ * Date: 11/29/15
+ * Time: 5:58 PM
+ */
+class WhenExecutingWrappedMethods extends Specification {
+
+    def BaseStepListener listener
+
+    def setup() {
+        listener = Mock(BaseStepListener)
+        StepEventBus.eventBus.registerListener(listener)
+    }
+
+    def cleanup() {
+        StepEventBus.eventBus.testFinished()
+    }
+
+    def "should work properly after executing log method"() {
+        given:
+            StepEventBus.eventBus.testStarted("rest")
+        and:
+            def samplePet = """{"id": 1001, "name": "doggie", "photoUrls": [], "status": "available"}"""
+        when:
+            rest().given().contentType("application/json").content(samplePet).log().all()
+            .post("http://petstore.swagger.io/v2/pet")
+        then: "The JSON request should be recorded in the test steps"
+            1 * listener.recordRestQuery({ RestQuery query ->
+                query.toString() == "POST http://petstore.swagger.io/v2/pet" &&
+                    query.content == samplePet &&
+                    query.contentType == "application/json"
+            })
+    }
+
+    def "should work properly after executing auth method"() {
+        given:
+            StepEventBus.eventBus.testStarted("rest")
+        and:
+            def samplePet = """{"id": 1001, "name": "doggie", "photoUrls": [], "status": "available"}"""
+        when:
+            rest().given().contentType("application/json").content(samplePet).auth().none()
+                .post("http://petstore.swagger.io/v2/pet")
+        then: "The JSON request should be recorded in the test steps"
+            1 * listener.recordRestQuery({ RestQuery query ->
+                query.toString() == "POST http://petstore.swagger.io/v2/pet" &&
+                    query.content == samplePet &&
+                    query.contentType == "application/json"
+            })
+    }
+
+    @Ignore
+    def "should work properly after executing redirect method"() {
+        given:
+            def mockListener = Mock(BaseStepListener)
+            StepEventBus.eventBus.registerListener(mockListener)
+            StepEventBus.eventBus.testStarted("rest")
+        and:
+            def samplePet = """{"id": 1001, "name": "doggie", "photoUrls": [], "status": "available"}"""
+        when:
+            rest().given().contentType("application/json").content(samplePet).redirects().follow(true)
+                .post("http://petstore.swagger.io/v2/pet")
+            then: "The JSON request should be recorded in the test steps"
+            1 * listener.recordRestQuery({ RestQuery query ->
+                query.toString() == "POST http://petstore.swagger.io/v2/pet" &&
+                    query.content == samplePet &&
+                    query.contentType == "application/json"
+            })
+    }
+}


### PR DESCRIPTION
Problem:
 in #212 and #185 was reported about impossibility usage of log() and auth() and auntificate() methods of serenity-rest-assured

Reason:
 We use enhancements of RequestSpecification methods to record calls of them. We "wrap" all method  to be notified about it call, but during log and auth RequstSpecification returned without provided wrappers. This was not tested at all. 

Solution: 
 Providing wrappers for AuthenticationSpecification and RequestLogSpecification to be sure that they will operate with enhancemened RequestSpecification. Also some tests are provided. 