### PR TITLE
Updating of report generation engine to wait for started threads, and close all opened streams

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/buildinfo/PropertyBasedDriverCapabilityRecord.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/buildinfo/PropertyBasedDriverCapabilityRecord.java
@@ -5,11 +5,10 @@ import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 import net.thucydides.core.webdriver.Configuration;
 import org.openqa.selenium.Capabilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
+import java.io.*;
 import java.nio.file.DirectoryIteratorException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -24,6 +23,8 @@ import static java.nio.file.Files.newInputStream;
  * Created by john on 12/02/15.
  */
 public class PropertyBasedDriverCapabilityRecord implements DriverCapabilityRecord {
+
+    Logger LOGGER = LoggerFactory.getLogger(PropertyBasedDriverCapabilityRecord.class);
 
     private Configuration configuration;
 
@@ -60,7 +61,7 @@ public class PropertyBasedDriverCapabilityRecord implements DriverCapabilityReco
                 drivers.add(driverName);
             }
         } catch (IOException | DirectoryIteratorException x) {
-            System.err.println(x);
+            LOGGER.error("Exception during getting drivers", x);
         }
         return drivers;
     }
@@ -81,11 +82,13 @@ public class PropertyBasedDriverCapabilityRecord implements DriverCapabilityReco
             for (Path file : stream) {
                 String driverName = driverNameFrom(file);
                 Properties driverProperties = new Properties();
-                driverProperties.load(newInputStream(file));
+                try(InputStream properties = newInputStream(file)) {
+                    driverProperties.load(properties);
+                }
                 driverCapabilities.put(driverName, driverProperties);
             }
         } catch (IOException | DirectoryIteratorException x) {
-            System.err.println(x);
+            LOGGER.error("Exception during getting driver capabilities",x);
         }
         return driverCapabilities;
     }

--- a/serenity-core/src/main/java/net/thucydides/core/images/ResizableImage.java
+++ b/serenity-core/src/main/java/net/thucydides/core/images/ResizableImage.java
@@ -55,11 +55,8 @@ public class ResizableImage {
         String suffix = this.getFileSuffix(screenshotFile.getPath());
         Iterator<ImageReader> imageReaders = ImageIO.getImageReadersBySuffix(suffix);
         if (imageReaders.hasNext()) {
-
             ImageReader reader = imageReaders.next();
-            ImageInputStream stream = null;
-            try{
-                stream = new FileImageInputStream(screenshotFile);
+            try (ImageInputStream stream = new FileImageInputStream(screenshotFile);) {
                 reader.setInput(stream);
                 int width = reader.getWidth(reader.getMinIndex());
                 int height = reader.getHeight(reader.getMinIndex());
@@ -72,13 +69,6 @@ public class ResizableImage {
                     reader.dispose();
                 } catch (Throwable e) {
                     logger.error("During reader disposing",e);
-                }
-                try {
-                    if (stream != null) {
-                        stream.close();
-                    }
-                } catch (IOException e) {
-                    logger.error("During image stream closing",e);
                 }
             }
         } else {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/MultithreadExecutorServiceProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/MultithreadExecutorServiceProvider.java
@@ -17,8 +17,8 @@ public class MultithreadExecutorServiceProvider implements ExecutorServiceProvid
 
     @Inject
     public MultithreadExecutorServiceProvider(EnvironmentVariables environmentVariables) {
-        corePoolSize = ThucydidesSystemProperty.REPORT_THREADS.integerFrom(environmentVariables, 4);
-        maximumPoolSize = ThucydidesSystemProperty.REPORT_MAX_THREADS.integerFrom(environmentVariables, 8);
+        corePoolSize = ThucydidesSystemProperty.REPORT_THREADS.integerFrom(environmentVariables, Runtime.getRuntime().availableProcessors());
+        maximumPoolSize = ThucydidesSystemProperty.REPORT_MAX_THREADS.integerFrom(environmentVariables, Runtime.getRuntime().availableProcessors());
         keepAliveTime = ThucydidesSystemProperty.REPORT_KEEP_ALIVE_TIME.integerFrom(environmentVariables, 60000);
     }
 

--- a/serenity-core/src/main/java/net/thucydides/core/reports/csv/CSVReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/csv/CSVReporter.java
@@ -49,10 +49,12 @@ public class CSVReporter extends ThucydidesReporter {
     }
 
     public File generateReportFor(TestOutcomes testOutcomes, String reportName) throws IOException {
-        CSVWriter writer = new CSVWriter(new java.io.OutputStreamWriter(new java.io.FileOutputStream(getOutputFile(reportName)), encoding));
-        writeTitleRow(writer);
-        writeEachRow(testOutcomes.withHistory(), writer);
-        writer.close();
+        try(CSVWriter writer = new CSVWriter(
+                new java.io.OutputStreamWriter(
+                        new java.io.FileOutputStream(getOutputFile(reportName)), encoding))) {
+            writeTitleRow(writer);
+            writeEachRow(testOutcomes.withHistory(), writer);
+        }
         return getOutputFile(reportName);
     }
 

--- a/serenity-core/src/main/java/net/thucydides/core/reports/html/Formatter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/html/Formatter.java
@@ -221,11 +221,10 @@ public class Formatter {
 
     private List<String> getEmbeddedTablesIn(String text) {
         List<String> embeddedTables = Lists.newArrayList();
-        BufferedReader reader = new BufferedReader(new StringReader(text));
         StringBuffer tableText = new StringBuffer();
-        boolean inTable = false;
-        String newLine = newLineUsedIn(text);
-        try {
+        try (BufferedReader reader = new BufferedReader(new StringReader(text))) {
+            boolean inTable = false;
+            String newLine = newLineUsedIn(text);
             String line;
             while ((line = reader.readLine()) != null) {
                 if (!inTable && line.contains("|")){ // start of a table

--- a/serenity-core/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
@@ -138,9 +138,7 @@ public class HtmlAggregateStoryReporter extends HtmlReporter implements UserStor
 
             Path targetPath = Paths.get(getOutputDirectory().toURI());
             Path sourcePath = Paths.get(sourceDirectory.toURI());
-            try {
-
-                DirectoryStream<Path> directoryContents = Files.newDirectoryStream(sourcePath);
+            try (DirectoryStream<Path> directoryContents = Files.newDirectoryStream(sourcePath)) {
                 for(Path sourceFile : directoryContents) {
                     Path destinationFile = targetPath.resolve(sourceFile.getFileName());
                     if (Files.notExists(destinationFile)) {

--- a/serenity-core/src/main/java/net/thucydides/core/steps/stepdata/CSVTestDataSource.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/stepdata/CSVTestDataSource.java
@@ -25,7 +25,7 @@ import static ch.lambdaj.Lambda.convert;
  * Test data from a CSV file.
  */
 public class CSVTestDataSource implements TestDataSource {
-    
+
     //private final List<Map<String, String>> testData;
     private char separator;
     private final char quotechar;
@@ -57,8 +57,8 @@ public class CSVTestDataSource implements TestDataSource {
 
     List<String[]> getDataRows() {
         if (csvDataRows == null) {
-            try {
-                csvDataRows = getCSVDataFrom(getDataFileFor(instantiatedPath));
+            try (Reader reader = getDataFileFor(instantiatedPath)) {
+                csvDataRows = getCSVDataFrom(reader);
             } catch (IOException e) {
                 LOGGER.error("Could not read test data file from {}", instantiatedPath, e);
             }
@@ -99,7 +99,7 @@ public class CSVTestDataSource implements TestDataSource {
 
     private static boolean isAClasspathResource(final String path) {
     	return !(CSVTestDataSource.class.getClassLoader().getResourceAsStream(path) == null);
-        
+
     }
 
     private static boolean validFileSystemPath(final String path) {
@@ -144,8 +144,8 @@ public class CSVTestDataSource implements TestDataSource {
     }
 
     public List<Map<String, String>> getData() {
-        try {
-            return loadTestDataFrom(getCSVDataFrom(getDataFileFor(instantiatedPath)));
+        try (Reader reader = getDataFileFor(instantiatedPath)) {
+            return loadTestDataFrom(getCSVDataFrom(reader));
         } catch (IOException e) {
             LOGGER.error("Could not read test data file from {}", instantiatedPath, e);
         }
@@ -180,7 +180,7 @@ public class CSVTestDataSource implements TestDataSource {
 
     public <T> List<T> getInstanciatedInstancesFrom(final Class<T> clazz, final StepFactory factory) {
         List<Map<String, String>> data = getData();
-        
+
         List<T> resultsList = new ArrayList<>();
         for (Map<String, String> rowData : data) {
             resultsList.add(newInstanceFrom(clazz, factory, rowData));
@@ -206,7 +206,7 @@ public class CSVTestDataSource implements TestDataSource {
     private <T> T newInstanceFrom(final Class<T> clazz,
                                   final StepFactory factory,
                                   final Map<String,String> rowData) {
-    	
+
     	T newObject = factory.getUniqueStepLibraryFor(clazz);
         assignPropertiesFromTestData(clazz, rowData, newObject);
         return newObject;

--- a/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
@@ -73,23 +73,22 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
     }
 
     private Properties preferencesInClasspath() throws IOException {
-        InputStream propertiesOnClasspath = null;
-        try {
-            propertiesOnClasspath = Thread.currentThread().getContextClassLoader().getResourceAsStream(defaultPropertiesFileName());
-            if (propertiesOnClasspath == null) {
-                propertiesOnClasspath = Thread.currentThread().getContextClassLoader().getResourceAsStream(legacyPropertiesFileName());
-            }
+        try (InputStream propertiesOnClasspath = propertiesInputStream()) {
             if (propertiesOnClasspath != null) {
                 Properties localPreferences = new Properties();
                 localPreferences.load(propertiesOnClasspath);
                 return localPreferences;
             }
-        } finally {
-            if (propertiesOnClasspath != null) {
-                propertiesOnClasspath.close();
-            }
         }
         return new Properties();
+    }
+
+    private InputStream propertiesInputStream(){
+        InputStream input = Thread.currentThread().getContextClassLoader().getResourceAsStream(defaultPropertiesFileName());
+        if (input == null) {
+            input = Thread.currentThread().getContextClassLoader().getResourceAsStream(legacyPropertiesFileName());
+        }
+        return input;
     }
 
     private Properties typesafeConfigPreferences() {

--- a/serenity-core/src/test/groovy/net/thucydides/core/reports/csv/WhenSavingTestOutcomesInCSVForm.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/reports/csv/WhenSavingTestOutcomesInCSVForm.groovy
@@ -80,7 +80,11 @@ class WhenSavingTestOutcomesInCSVForm extends Specification {
     }
 
     def linesIn(File csvResults) {
-        def reader = new CSVReader(new java.io.InputStreamReader(new java.io.FileInputStream(csvResults), "windows-1251"))
-        reader.readAll()
+        def CSVReader reader = new CSVReader(new java.io.InputStreamReader(new java.io.FileInputStream(csvResults), "windows-1251"))
+        try{
+            reader.readAll()
+        }finally{
+            reader.close()
+        }
     }
 }

--- a/serenity-core/src/test/java/net/thucydides/core/util/WhenLoadingPreferencesFromALocalPropertiesFile.java
+++ b/serenity-core/src/test/java/net/thucydides/core/util/WhenLoadingPreferencesFromALocalPropertiesFile.java
@@ -4,6 +4,8 @@ import net.thucydides.core.guice.Injectors;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -16,6 +18,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class WhenLoadingPreferencesFromALocalPropertiesFile {
 
+    Logger LOGGER = LoggerFactory.getLogger(WhenLoadingPreferencesFromALocalPropertiesFile.class);
+
     @Rule
     public ExtendedTemporaryFolder temporaryFolder = new ExtendedTemporaryFolder();
 
@@ -23,7 +27,7 @@ public class WhenLoadingPreferencesFromALocalPropertiesFile {
     File thucydidesPropertiesFile;
     EnvironmentVariables environmentVariables;
     PropertiesFileLocalPreferences localPreferences;
-    
+
     @Before
     public void setupDirectories() throws IOException {
         environmentVariables = new MockEnvironmentVariables();
@@ -36,7 +40,7 @@ public class WhenLoadingPreferencesFromALocalPropertiesFile {
     @Test
     public void the_default_preferences_directory_is_the_users_home_directory() throws Exception {
         PropertiesFileLocalPreferences localPreferences = new PropertiesFileLocalPreferences(environmentVariables);
-        
+
         String homeDirectory = System.getProperty("user.home");
 
         assertThat(localPreferences.getHomeDirectory().getPath(), is(homeDirectory));
@@ -47,7 +51,7 @@ public class WhenLoadingPreferencesFromALocalPropertiesFile {
         writeToPropertiesFile("webdriver.driver = opera");
 
         localPreferences.setHomeDirectory(homeDirectory);
-        
+
         localPreferences.loadPreferences();
 
         assertThat(environmentVariables.getProperty("webdriver.driver"), is("opera"));
@@ -150,11 +154,11 @@ public class WhenLoadingPreferencesFromALocalPropertiesFile {
         thucydidesPropertiesFile.setReadable(true);
         thucydidesPropertiesFile.setWritable(true);
         thucydidesPropertiesFile.setExecutable(true);
-        
+
         try {
         	thucydidesPropertiesFile.createNewFile();
         } catch (IOException e) {
-        	System.err.println(e);
+            LOGGER.error("Exception during writing properties",e);
 		}
         Thread.currentThread().sleep(100);
         FileWriter outFile = new FileWriter(thucydidesPropertiesFile);


### PR DESCRIPTION
#### Summary of this PR
Updates way of waiting generated reports. Also code updated to use java-core enums instead of same from google, and updated way of closing opened streams. Updated code that prints to System.err to logging with error level. Updated default config of cores witch are used during report generation to be dependent on cpu configuration. 
#### Intended effect
Tests should became stable and do not fail "time to time" because of abscond reports/screenshots 
#### How should this be manually tested?
Behaving should not change
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#173
#### Screenshots (if appropriate)
N/A