### PR TITLE
Updating requirements location to use sumodule directory for multimodule projects

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/requirements/FileSystemRequirementsTagProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/requirements/FileSystemRequirementsTagProvider.java
@@ -15,6 +15,7 @@ import net.thucydides.core.requirements.model.Requirement;
 import net.thucydides.core.requirements.model.cucumber.CucumberParser;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.Inflector;
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -205,7 +206,15 @@ public class FileSystemRequirementsTagProvider extends AbstractRequirementsTagPr
     }
 
     private Set<String> getRootDirectoryFromWorkingDirectory() throws IOException {
-        return getRootDirectoryFromParentDir(System.getProperty(WORKING_DIR)).asSet();
+        final String workingDirectory = System.getProperty("user.dir");
+        final String mavenBuildDir = System.getProperty(SystemPropertiesConfiguration.PROJECT_BUILD_DIRECTORY);
+        String resultDir = "";
+        if (!StringUtils.isEmpty(mavenBuildDir)) {
+            resultDir = mavenBuildDir;
+        } else {
+            resultDir = workingDirectory;
+        }
+        return getRootDirectoryFromParentDir(resultDir).asSet();
     }
 
     private Optional<String> configuredRelativeRootDirectory;

--- a/serenity-core/src/main/java/net/thucydides/core/requirements/FileSystemRequirementsTagProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/requirements/FileSystemRequirementsTagProvider.java
@@ -18,6 +18,8 @@ import net.thucydides.core.util.Inflector;
 import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URI;
@@ -40,6 +42,8 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
  * By default, the tests
  */
 public class FileSystemRequirementsTagProvider extends AbstractRequirementsTagProvider implements RequirementsTagProvider, OverridableTagProvider {
+
+    private final static Logger logger = LoggerFactory.getLogger(FileSystemRequirementsTagProvider.class);
 
     private final static String DEFAULT_ROOT_DIRECTORY = "stories";
     private final static String FEATURES_ROOT_DIRECTORY = "features";
@@ -128,6 +132,7 @@ public class FileSystemRequirementsTagProvider extends AbstractRequirementsTagPr
                 Set<String> directoryPaths = getRootDirectoryPaths();
                 for (String rootDirectoryPath : directoryPaths) {
                     File rootDirectory = new File(rootDirectoryPath);
+                    logger.info("Loading requirements from isExists="+rootDirectory.exists()+" path:"+rootDirectory);
                     if (rootDirectory.exists()) {
                         allRequirements.addAll(loadCapabilitiesFrom(rootDirectory.listFiles(thatAreDirectories())));
                         allRequirements.addAll(loadStoriesFrom(rootDirectory.listFiles(thatAreStories())));

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/SystemPropertiesConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/SystemPropertiesConfiguration.java
@@ -146,6 +146,13 @@ public class SystemPropertiesConfiguration implements Configuration {
     }
 
     /**
+     * If some property that can change output directory was changed this method should be called
+     */
+    public void reloadOutputDirectory(){
+        setOutputDirectory(loadOutputDirectoryFromSystemProperties());
+    }
+
+    /**
      * should be base on module dir and not root project dir (if multimodule project iused with maven plugin)
      *
      * @param path to dir with reports, "outputDir"

--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -11,7 +11,6 @@ import org.gradle.api.Project
 class SerenityPlugin implements Plugin<Project> {
 
     File reportDirectory
-    def log
 
     @Override
     void apply(Project project) {
@@ -21,7 +20,6 @@ class SerenityPlugin implements Plugin<Project> {
             group 'Serenity BDD'
             description 'Generates aggregated Serenity reports'
             doLast {
-                log=logger
                 updateProperties(project)
                 reportDirectory = prepareReportDirectory(project)
                 if (!project.serenity.projectKey) {
@@ -47,7 +45,6 @@ class SerenityPlugin implements Plugin<Project> {
             inputs.dir reportDirectory
 
             doLast {
-                log=logger
                 updateProperties(project)
                 reportDirectory = prepareReportDirectory(project)
                 logger.lifecycle("Checking serenity results for ${project.serenity.projectKey} in directory $reportDirectory")
@@ -62,7 +59,6 @@ class SerenityPlugin implements Plugin<Project> {
             description "Deletes the Serenity output directory (run automatically with 'clean')"
 
             doLast {
-                log=logger
                 updateProperties(project)
                 reportDirectory = prepareReportDirectory(project)
                 reportDirectory.deleteDir()
@@ -90,7 +86,7 @@ class SerenityPlugin implements Plugin<Project> {
 
     def updateSystemPath(Project project) {
         System.properties['project.build.directory'] = project.projectDir.getAbsolutePath()
-        if (log) log.lifecycle("Updating project.build.directory to ${project.projectDir.getAbsolutePath()}")
+        printf ("Updating project.build.directory to ${project.projectDir.getAbsolutePath()}")
         def SystemPropertiesConfiguration configuration = (SystemPropertiesConfiguration) Injectors.getInjector().getProvider(Configuration.class).get()
         configuration.getEnvironmentVariables().setProperty('project.build.directory', project.projectDir.getAbsolutePath())
         configuration.reloadOutputDirectory()
@@ -100,7 +96,7 @@ class SerenityPlugin implements Plugin<Project> {
     def updateProperties(Project project) {
         updateSystemPath(project)
         def config = Injectors.getInjector().getProvider(Configuration.class).get()
-        if (log) log.lifecycle("Updating project.serenity.outputDirectory to ${config.getOutputDirectory()}")
+        printf ("Updating project.serenity.outputDirectory to ${config.getOutputDirectory()}")
         project.serenity.outputDirectory = config.getOutputDirectory()
         project.serenity.sourceDirectory = config.getOutputDirectory()
     }

--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -4,21 +4,25 @@ import net.thucydides.core.guice.Injectors
 import net.thucydides.core.reports.ResultChecker
 import net.thucydides.core.reports.html.HtmlAggregateStoryReporter
 import net.thucydides.core.webdriver.Configuration
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class SerenityPlugin implements Plugin<Project> {
 
     File reportDirectory
+    def log
 
     @Override
     void apply(Project project) {
+        updateSystemPath(project)
         project.extensions.create("serenity", SerenityPluginExtension)
         project.task('aggregate') {
-            updateProperties(project)
             group 'Serenity BDD'
             description 'Generates aggregated Serenity reports'
             doLast {
+                log=logger
+                updateProperties(project)
                 reportDirectory = prepareReportDirectory(project)
                 if (!project.serenity.projectKey) {
                     project.serenity.projectKey = project.name
@@ -37,13 +41,14 @@ class SerenityPlugin implements Plugin<Project> {
         }
 
         project.task('checkOutcomes') {
-            updateProperties(project)
             group 'Serenity BDD'
             description "Checks the Serenity reports and fails the build if there are test failures (run automatically with 'check')"
 
             inputs.dir reportDirectory
 
             doLast {
+                log=logger
+                updateProperties(project)
                 reportDirectory = prepareReportDirectory(project)
                 logger.lifecycle("Checking serenity results for ${project.serenity.projectKey} in directory $reportDirectory")
                 if (reportDirectory.exists()) {
@@ -53,11 +58,12 @@ class SerenityPlugin implements Plugin<Project> {
             }
         }
         project.task('clearReports') {
-            updateProperties(project)
             group 'Serenity BDD'
             description "Deletes the Serenity output directory (run automatically with 'clean')"
 
             doLast {
+                log=logger
+                updateProperties(project)
                 reportDirectory = prepareReportDirectory(project)
                 reportDirectory.deleteDir()
             }
@@ -82,10 +88,21 @@ class SerenityPlugin implements Plugin<Project> {
         outputDir
     }
 
-    def updateProperties(Project project) {
+    def updateSystemPath(Project project) {
         System.properties['project.build.directory'] = project.projectDir.getAbsolutePath()
+        log.lifecycle("Updating project.build.directory to ${project.projectDir.getAbsolutePath()}")
+        def SystemPropertiesConfiguration configuration = (SystemPropertiesConfiguration)Injectors.getInjector().getProvider(Configuration.class).get()
+        configuration.getEnvironmentVariables().setProperty('project.build.directory', project.projectDir.getAbsolutePath())
+        configuration.reloadOutputDirectory()
+    }
+
+
+    def updateProperties(Project project) {
+        updateSystemPath(project)
         def config = Injectors.getInjector().getProvider(Configuration.class).get()
+        log.lifecycle("Updating project.serenity.outputDirectory to ${config.getOutputDirectory()}")
         project.serenity.outputDirectory = config.getOutputDirectory()
         project.serenity.sourceDirectory = config.getOutputDirectory()
     }
+
 }

--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -90,8 +90,8 @@ class SerenityPlugin implements Plugin<Project> {
 
     def updateSystemPath(Project project) {
         System.properties['project.build.directory'] = project.projectDir.getAbsolutePath()
-        log.lifecycle("Updating project.build.directory to ${project.projectDir.getAbsolutePath()}")
-        def SystemPropertiesConfiguration configuration = (SystemPropertiesConfiguration)Injectors.getInjector().getProvider(Configuration.class).get()
+        if (log) log.lifecycle("Updating project.build.directory to ${project.projectDir.getAbsolutePath()}")
+        def SystemPropertiesConfiguration configuration = (SystemPropertiesConfiguration) Injectors.getInjector().getProvider(Configuration.class).get()
         configuration.getEnvironmentVariables().setProperty('project.build.directory', project.projectDir.getAbsolutePath())
         configuration.reloadOutputDirectory()
     }
@@ -100,7 +100,7 @@ class SerenityPlugin implements Plugin<Project> {
     def updateProperties(Project project) {
         updateSystemPath(project)
         def config = Injectors.getInjector().getProvider(Configuration.class).get()
-        log.lifecycle("Updating project.serenity.outputDirectory to ${config.getOutputDirectory()}")
+        if (log) log.lifecycle("Updating project.serenity.outputDirectory to ${config.getOutputDirectory()}")
         project.serenity.outputDirectory = config.getOutputDirectory()
         project.serenity.sourceDirectory = config.getOutputDirectory()
     }


### PR DESCRIPTION
#### Summary of this PR
Updating requirements location
#### Intended effect
Requirements can be in sumodule directory as well as in working directory
#### How should this be manually tested?
Some project with multi module structure should be created and run with gradle or maven plugin. 
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#305, serenity-bdd/serenity-maven-plugin/issues/22
#### Screenshots (if appropriate)
