### PR TITLE
#243 Upgrading typesafe.config from 1.2 to 1.3

### DIFF
--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     compile('com.jayway.awaitility:awaitility:1.6.3') {
         exclude group: 'cglib', module: 'cglib-nodep'
     }
-    compile 'com.typesafe:config:1.2.1'
+    compile 'com.typesafe:config:1.3.0'
     compile('org.jsoup:jsoup:1.8.3') {
         exclude group: 'junit', module: 'junit'
     }


### PR DESCRIPTION
#### Summary of this PR
Upgrades type.safe dependency 
#### Intended effect
Now it is possible to use [ConfigBeanFactory](https://github.com/typesafehub/config#configbeanfactory)
#### How should this be manually tested?
In compiling new classes will be available, also build should be successful
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#243  
#### Screenshots (if appropriate)
N/A