### PR TITLE
Updated processing of system properties for OS and browser versions for BrowserStack

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/BrowserStackRemoteDriverCapabilities.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/BrowserStackRemoteDriverCapabilities.java
@@ -36,14 +36,24 @@ public class BrowserStackRemoteDriverCapabilities implements RemoteDriverCapabil
         return capabilities;
     }
 
+    private String getPreparedPropertyKey(String propertyKey) {
+        String shortenedPropertyKey = propertyKey.replace("browserstack.","");
+        if (shortenedPropertyKey.equals("os.version")) {
+            return "os_version";
+        } else if (shortenedPropertyKey.equals("browser.version")) {
+            return "browser_version";
+        }
+        return shortenedPropertyKey;
+    }
+
     private void configureBrowserStackCapabilities(DesiredCapabilities capabilities) {
         List<String> browserStackProperties = filter(having(on(String.class), startsWith("browserstack.")),
                                                      environmentVariables.getKeys());
         for(String propertyKey : browserStackProperties) {
-            String shortenedPropertyKey = propertyKey.replace("browserstack.","");
+            String preparedPropertyKey = getPreparedPropertyKey(propertyKey);
             String propertyValue = environmentVariables.getProperty(propertyKey);
             if (isNotEmpty(propertyValue)) {
-                capabilities.setCapability(shortenedPropertyKey, propertyValue);
+                capabilities.setCapability(preparedPropertyKey, propertyValue);
                 capabilities.setCapability(propertyKey, propertyValue);
             }
         }


### PR DESCRIPTION
#### Summary of this PR
Update processing of "browserstack.os.version" and "browserstack.browser.version" system properties
#### Intended effect
Currently BrowserStack requires to use "os_version" and "browser_version" capabilities to define OS and browser version. Serenity sends these parameter with "." as a separator (as it was required previously). This PR changes processing of two system parameters to follow updated BrowserStack parameter syntax.
#### How should this be manually tested?
There are no ready tests because it requires providing credentials for BrowserStack. The fix was tested locally.
#### Side effects
No.
#### Documentation
The fix was implemented in the way that doesn't affect existing Serenity configuration parameters. No need to reflect in the documentation.
#### Relevant tickets
https://github.com/serenity-bdd/serenity-core/issues/276
#### Screenshots (if appropriate)
No.