### PR TITLE
Pull request for adding reloading output dir before checks in tests

### DIFF
--- a/serenity-junit/src/test/groovy/net/thucydides/junit/runners/WhenRunningTestScenarios.groovy
+++ b/serenity-junit/src/test/groovy/net/thucydides/junit/runners/WhenRunningTestScenarios.groovy
@@ -14,6 +14,9 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.file.Path
+import java.nio.file.Paths
+
 import static net.thucydides.core.model.TestResult.*
 import static net.thucydides.junit.runners.TestOutcomeChecks.resultsFrom
 
@@ -428,7 +431,7 @@ class WhenRunningTestScenarios extends Specification {
         def runner = new ATestableThucydidesRunnerSample(SamplePassingScenario, webDriverFactory)
         when:
         runner.run(new RunNotifier())
-        def xmlReports = temporaryDirectory.list().findAll {it.endsWith(".xml") && !it.startsWith("SERENITY-")}
+        def xmlReports = reload(temporaryDirectory).list().findAll {it.endsWith(".xml") && !it.startsWith("SERENITY-")}
         then:
         xmlReports.size() == 3
     }
@@ -437,7 +440,7 @@ class WhenRunningTestScenarios extends Specification {
         when:
         new ATestableThucydidesRunnerSample(SamplePassingScenarioUsingHtmlUnit, webDriverFactory).run(new RunNotifier())
         new ATestableThucydidesRunnerSample(SampleFailingScenarioUsingHtmlUnit, webDriverFactory).run(new RunNotifier())
-        def xmlReports = temporaryDirectory.list().findAll {it.endsWith(".xml") && !it.startsWith("SERENITY-")}
+        def xmlReports = reload(temporaryDirectory).list().findAll {it.endsWith(".xml") && !it.startsWith("SERENITY-")}
         then:
         xmlReports.size() == 6
     }
@@ -445,7 +448,7 @@ class WhenRunningTestScenarios extends Specification {
     def "HTML test results should be written to the output directory"() {
         when:
             new ATestableThucydidesRunnerSample(SamplePassingScenarioUsingHtmlUnit, webDriverFactory).run(new RunNotifier())
-            def xmlReports = temporaryDirectory.list().findAll {it.endsWith(".html")}
+            def xmlReports = reload(temporaryDirectory).list().findAll {it.endsWith(".html")}
         then:
             xmlReports.size() == 3
     }
@@ -486,4 +489,10 @@ class WhenRunningTestScenarios extends Specification {
             "iteration:I3"                | 0
     }
 
+    private File reload(File old) {
+        return Paths.get(old.getAbsolutePath()).toFile();
+    }
+    private Path reload(Path old) {
+        return Paths.get(old.toAbsolutePath().toString());
+    }
 }

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
@@ -46,7 +46,6 @@ import org.junit.runner.RunWith;
 import org.junit.runner.notification.RunNotifier;
 import org.mockito.MockitoAnnotations;
 import org.openqa.selenium.WebDriver;
-
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -58,11 +57,11 @@ import java.util.List;
 
 import static ch.lambdaj.Lambda.filter;
 import static net.thucydides.core.steps.stepdata.StepData.withTestDataFrom;
-import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS;
-import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES;
 
 public class WhenRunningADataDrivenTestScenario {
 
@@ -610,7 +609,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         File outputDirectory = tempFolder.newFolder("thucydides");
         environmentVariables.setProperty(ThucydidesSystemProperty.THUCYDIDES_OUTPUT_DIRECTORY.getPropertyName(),
-                outputDirectory.getAbsolutePath());
+            outputDirectory.getAbsolutePath());
 
         SerenityParameterizedRunner runner = getTestRunnerUsing(SimpleSuccessfulParametrizedTestSample.class);
 
@@ -654,7 +653,7 @@ public class WhenRunningADataDrivenTestScenario {
     }
 
     @Test
-    public void by_default_the_number_of_threads_is_2_times_the_number_of_CPU_cores() throws Throwable  {
+    public void by_default_the_number_of_threads_is_2_times_the_number_of_CPU_cores() throws Throwable {
 
         SerenityParameterizedRunner runner = getTestRunnerUsing(SampleParallelDataDrivenScenario.class);
         int threadCount = runner.getThreadCountFor(SampleParallelDataDrivenScenario.class);
@@ -686,11 +685,11 @@ public class WhenRunningADataDrivenTestScenario {
     }
 
     @Test
-    public void the_number_of_threads_can_be_overridden_with_a_system_property() throws Throwable  {
+    public void the_number_of_threads_can_be_overridden_with_a_system_property() throws Throwable {
 
         environmentVariables.setProperty("thucydides.concurrent.threads","4");
         SerenityParameterizedRunner runner
-                = getTestRunnerUsing(ParallelDataDrivenScenarioWithSpecifiedThreadCountSample.class);
+            = getTestRunnerUsing(ParallelDataDrivenScenarioWithSpecifiedThreadCountSample.class);
         int threadCount = runner.getThreadCountFor(ParallelDataDrivenScenarioWithSpecifiedThreadCountSample.class);
 
         assertThat(threadCount, is(4));

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningADataDrivenTestScenario.java
@@ -22,7 +22,18 @@ import net.thucydides.junit.annotations.Concurrent;
 import net.thucydides.junit.annotations.TestData;
 import net.thucydides.junit.rules.QuietThucydidesLoggingRule;
 import net.thucydides.junit.rules.SaveWebdriverSystemPropertiesRule;
-import net.thucydides.samples.*;
+import net.thucydides.samples.NestedDatadrivenSteps;
+import net.thucydides.samples.SampleCSVDataDrivenScenario;
+import net.thucydides.samples.SampleDataDrivenIgnoredScenario;
+import net.thucydides.samples.SampleDataDrivenPendingScenario;
+import net.thucydides.samples.SampleDataDrivenScenario;
+import net.thucydides.samples.SampleDataDrivenScenarioWithExternalFailure;
+import net.thucydides.samples.SampleParallelDataDrivenScenario;
+import net.thucydides.samples.SamplePassingScenarioWithTestSpecificData;
+import net.thucydides.samples.SampleScenarioSteps;
+import net.thucydides.samples.SampleSingleDataDrivenScenario;
+import net.thucydides.samples.SampleSingleDataDrivenScenarioWithFailingAssumption;
+import net.thucydides.samples.SampleSingleSessionDataDrivenScenario;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -39,6 +50,7 @@ import org.openqa.selenium.WebDriver;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,11 +58,11 @@ import java.util.List;
 
 import static ch.lambdaj.Lambda.filter;
 import static net.thucydides.core.steps.stepdata.StepData.withTestDataFrom;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS;
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES;
-import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS;
 
 public class WhenRunningADataDrivenTestScenario {
 
@@ -202,7 +214,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        File[] reports = outputDirectory.listFiles(new XMLFileFilter());
+        File[] reports = reload(outputDirectory).listFiles(new XMLFileFilter());
         assertThat(reports.length, is(2));
     }
 
@@ -217,7 +229,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        File[] reports = outputDirectory.listFiles(new XMLFileFilter());
+        File[] reports = reload(outputDirectory).listFiles(new XMLFileFilter());
         assertThat(reports.length, is(2));
     }
 
@@ -232,7 +244,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        List<String> reportContents = contentsOf(outputDirectory.listFiles(new XMLFileFilter()));
+        List<String> reportContents = contentsOf(reload(outputDirectory).listFiles(new XMLFileFilter()));
 
         assertThat(reportContents, hasItemContainsString("Jack Black"));
         assertThat(reportContents, hasItemContainsString("Joe Smith"));
@@ -272,7 +284,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        List reportContents = contentsOf(outputDirectory.listFiles(new XMLFileFilter()));
+        List reportContents = contentsOf(reload(outputDirectory).listFiles(new XMLFileFilter()));
         assertThat(reportContents.size(), is(1));
     }
 
@@ -604,7 +616,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        List<String> reportContents = contentsOf(outputDirectory.listFiles(new XMLFileFilter()));
+        List<String> reportContents = contentsOf(reload(outputDirectory).listFiles(new XMLFileFilter()));
 
         assertThat(reportContents.size(), is(2));
 
@@ -621,7 +633,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        List<String> reportContents = contentsOf(outputDirectory.listFiles(new XMLFileFilter()));
+        List<String> reportContents = contentsOf(reload(outputDirectory).listFiles(new XMLFileFilter()));
 
         assertThat(reportContents, hasItemContainsString("<value>a</value>"));
         assertThat(reportContents, hasItemContainsString("<value>1</value>"));
@@ -745,6 +757,10 @@ public class WhenRunningADataDrivenTestScenario {
         return FileUtils.readFileToString(reportFile);
     }
 
+    private File reload(File old) {
+        return Paths.get(old.getAbsolutePath()).toFile();
+    }
+
     @Test
     public void a_separate_html_report_should_be_generated_from_each_scenario() throws Throwable  {
 
@@ -756,7 +772,7 @@ public class WhenRunningADataDrivenTestScenario {
 
         runner.run(new RunNotifier());
 
-        File[] reports = outputDirectory.listFiles(new HTMLFileFilter());
+        File[] reports = reload(outputDirectory).listFiles(new HTMLFileFilter());
         assertThat(reports.length, is(2));
     }
 


### PR DESCRIPTION
Problem:
 in #223 reported that some how WhenRunningADataDrivenTestScenario fails sometime

Reason:
 I can't reproduce it on my pc, but it can be reproduced on CI. 

Solution:
 It can be issue with filtering files in directory, that created before adding files to it. This is experimental fix, and should be rollbacked if issue with this test will appear in future. 
