### PR TITLE
Updated RequirementPersister

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/requirements/RequirementPersister.java
+++ b/serenity-core/src/main/java/net/thucydides/core/requirements/RequirementPersister.java
@@ -11,6 +11,7 @@ import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -39,6 +40,9 @@ public class RequirementPersister {
         Type requirementsMapType = new TypeToken<SortedMap<String, Requirement>>(){}.getType();
         try(FileReader reader = new FileReader(jsonFile)) {
             storedRequirementsMap = gson.fromJson(reader, requirementsMapType);
+            if (storedRequirementsMap == null) {
+                storedRequirementsMap = Collections.emptySortedMap();
+            }
         }
         map.putAll(storedRequirementsMap);
 


### PR DESCRIPTION
#### Summary of this PR
Updated RequirementPersister
#### Intended effect
Will not throw exception during loading json requirements if gson can not be read (and google gson lib returned null as expected)
#### How should this be manually tested?
All tests should be fine
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
N/A
#### Screenshots (if appropriate)
N/A