### PR TITLE
Revert "#243 Upgrading typesafe.config from 1.2 to 1.3"

### DIFF
--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     compile('com.jayway.awaitility:awaitility:1.6.3') {
         exclude group: 'cglib', module: 'cglib-nodep'
     }
-    compile 'com.typesafe:config:1.3.0'
+    compile 'com.typesafe:config:1.2.1'
     compile('org.jsoup:jsoup:1.8.3') {
         exclude group: 'junit', module: 'junit'
     }


### PR DESCRIPTION
Reverts serenity-bdd/serenity-core#248, because 1.3 can be used only with java 8, and some of our users are use java 7. 