### PR TITLE
Report for configuration

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -5,6 +5,9 @@ import net.thucydides.core.util.EnvironmentVariables;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Properties that can be passed to a web driver test to customize its behaviour.
  * The properties can be passed as system properties or placed in the 'thucydides.properties' file using a lower-case,
@@ -89,6 +92,11 @@ public enum ThucydidesSystemProperty {
      * Where should reports be generated (use the system property 'thucydides.outputDirectory').
      */
     THUCYDIDES_OUTPUT_DIRECTORY("thucydides.outputDirectory"),
+
+    /**
+     * Default name of report with configurations. It will contains some values that was used during generation of reports
+     */
+    THUCYDIDES_CONFIGURATION_REPORT("thucydides.configuration.json"),
 
     /**
      * Should Thucydides only store screenshots for failing steps?
@@ -394,7 +402,7 @@ public enum ThucydidesSystemProperty {
     BROWSERSTACK_URL,
 
     BROWSERSTACK_OS,
-    
+
     BROWSERSTACK_OS_VERSION,
 
     BROWSERSTACK_BROWSER,
@@ -780,6 +788,16 @@ public enum ThucydidesSystemProperty {
 
     private String withSerenityPrefix(String propertyName) {
         return propertyName.replaceAll("thucydides.","serenity.");
+    }
+
+    public String preferredName(){
+        return withSerenityPrefix(getPropertyName());
+    }
+
+    public List<String> legacyNames(){
+        List<String> names = new ArrayList<>(1);
+        names.add(withLegacyPrefix(getPropertyName()));
+        return names;
     }
 
     public String from(EnvironmentVariables environmentVariables, String defaultValue) {

--- a/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -99,6 +99,11 @@ public enum ThucydidesSystemProperty {
     THUCYDIDES_CONFIGURATION_REPORT("thucydides.configuration.json"),
 
     /**
+     * Default name of folder, with reports about test flow and aggregation report generation
+     */
+    THUCYDIDES_FLOW_REPORTS_DIR("flow"),
+
+    /**
      * Should Thucydides only store screenshots for failing steps?
      * This can save disk space and speed up the tests somewhat. Useful for data-driven testing.
      * @deprecated This property is still supported, but thucydides.take.screenshots provides more fine-grained control.
@@ -783,11 +788,11 @@ public enum ThucydidesSystemProperty {
     }
 
     private String withLegacyPrefix(String propertyName) {
-        return propertyName.replaceAll("serenity.","thucydides.");
+        return propertyName.replaceAll("serenity.", "thucydides.");
     }
 
     private String withSerenityPrefix(String propertyName) {
-        return propertyName.replaceAll("thucydides.","serenity.");
+        return propertyName.replaceAll("thucydides.", "serenity.");
     }
 
     public String preferredName(){

--- a/serenity-core/src/main/java/net/thucydides/core/bootstrap/ThucydidesContext.java
+++ b/serenity-core/src/main/java/net/thucydides/core/bootstrap/ThucydidesContext.java
@@ -121,6 +121,7 @@ class ThucydidesContext {
 
     public void generateReports() {
         reportService.generateReportsFor(latestTestOutcomes());
+        reportService.generateConfigurationsReport();
     }
 
     private List<TestOutcome> latestTestOutcomes() {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
@@ -118,9 +118,10 @@ public class ReportService {
 
         try {
             final boolean autoFlush = true;
-            final Path file = this.outputDirectory.toPath()
-                    .resolve(ThucydidesSystemProperty.THUCYDIDES_CONFIGURATION_REPORT.preferredName());
-            Files.createDirectories(this.outputDirectory.toPath());
+            final Path flow = this.outputDirectory.toPath().resolve(
+                    ThucydidesSystemProperty.THUCYDIDES_FLOW_REPORTS_DIR.preferredName());
+            final Path file = flow.resolve(ThucydidesSystemProperty.THUCYDIDES_CONFIGURATION_REPORT.preferredName());
+            Files.createDirectories(flow);
             try (Writer writer = new PrintWriter(Files.newBufferedWriter(file, Charset.defaultCharset()), autoFlush)) {
                 LOGGER.debug("Generating report for configuration");
                 writer.write(config.root().render(ConfigRenderOptions.concise().setJson(true)));

--- a/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
@@ -120,7 +120,7 @@ public class ReportService {
             boolean autoFlush = true;
             Path file = this.outputDirectory.toPath()
                     .resolve(ThucydidesSystemProperty.THUCYDIDES_CONFIGURATION_REPORT.preferredName());
-            Files.createDirectories(file);
+            Files.createDirectories(this.outputDirectory.toPath());
             try (Writer writer = new PrintWriter(Files.newBufferedWriter(file, Charset.defaultCharset()), autoFlush)) {
                 LOGGER.debug("Generating report for configuration");
                 writer.write(config.root().render(ConfigRenderOptions.concise().setJson(true)));

--- a/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
@@ -110,22 +110,22 @@ public class ReportService {
      */
     public void generateConfigurationsReport(){
 
-        Configuration configuration = Injectors.getInjector().getInstance(Configuration.class);
+        final Configuration configuration = Injectors.getInjector().getInstance(Configuration.class);
         Config config = ConfigFactory.empty();
 
-        config.withValue(ThucydidesSystemProperty.THUCYDIDES_OUTPUT_DIRECTORY.preferredName(),
+        config = config.withValue(ThucydidesSystemProperty.THUCYDIDES_OUTPUT_DIRECTORY.preferredName(),
                 ConfigValueFactory.fromAnyRef(configuration.getOutputDirectory().getAbsolutePath()));
 
         try {
-            boolean autoFlush = true;
-            Path file = this.outputDirectory.toPath()
+            final boolean autoFlush = true;
+            final Path file = this.outputDirectory.toPath()
                     .resolve(ThucydidesSystemProperty.THUCYDIDES_CONFIGURATION_REPORT.preferredName());
             Files.createDirectories(this.outputDirectory.toPath());
             try (Writer writer = new PrintWriter(Files.newBufferedWriter(file, Charset.defaultCharset()), autoFlush)) {
                 LOGGER.debug("Generating report for configuration");
                 writer.write(config.root().render(ConfigRenderOptions.concise().setJson(true)));
             }
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new ReportGenerationFailedError(
                     "Failed to generate configuration reports", e);
         }

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityParameterizedRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityParameterizedRunner.java
@@ -191,6 +191,7 @@ public class SerenityParameterizedRunner extends Suite {
 
     private void generateReportsFor(List<TestOutcome> testOutcomes) {
         getReportService().generateReportsFor(testOutcomes);
+        getReportService().generateConfigurationsReport();
     }
 
     private ReportService getReportService() {

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
@@ -405,6 +405,7 @@ public class SerenityRunner extends BlockJUnit4ClassRunner {
      */
     private void generateReportsFor(final List<TestOutcome> testOutcomeResults) {
         getReportService().generateReportsFor(testOutcomeResults);
+        getReportService().generateConfigurationsReport();
     }
 
 


### PR DESCRIPTION
#### Summary of this PR
Adds "report" with actual properties used in configuration during execution of tests
#### Intended effect
Now it is possible get information what properties are used during creating test reports in Junit. Will be used to add more properties to analyze of test results. Also it will be possible to turn it off in some nearest future. 
#### How should this be manually tested?
Project with JUnit tests and Serenity BDD should be compiled, in target folder (target for reports) file with name "serenity.configuration.json" will appear. In this file should be valid json with path to target directory used during test execution
#### Side effects
N/A
#### Documentation
will be created under issue serenity-bdd/serenity-documentation/issues/50
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A