### PR TITLE
Updating dependency for using in serenity modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,9 @@ allprojects {
             // TODO make work for generated Maven POM...
             // it's working for gradle build, but also had to exclude old transitives for geio.appiumnerated POM
             force  'com.thoughtworks.xstream:xstream:1.4.5',
-                   'commons-collections:commons-collections:3.2.1',
+                   'commons-collections:commons-collections:3.2.2',
                    'commons-logging:commons-logging:1.2',
-                    'xml-apis:xml-apis:1.4.01'
+                   'xml-apis:xml-apis:1.4.01'
         }
     }
 }
@@ -403,7 +403,7 @@ subprojects {
     }
 
     task copyDeps(type: Copy) {
-        from configurations.runtime
+        from configurations.runtime + configurations.testCompile
         into project.projectDir.path + "/lib"
     }
 }


### PR DESCRIPTION
#### Summary of this PR
Updating dependency for using in serenity modules
#### Intended effect
Will be used commons-collections:commons-collections:3.2.2 instead of 3.2.1 as in selenium 2.50.1. 
This was done for serenity modules (jira, cucumber, etc.)
#### How should this be manually tested?
N/A
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A