### PR TITLE
Moving definition of reportDirectory to within the tasks

### DIFF
--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -15,12 +15,12 @@ class SerenityPlugin implements Plugin<Project> {
             System.properties['project.build.directory'] = project.projectDir.getAbsolutePath()
         }
         project.extensions.create("serenity", SerenityPluginExtension)
-        reportDirectory = prepareReportDirectory(project)
 
         project.task('aggregate') {
             group 'Serenity BDD'
             description 'Generates aggregated Serenity reports'
             doLast {
+                reportDirectory = prepareReportDirectory(project)
                 if (!project.serenity.projectKey) {
                     project.serenity.projectKey = project.name
                 }
@@ -44,6 +44,7 @@ class SerenityPlugin implements Plugin<Project> {
             inputs.dir reportDirectory
 
             doLast {
+                reportDirectory = prepareReportDirectory(project)
                 logger.lifecycle("Checking serenity results for ${project.serenity.projectKey} in directory $reportDirectory")
                 if (reportDirectory.exists()) {
                     def checker = new ResultChecker(reportDirectory)
@@ -56,6 +57,7 @@ class SerenityPlugin implements Plugin<Project> {
             description "Deletes the Serenity output directory (run automatically with 'clean')"
 
             doLast {
+                reportDirectory = prepareReportDirectory(project)
                 reportDirectory.deleteDir()
             }
         }


### PR DESCRIPTION
Moving the definition of reportDirectory in order to allow easy configuration through the serenity configuration block. Currently this directory gets set when applying the plugin, which makes it only possible to change through setting an environment variable at the same level as applying the plugin. For multi-module projects with compile dependencies, setting this on a module basis does not work without making it part of the task.

This now allows for configuration per service to do something like:

serenity {
     reportDirectory "/dev/multi-module-project/test-output/integrationTest/${project.name}"
}