### PR TITLE
Updating gitattributes not to update chromedriver and woff files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,3 +40,5 @@
 *.xpi binary
 *.otf binary
 *.pages binary
+*driver
+*.woff


### PR DESCRIPTION
Updating gitattributes not to update chromedriver and woff files