### PR TITLE
Updating ThucydidesWebDriverSupport.getSessionId() to work properly with remote drivers

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/ThucydidesWebdriverManager.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/ThucydidesWebdriverManager.java
@@ -133,7 +133,7 @@ public class ThucydidesWebdriverManager implements WebdriverManager {
         WebDriver driver = getThreadLocalWebDriver(configuration, webDriverFactory,
                                                    inThisTestThread().getCurrentDriverName());
         if(driver instanceof WebDriverFacade){
-            driver = ((WebDriverFacade) driver).getProxiedDriver();
+            driver = ((WebDriverFacade) driver).getDriverInstance();
         }
         if (driver instanceof RemoteWebDriver) {
             return ((RemoteWebDriver) driver).getSessionId();

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/ThucydidesWebdriverManager.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/ThucydidesWebdriverManager.java
@@ -132,6 +132,9 @@ public class ThucydidesWebdriverManager implements WebdriverManager {
     public SessionId getSessionId() {
         WebDriver driver = getThreadLocalWebDriver(configuration, webDriverFactory,
                                                    inThisTestThread().getCurrentDriverName());
+        if(driver instanceof WebDriverFacade){
+            driver = ((WebDriverFacade) driver).getProxiedDriver();
+        }
         if (driver instanceof RemoteWebDriver) {
             return ((RemoteWebDriver) driver).getSessionId();
         }

--- a/serenity-core/src/test/groovy/net/serenitybdd/core/webdriver/WhenUsingWebDriverFacade.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/webdriver/WhenUsingWebDriverFacade.groovy
@@ -48,7 +48,7 @@ class WhenUsingWebDriverFacade extends Specification {
         configuration = new SystemPropertiesConfiguration(environmentVariables)
     }
 
-    def "stack should be initially empty"() {
+    def "should be possible get session id using webdriverManager"() {
         given:
             when(remote.getSessionId()).thenReturn(session)
             when(webDriverFactory.newInstanceOf(any(SupportedWebDriver.class))).thenReturn(remote)

--- a/serenity-core/src/test/groovy/net/serenitybdd/core/webdriver/WhenUsingWebDriverFacade.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/webdriver/WhenUsingWebDriverFacade.groovy
@@ -1,0 +1,64 @@
+package net.serenitybdd.core.webdriver
+
+import net.thucydides.core.util.EnvironmentVariables
+import net.thucydides.core.util.MockEnvironmentVariables
+import net.thucydides.core.webdriver.SupportedWebDriver
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration
+import net.thucydides.core.webdriver.ThucydidesWebdriverManager
+import net.thucydides.core.webdriver.TimeoutStack
+import net.thucydides.core.webdriver.WebDriverFacade
+import net.thucydides.core.webdriver.WebDriverFactory
+import net.thucydides.core.webdriver.WebdriverInstanceFactory
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.firefox.FirefoxDriver
+import org.openqa.selenium.remote.RemoteWebDriver
+import org.openqa.selenium.remote.SessionId
+import spock.lang.Specification
+import static org.mockito.Mockito.*
+
+/**
+ * User: YamStranger
+ * Date: 2/8/16
+ * Time: 12:58 PM
+ */
+class WhenUsingWebDriverFacade extends Specification {
+
+    @Mock
+    def RemoteWebDriver remote
+
+    @Mock
+    SessionId session
+
+    def EnvironmentVariables environmentVariables
+
+    @Mock
+    def WebdriverInstanceFactory webdriverInstanceFactory
+
+    def configuration
+
+    @Mock
+    def WebDriverFactory webDriverFactory
+
+    def setup() {
+        MockitoAnnotations.initMocks(this);
+        environmentVariables = new MockEnvironmentVariables()
+        configuration = new SystemPropertiesConfiguration(environmentVariables)
+    }
+
+    def "stack should be initially empty"() {
+        given:
+            when(remote.getSessionId()).thenReturn(session)
+            when(webDriverFactory.newInstanceOf(any(SupportedWebDriver.class))).thenReturn(remote)
+            def manager = new ThucydidesWebdriverManager(webDriverFactory, configuration);
+        when:
+            manager.registerDriver(remote)
+            manager.getSessionId()
+        then:
+            session == manager.getSessionId()
+            null == verify(remote, atLeast(2)).getSessionId();
+
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
Updating ThucydidesWebDriverSupport.getSessionId() to work properly with remote drivers 
#### Intended effect
If remote driver is used ThucydidesWebDriverSupport.getSessionId() should return session for it (if defined)
#### How should this be manually tested?
You can create some tests using Saucelabs as described under  #299
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#299 
#### Screenshots (if appropriate)
N/A
