### PR TITLE
Updated checking of empty string to use StringUtils, for #310

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -781,7 +781,7 @@ public enum ThucydidesSystemProperty {
 
     private Optional<String> legacyPropertyValueIfPresentIn(EnvironmentVariables environmentVariables) {
         String legacyValue = environmentVariables.getProperty(withLegacyPrefix(getPropertyName()));
-        if (legacyValue != null) {
+        if (StringUtils.isNotEmpty(legacyValue)) {
             logger.warn("Legacy property format detected for {}, please use the serenity.* format instead.",getPropertyName());
         }
         return Optional.fromNullable(legacyValue);

--- a/serenity-core/src/main/java/net/thucydides/core/reflection/StackTraceAnalyser.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reflection/StackTraceAnalyser.java
@@ -1,5 +1,6 @@
 package net.thucydides.core.reflection;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +56,7 @@ public class StackTraceAnalyser {
     }
 
     private static boolean isInstrumentedMethod(StackTraceElement stackTraceElement) {
-        return (stackTraceElement.getFileName()) != null && (stackTraceElement.getFileName().equals("<generated>"));
+        return StringUtils.isNotEmpty(stackTraceElement.getFileName()) && (stackTraceElement.getFileName().equals("<generated>"));
     }
 
     private boolean allowedClassName(String className) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/adaptors/specflow/ScenarioSplitter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/adaptors/specflow/ScenarioSplitter.java
@@ -2,6 +2,7 @@ package net.thucydides.core.reports.adaptors.specflow;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 
@@ -51,7 +52,7 @@ public class ScenarioSplitter {
     }
 
     private String removeParametersFrom(String title) {
-        if (title != null && title.indexOf("(") > -1) {
+        if (StringUtils.isNotEmpty(title) && title.indexOf("(") > -1) {
             return title.substring(0, title.indexOf("(") );
         } else {
             return title;

--- a/serenity-core/src/main/java/net/thucydides/core/reports/html/HtmlAcceptanceTestReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/html/HtmlAcceptanceTestReporter.java
@@ -20,6 +20,7 @@ import net.thucydides.core.tags.BreadcrumbTagFilter;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.Inflector;
 import net.thucydides.core.util.VersionProvider;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +96,7 @@ public class HtmlAcceptanceTestReporter extends HtmlReporter implements Acceptan
         copyResourcesToOutputDirectory();
 
         String reportFilename = reportFor(storedTestOutcome);
-        LOGGER.debug("GENERATING HTML REPORT FOR " + storedTestOutcome.getCompleteName() + (qualifier != null ? "/" + qualifier : "") + " => " + reportFilename);
+        LOGGER.debug("GENERATING HTML REPORT FOR " + storedTestOutcome.getCompleteName() + (StringUtils.isNotEmpty(qualifier) ? "/" + qualifier : "") + " => " + reportFilename);
 
         return writeReportToOutputDirectory(reportFilename, htmlContents);
     }

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
@@ -7,6 +7,7 @@ import net.thucydides.core.model.ReportNamer;
 import net.thucydides.core.model.ReportType;
 import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.reports.TestOutcomes;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,7 @@ public class JUnitXMLOutcomeReporter  {
     private Map<String, List<TestOutcome>> groupByTestCase(TestOutcomes testOutcomes) {
         Map<String, List<TestOutcome>> groupedTestOutcomes = Maps.newHashMap();
         for(TestOutcome outcome : testOutcomes.getOutcomes()) {
-            String testCaseName = outcome.getTestCaseName() != null ? outcome.getTestCaseName() : outcome.getStoryTitle();
+            String testCaseName = StringUtils.isNotEmpty(outcome.getTestCaseName()) ? outcome.getTestCaseName() : outcome.getStoryTitle();
             if (groupedTestOutcomes.containsKey(testCaseName)) {
                 groupedTestOutcomes.get(testCaseName).add(outcome);
             } else {

--- a/serenity-core/src/main/java/net/thucydides/core/requirements/FileSystemRequirementsTagProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/requirements/FileSystemRequirementsTagProvider.java
@@ -466,7 +466,7 @@ public class FileSystemRequirementsTagProvider extends AbstractRequirementsTagPr
 
     private String stripRootPathFrom(String testOutcomePath) {
         String rootPath = ThucydidesSystemProperty.THUCYDIDES_TEST_ROOT.from(environmentVariables);
-        if (rootPath != null && testOutcomePath.startsWith(rootPath) && (!testOutcomePath.equals(rootPath))) {
+        if (StringUtils.isNotEmpty(rootPath) && testOutcomePath.startsWith(rootPath) && (!testOutcomePath.equals(rootPath))) {
             return testOutcomePath.substring(rootPath.length() + 1);
         } else {
             return testOutcomePath;

--- a/serenity-core/src/main/java/net/thucydides/core/requirements/PackageAnnotationBasedTagProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/requirements/PackageAnnotationBasedTagProvider.java
@@ -328,7 +328,7 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
         public List<Requirement> in(Collection<Requirement> requirements) {
             List<Requirement> children = Lists.newArrayList();
             for (Requirement requirement : requirements) {
-                if (requirement.getParent() != null && requirement.getParent().equals(parent.getName())) {
+                if (StringUtils.isNotEmpty(requirement.getParent()) && requirement.getParent().equals(parent.getName())) {
                     children.add(requirement);
                 }
             }


### PR DESCRIPTION
#### Summary of this PR
Updated lines where "is empty" string condition used from value!=null to StringUtils.isNotEmpty(value)
#### Intended effect
If some property are not provided it means that they can be "" or null. So this improvenment will mark strings with value "" as empty
#### How should this be manually tested?
All should work as before 
#### Side effects
Warn of legacy properties  should disappear (if you don't use them) 
#### Documentation
N/A
#### Relevant tickets
#310
#### Screenshots (if appropriate)
N/A