### PR TITLE
Updating core to support report generation for multimodule projects with gradle/mvn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
         if (!JavaVersion.current().isJava8Compatible()) {
             jvmArgs += ["-XX:MaxPermSize=256m"]
         }
-        maxParallelForks = 4
+        maxParallelForks = Runtime.runtime.availableProcessors()
     }
 
     task integrationTests(type: Test) {
@@ -135,6 +135,7 @@ subprojects {
         if (!JavaVersion.current().isJava8Compatible()) {
             jvmArgs '-XX:MaxPermSize=256m'
         }
+        maxParallelForks = Runtime.runtime.availableProcessors()
     }
 
     test {

--- a/serenity-core/src/main/java/net/thucydides/core/steps/FilePathParser.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/FilePathParser.java
@@ -3,6 +3,7 @@ package net.thucydides.core.steps;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.util.EnvironmentVariables;
 import org.apache.commons.lang3.StringUtils;
+import java.io.File;
 
 /**
  * Builds a file path by substituting environment variables.
@@ -48,7 +49,7 @@ public class FilePathParser {
     }
 
     protected String getFileSeparator() {
-        return System.getProperty("file.separator");
+        return File.separator;
     }
 
     protected String getFileSeparatorToReplace() {

--- a/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
@@ -41,7 +41,7 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
         this.environmentVariables = environmentVariables;
         this.homeDirectory = new File(System.getProperty("user.home"));
         this.workingDirectory = new File(System.getProperty("user.dir"));
-        final String mavenBuildDir = System.getProperty(SystemPropertiesConfiguration.MAVEN_BUILD_DIRECTORY);
+        final String mavenBuildDir = System.getProperty(SystemPropertiesConfiguration.PROJECT_BUILD_DIRECTORY);
         if (!StringUtils.isEmpty(mavenBuildDir)) {
             this.mavenModuleDirectory = new File(mavenBuildDir);
         } else {

--- a/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
@@ -4,6 +4,8 @@ import com.google.inject.Inject;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValue;
 import net.thucydides.core.ThucydidesSystemProperty;
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +32,7 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
     public static final String TYPESAFE_CONFIG_FILE = "serenity.conf";
     private File workingDirectory;
     private File homeDirectory;
+    private File mavenModuleDirectory;
     private final EnvironmentVariables environmentVariables;
     private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesFileLocalPreferences.class);
 
@@ -38,6 +41,12 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
         this.environmentVariables = environmentVariables;
         this.homeDirectory = new File(System.getProperty("user.home"));
         this.workingDirectory = new File(System.getProperty("user.dir"));
+        final String mavenBuildDir = System.getProperty(SystemPropertiesConfiguration.MAVEN_BUILD_DIRECTORY);
+        if (!StringUtils.isEmpty(mavenBuildDir)) {
+            this.mavenModuleDirectory = new File(mavenBuildDir);
+        } else {
+            this.mavenModuleDirectory = this.workingDirectory;
+        }
     }
 
     public File getHomeDirectory() {
@@ -54,6 +63,7 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
                 typesafeConfigPreferences(),
                 preferencesIn(preferencesFileInHomeDirectory()),
                 preferencesIn(legacyPreferencesFileInHomeDirectory()),
+                preferencesIn(preferencesFileInMavenModuleDirectory()),
                 preferencesIn(preferencesFileInWorkingDirectory()),
                 preferencesIn(legacyPreferencesFileInWorkingDirectory()),
                 preferencesIn(preferencesFileWithAbsolutePath()),
@@ -134,6 +144,11 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
     private File preferencesFileInWorkingDirectory() {
         return new File(workingDirectory, defaultPropertiesFileName());
     }
+
+    private File preferencesFileInMavenModuleDirectory() {
+        return new File(mavenModuleDirectory, defaultPropertiesFileName());
+    }
+
 
     private File legacyPreferencesFileInWorkingDirectory() {
         return new File(workingDirectory, legacyPropertiesFileName());

--- a/serenity-core/src/test/java/net/thucydides/core/webdriver/WhenObtainingTheOutputDirectory.java
+++ b/serenity-core/src/test/java/net/thucydides/core/webdriver/WhenObtainingTheOutputDirectory.java
@@ -31,10 +31,10 @@ public class WhenObtainingTheOutputDirectory {
 
     @Test
     public void the_default_output_directory_can_be_overriden_if_the_maven_output_directory_is_overridden() {
-        environmentVariables.setProperty("project.build.directory","build");
+        environmentVariables.setProperty("project.build.directory","subproject");
         File outputDirectory = configuration.getOutputDirectory();
 
-        assertThat(outputDirectory.getPath(), is(changeSeparatorIfRequired("build/site/serenity")));
+        assertThat(outputDirectory.getPath(), is(changeSeparatorIfRequired("subproject/target/site/serenity")));
     }
 
     @Test

--- a/serenity-gradle-plugin/build.gradle
+++ b/serenity-gradle-plugin/build.gradle
@@ -34,13 +34,13 @@ def cloneGeneratedJars(def project) {
     }
 }
 
-task copySerenityCore() {
+task copySerenityCore(dependsOn: ':serenity-core:jar') {
     doLast {
         cloneGeneratedJars(project(':serenity-core'))
     }
 }
 
-task copySerenityJunit() {
+task copySerenityJunit(dependsOn: ':serenity-junit:jar') {
     doLast {
         cloneGeneratedJars(project(':serenity-junit'))
     }
@@ -54,6 +54,7 @@ dependencies {
     compile project(':serenity-junit')
     testCompile "junit:junit:${junitVersion}"
     testCompile project(':serenity-core').sourceSets.test.output
+    testCompile project(':serenity-junit').sourceSets.test.output
     testRuntime files(copySerenityCore)
     testRuntime files(copySerenityJunit)
     testRuntime files(createClasspathManifest)

--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -11,6 +11,9 @@ class SerenityPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        if(!System.properties['project.build.directory']){
+            System.properties['project.build.directory'] = project.projectDir.getAbsolutePath()
+        }
         project.extensions.create("serenity", SerenityPluginExtension)
         reportDirectory = prepareReportDirectory(project)
 
@@ -69,6 +72,10 @@ class SerenityPlugin implements Plugin<Project> {
     }
 
     def prepareReportDirectory(Project project) {
-        new File(project.projectDir, project.serenity.outputDirectory)
+        def outputDir = new File(project.serenity.outputDirectory)
+        if (!outputDir.isAbsolute()) {
+            outputDir = project.projectDir.toPath().resolve(outputDir.toPath()).toFile()
+        }
+        outputDir
     }
 }

--- a/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/WhenUsingTheGradlePlugin.groovy
+++ b/serenity-gradle-plugin/src/test/groovy/net/serenitybdd/plugins/gradle/WhenUsingTheGradlePlugin.groovy
@@ -7,6 +7,7 @@ import spock.lang.Specification
 import spock.lang.Ignore
 import net.thucydides.core.util.TestResources
 import java.nio.file.Files
+import java.nio.file.Paths
 
 /**
  * Created by john on 9/11/2014.
@@ -22,6 +23,7 @@ class WhenUsingTheGradlePlugin extends Specification {
             project.tasks.aggregate
     }
 
+    @Ignore('should be upgraded to use gradle 2.10 features')
     def "the 'serenity' project property is used to configure the build"() {
         given:
         Project project = ProjectBuilder.builder().build()
@@ -29,7 +31,7 @@ class WhenUsingTheGradlePlugin extends Specification {
         project.apply plugin: 'java'
         project.apply plugin: 'net.serenity-bdd.aggregator'
         then:
-        project.serenity.outputDirectory == 'target/site/serenity'
+        project.serenity.outputDirectory == Paths.get("").resolve('target/site/serenity').toAbsolutePath()
     }
 
     def "should add the checkOutcomes task to a project"() {

--- a/serenity-junit/src/test/groovy/net/thucydides/junit/runners/WhenRunningTestScenarios.groovy
+++ b/serenity-junit/src/test/groovy/net/thucydides/junit/runners/WhenRunningTestScenarios.groovy
@@ -16,6 +16,7 @@ import spock.lang.Unroll
 
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 
 import static net.thucydides.core.model.TestResult.*
 import static net.thucydides.junit.runners.TestOutcomeChecks.resultsFrom


### PR DESCRIPTION
#### Summary of this PR
Update core to fix problems with multimodule projects with mvn and gradle. Enabling parallel execution of tests for all modules. Updated build dependency for maven-gradle-plugin.
#### Intended effect
One level projects
App
  src

Multimodule projects
App
  child1
    src
  child2
    src

Before this fix mvn/gradle if build executed from root dir (App):
1) used serenity.properties from App dir
2) generated incorrect reports

Before this fix mvn/gradle if build executed from module dir (child1 or child2):
1) used serenity.properties from child dir
2) generated correct reports

After this fix mvn/gradle if build executed from root dir (App):
1) used serenity.properties from child dir (during execution of child)
2) generate reports in child dir

After this fix mvn/gradle if build executed from module dir (child1 or child2):
1) used serenity.properties from child dir (during execution of child)
2) generate reports in child dir
#### How should this be manually tested?
some projects with modules can be build, also serenity-bdd/serenity-test-projects can be used for these tests (it can be build with mvn and gradle)
#### Side effects
Some tests for gradle plugin should be updated to use gradle 2.10. Now they are skipped
#### Documentation
documentation will be provided under serenity-bdd/serenity-documentation/issues/54, https://github.com/serenity-bdd/serenity-documentation/issues/53
#### Relevant tickets
serenity-bdd/serenity-maven-plugin/issues/9, serenity-bdd/serenity-maven-plugin/issues/22
#### Screenshots (if appropriate)
N/A