### PR TITLE
#268 Fix issue with custom step name when a method parameter contains with comma

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
@@ -260,19 +260,13 @@ public final class AnnotatedStepDescription {
     private String annotatedStepNameWithParameters(String annotatedStepTemplate) {
         String annotatedStepName = annotatedStepTemplate;
 
-        Iterable<String> parameters = getParamatersFrom(description.getName());
         int counter = 0;
-        for(String parameter : parameters) {
+        for(String parameter : description.getArguments()) {
             String token = "{" + counter++ + "}";
             annotatedStepName = StringUtils.replace(annotatedStepName, token, parameter);
 
         }
         return annotatedStepName;
-    }
-
-    private Iterable<String> getParamatersFrom(String name) {
-        String parameters = StringUtils.substringAfter(name,":");
-        return Splitter.on(",").trimResults().split(parameters);
     }
 
     public boolean isAGroup() {

--- a/serenity-core/src/main/java/net/thucydides/core/steps/ExecutedStepDescription.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/ExecutedStepDescription.java
@@ -1,9 +1,11 @@
 package net.thucydides.core.steps;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import net.thucydides.core.reflection.MethodFinder;
 
 import java.lang.reflect.Method;
+import java.util.List;
 import java.util.Map;
 
 import static net.thucydides.core.util.NameConverter.humanize;
@@ -17,17 +19,21 @@ public class ExecutedStepDescription implements Cloneable {
 
     private final Class<? extends Object> stepsClass;
     private final String name;
+    private final List<String> argumentsList;
     private final Map<String, Object> displayedFields;
     private boolean isAGroup;
 
     private final static Map<String,Object> NO_FIELDS = Maps.newHashMap();
+    private final static List<String> NO_ARGUMENTS = Lists.newArrayList();
 
     protected ExecutedStepDescription(final Class<? extends Object> stepsClass,
                                       final String name,
+                                      List<String> argumentsList,
                                       Map<String, Object> displayedFields,
                                       final boolean isAGroup) {
         this.stepsClass = stepsClass;
         this.name = name;
+        this.argumentsList = argumentsList;
         this.displayedFields = displayedFields;
         this.isAGroup = isAGroup;
     }
@@ -35,20 +41,20 @@ public class ExecutedStepDescription implements Cloneable {
     protected ExecutedStepDescription(final Class<? extends Object> stepsClass,
                                       final String name,
                                       final boolean isAGroup) {
-        this(stepsClass, name, NO_FIELDS, isAGroup);
+        this(stepsClass, name, NO_ARGUMENTS, NO_FIELDS, isAGroup);
     }
 
     protected ExecutedStepDescription(final Class<? extends Object> stepsClass,
                                       final String name) {
-        this(stepsClass, name, NO_FIELDS, false);
+        this(stepsClass, name, NO_ARGUMENTS, NO_FIELDS, false);
     }
 
     protected ExecutedStepDescription(final String name) {
-        this(null, name, NO_FIELDS, false);
+        this(null, name, NO_ARGUMENTS, NO_FIELDS, false);
     }
 
     public ExecutedStepDescription clone() {
-        return new ExecutedStepDescription(stepsClass, name, displayedFields, isAGroup);
+        return new ExecutedStepDescription(stepsClass, name, argumentsList, displayedFields, isAGroup);
     }
 
     /**
@@ -58,9 +64,12 @@ public class ExecutedStepDescription implements Cloneable {
         return stepsClass;
     }
 
-
     public String getName() {
         return name;
+    }
+
+    public List<String> getArguments() {
+        return argumentsList;
     }
 
     public ExecutedStepDescription withName(String newName) {
@@ -68,7 +77,7 @@ public class ExecutedStepDescription implements Cloneable {
     }
 
     public ExecutedStepDescription withDisplayedFields(Map<String, Object> displayedFields) {
-        return new ExecutedStepDescription(this.stepsClass, this.name, displayedFields, isAGroup);
+        return new ExecutedStepDescription(this.stepsClass, this.name, this.argumentsList, displayedFields, isAGroup);
     }
 
     /**
@@ -76,7 +85,21 @@ public class ExecutedStepDescription implements Cloneable {
      */
     public static ExecutedStepDescription of(final Class<? extends Object> stepsClass,
                                              final String name) {
-        return new ExecutedStepDescription(stepsClass, name, NO_FIELDS, false);
+        return new ExecutedStepDescription(stepsClass, name, NO_ARGUMENTS, NO_FIELDS, false);
+    }
+
+    public static ExecutedStepDescription of(final Class<? extends Object> stepsClass,
+                                             final String name,
+                                             final Object[] arguments) {
+        return new ExecutedStepDescription(stepsClass, name, convertArguments(arguments), NO_FIELDS, false);
+    }
+
+    private static List<String> convertArguments(Object[] arguments) {
+        List<String> listResult = Lists.newArrayList();
+        for (Object argument : arguments) {
+            listResult.add(StepArgumentWriter.readableFormOf(argument));
+        }
+        return listResult;
     }
 
     public static ExecutedStepDescription withTitle(final String name) {

--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
@@ -418,7 +418,7 @@ public class StepInterceptor implements MethodInterceptor, MethodErrorReporter {
 
     private void notifyOfStepFailure(final Object object, final Method method, final Object[] args,
                                      final Throwable cause) throws Throwable {
-        ExecutedStepDescription description = ExecutedStepDescription.of(testStepClass, getTestNameFrom(method, args))
+        ExecutedStepDescription description = ExecutedStepDescription.of(testStepClass, getTestNameFrom(method, args), args)
                 .withDisplayedFields(fieldValuesIn(object));
 
         StepFailure failure = new StepFailure(description, cause);
@@ -433,7 +433,7 @@ public class StepInterceptor implements MethodInterceptor, MethodErrorReporter {
     }
 
     private void notifyStepStarted(final Object object, final Method method, final Object[] args) {
-        ExecutedStepDescription description = ExecutedStepDescription.of(testStepClass, getTestNameFrom(method, args))
+        ExecutedStepDescription description = ExecutedStepDescription.of(testStepClass, getTestNameFrom(method, args), args)
                 .withDisplayedFields(fieldValuesIn(object));
         StepEventBus.getEventBus().stepStarted(description);
     }
@@ -444,7 +444,7 @@ public class StepInterceptor implements MethodInterceptor, MethodErrorReporter {
 
     private void notifySkippedStepStarted(final Object object, final Method method, final Object[] args) {
 
-        ExecutedStepDescription description = ExecutedStepDescription.of(testStepClass, getTestNameFrom(method, args))
+        ExecutedStepDescription description = ExecutedStepDescription.of(testStepClass, getTestNameFrom(method, args), args)
                 .withDisplayedFields(fieldValuesIn(object));
         StepEventBus.getEventBus().skippedStepStarted(description);
     }

--- a/serenity-core/src/test/java/net/thucydides/core/steps/WhenDescribingSteps.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/WhenDescribingSteps.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 
@@ -112,6 +113,25 @@ public class WhenDescribingSteps {
         assertThat(clone.getName(), is(description.getName()));
         assertThat(clone.getTestMethod(), is(description.getTestMethod()));
         assertThat(clone.isAGroup(), is(description.isAGroup()));
+        assertThat(clone.getArguments(), is(description.getArguments()));
     }
 
+    @Test
+    public void a_description_can_be_created_without_arguments_list() {
+        ExecutedStepDescription description = new ExecutedStepDescription(SampleTestSteps.class, "a_step");
+
+        assertThat(description.getTestMethod().getName(), is("a_step"));
+        assertThat(description.getArguments(), notNullValue());
+        assertThat(description.getArguments().size(), is(0));
+    }
+
+    @Test
+    public void a_description_can_be_created_with_arguments_list() {
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class, "a_step_with_parameters", new Object[] {"Joe"});
+
+        assertThat(description.getTestMethod().getName(), is("a_step_with_parameters"));
+        assertThat(description.getArguments(), notNullValue());
+        assertThat(description.getArguments().size(), is(1));
+        assertThat(description.getArguments().get(0), is("Joe"));
+    }
 }

--- a/serenity-core/src/test/java/net/thucydides/core/steps/WhenDescribingStepsUsingAnnotations.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/WhenDescribingStepsUsingAnnotations.java
@@ -132,7 +132,9 @@ public class WhenDescribingStepsUsingAnnotations {
 
     @Test
     public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_a_parameter() {
-        ExecutedStepDescription description = new ExecutedStepDescription(SampleTestSteps.class, "a_customized_step_with_parameters: Joe");
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
+                "a_customized_step_with_parameters: Joe",
+                new Object[]{"Joe"});
 
         AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
 
@@ -142,9 +144,10 @@ public class WhenDescribingStepsUsingAnnotations {
     @Test
     public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_a_parameter_and_a_field_variable() {
 
-        ExecutedStepDescription description = new ExecutedStepDescription(SampleTestSteps.class,
-                                                                          "a_customized_step_with_parameters_and_fields: Joe")
-                                                                          .withDisplayedFields(ImmutableMap.of("color",(Object)"red"));
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
+                "a_customized_step_with_parameters_and_fields",
+                new Object[]{"Joe"})
+                .withDisplayedFields(ImmutableMap.of("color", (Object) "red"));
 
         AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
 
@@ -155,8 +158,9 @@ public class WhenDescribingStepsUsingAnnotations {
     @Test(expected = AssertionError.class)
     public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_a_parameter_and_an_empty_field_variable() {
 
-        ExecutedStepDescription description = new ExecutedStepDescription(SampleTestSteps.class,
-                "a_customized_step_with_parameters_and_empty_field_value: Joe")
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
+                "a_customized_step_with_parameters_and_empty_field_value",
+                new Object[] {"Joe"})
                 .withDisplayedFields(ImmutableMap.of("color",(Object)"red", "emptyField", Fields.FieldValue.UNDEFINED));
 
         AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
@@ -165,11 +169,24 @@ public class WhenDescribingStepsUsingAnnotations {
 
     @Test
     public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_several_parameters() {
-        ExecutedStepDescription description = new ExecutedStepDescription(SampleTestSteps.class, "a_customized_step_with_two_parameters: Joe,20");
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
+                "a_customized_step_with_two_parameters",
+                new Object[]{"Joe", "20"});
 
         AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
 
         assertThat(annotatedStepDescription.getName(), is("a step about a person called Joe, aged 20"));
+    }
+
+    @Test
+    public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_several_parameters_with_comma() {
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
+                "a_customized_step_with_two_parameters",
+                new Object[] {"Smith, Joe", "20"});
+
+        AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
+
+        assertThat(annotatedStepDescription.getName(), is("a step about a person called Smith, Joe, aged 20"));
     }
 
     @Test

--- a/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningANonWebTestScenario.java
+++ b/serenity-junit/src/test/java/net/serenitybdd/junit/runners/integration/WhenRunningANonWebTestScenario.java
@@ -295,7 +295,20 @@ public class WhenRunningANonWebTestScenario extends AbstractTestStepRunnerTest {
 
         TestOutcome testOutcome = testOutcomeWithTitle("Should handle nested object parameters", executedScenarios);
         TestStep firstStep = testOutcome.getTestSteps().get(0);
-        assertThat(firstStep.getDescription(), is("a step with an object parameter called <span class='step-parameter'>$100.00</span>"));
+        assertThat(firstStep.getDescription(), is("a step with an object parameter called $100.00"));
+    }
+
+    @Test
+    public void should_report_correctly_customized_title_for_parameter_with_comma() throws InitializationError {
+
+        SerenityRunner runner = new SerenityRunner(NonWebTestScenarioWithParameterizedSteps.class);
+        runner.run(new RunNotifier());
+
+        List<TestOutcome> executedScenarios = runner.getTestOutcomes();
+
+        TestOutcome testOutcome = testOutcomeWithTitle("Should be correct customized title for parameter with comma", executedScenarios);
+        TestStep firstStep = testOutcome.getTestSteps().get(0);
+        assertThat(firstStep.getDescription(), is("a step with two object parameters called 'Joe, Smith' and '20'"));
     }
 
     private TestOutcome testOutcomeWithTitle(String title, List<TestOutcome> testOutcomes) {

--- a/serenity-junit/src/test/java/net/thucydides/samples/NonWebTestScenarioWithParameterizedSteps.java
+++ b/serenity-junit/src/test/java/net/thucydides/samples/NonWebTestScenarioWithParameterizedSteps.java
@@ -38,5 +38,8 @@ public class NonWebTestScenarioWithParameterizedSteps {
         steps.a_customized_step_with_object_parameters(new SampleNonWebSteps.CurrencyIn$(100));
     }
 
-
+    @Test
+    public void should_be_correct_customized_title_for_parameter_with_comma() {
+        steps.a_customized_step_with_two_parameters("Joe, Smith", "20");
+    }
 }

--- a/serenity-junit/src/test/java/net/thucydides/samples/SampleNonWebSteps.java
+++ b/serenity-junit/src/test/java/net/thucydides/samples/SampleNonWebSteps.java
@@ -96,4 +96,7 @@ public class SampleNonWebSteps {
     @Step("a step with an object parameter called {0}")
     public void a_customized_step_with_object_parameters(CurrencyIn$ currency) {}
 
+    @Step("a step with two object parameters called '{0}' and '{1}'")
+    public void a_customized_step_with_two_parameters(String param1, String param2) {}
+
 }


### PR DESCRIPTION
#### Summary of this PR
The goal of this change is to fix problem with wrong step title displayed in the generated HTML-report in case if the method parameter contains comma character.
#### Intended effect
As far as I understood currently information about method name and its parameters is stored as string value (StepInterceptor#testNameWithArguments) and later there is an attempt to restore information about arguments by splitting this string by delimiter character (AnnotatedStepDescription#annotatedStepNameWithParameters). The problems appears when some parameter contains delimiter character and it leads to wrong splitting. 
One of possible way to solve the problems was encoding of delimiter character inside method parameters, but there may be some problems with extracting them (especially taking into account that the description string contains also decoration HTML-tags, currently it's span tag).
Easier way is to store information about method arguments inside ExecutedStepDescription object. It lets avoid problem with restoring of arguments list from the string representation and has minimum influence on existing code.
#### How should this be manually tested?
In order to test manually it's necessary:
- run should_be_correct_customized_title_for_parameter_with_comma test in NonWebTestScenarioWithParameterizedSteps class (serenity-junit project)
- open generated html-report

#### Side effects
The constructor of ExecutedStepDescription class has been changed, correspondent unit-tests for ExecutedStepDescription class have been updated too.
#### Documentation
No need to update user documentation.
#### Relevant tickets
https://github.com/serenity-bdd/serenity-core/issues/268
#### Screenshots (if appropriate)
“what was before this PR” 
![268_before](https://cloud.githubusercontent.com/assets/3194707/12510168/8f411750-c110-11e5-828e-2754575b802a.png)
"how it will be changed”
![268_after](https://cloud.githubusercontent.com/assets/3194707/12510166/8dce1ec2-c110-11e5-9183-6738abf414bc.png)
