### PR TITLE
#312 On Test Failure stacktrace can contain elements with no fileName (default.ftl)

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/default.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/default.ftl
@@ -279,7 +279,7 @@
                                 <#if (cause.message)??><h4>${cause.message}</h4></#if>
                                 <#list cause.stackTrace as element>
                                 ${element.className}.${element.methodName}(${(element.fileName)!""}
-                                    :${element.lineNumber})
+                                    :${element.lineNumber}) <br>
                                 </#list>
                             </div>
                             <div class="modal-footer">

--- a/serenity-report-resources/src/main/resources/freemarker/default.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/default.ftl
@@ -278,7 +278,7 @@
                             <div class="modal-body">
                                 <#if (cause.message)??><h4>${cause.message}</h4></#if>
                                 <#list cause.stackTrace as element>
-                                ${element.className}.${element.methodName}(${element.fileName}
+                                ${element.className}.${element.methodName}(${(element.fileName)!""}
                                     :${element.lineNumber})
                                 </#list>
                             </div>


### PR DESCRIPTION
#### Summary of this PR
Adds a default empty string "" into default.ftl template file to avoid crashing when a fileName is not provided for a function within the error stacktrace.

Adds a newline br tag into the stacktrace dialog, till now there were occasions where multiple functions fit on a single line.

#### Intended effect
Should prevent failure when a call in the stacktrace does not have an associated fileName. 

#### How should this be manually tested?
Recreate an identical stack to #312. 

#### Side effects
No.
#### Documentation
Not user facing and no new behavior.

#### Relevant tickets
#312 

#### Screenshots (if appropriate)
Before:
![before](https://cloud.githubusercontent.com/assets/6081895/13133310/ba56fc2a-d5bf-11e5-9fcc-c2dccd45e00c.png)
After:
![after](https://cloud.githubusercontent.com/assets/6081895/13133314/bec97af8-d5bf-11e5-8673-dcd029a0e6d6.png)

Error:
![screen shot 2016-02-17 at 9 52 36 pm](https://cloud.githubusercontent.com/assets/6081895/13133427/cd0b4e60-d5c0-11e5-8215-fe12df90fa77.png)
