### PR TITLE
Updated loader and reporter to load and generate testoutcomes concurrently with tests, updated gson core to 2.4

### DIFF
--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     compile project(':serenity-report-resources')
 
-    compile 'com.google.code.gson:gson:2.3.1'
+    compile 'com.google.code.gson:gson:2.4'
 
     compile "commons-codec:commons-codec:1.9"
     compile "commons-io:commons-io:2.4"

--- a/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestLoader.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestLoader.java
@@ -4,9 +4,17 @@ import com.google.common.base.Optional;
 import net.thucydides.core.model.TestOutcome;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 
 public interface AcceptanceTestLoader {
     Optional<TestOutcome> loadReportFrom(final File reportFile);
-    List<TestOutcome> loadReportsFrom(File outputDirectory);
+
+    List<TestOutcome> loadReportsFrom(final File outputDirectory);
+
+    Optional<TestOutcome> loadReportFrom(final Path reportFile);
+
+    List<TestOutcome> loadReportsFrom(final Path outputDirectory);
+
+    Optional<OutcomeFormat> getFormat();
 }

--- a/serenity-core/src/main/java/net/thucydides/core/reports/ReportLoadingFailedError.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/ReportLoadingFailedError.java
@@ -1,0 +1,13 @@
+package net.thucydides.core.reports;
+
+/**
+ * Report loading has failed for some reason.
+ */
+public class ReportLoadingFailedError extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ReportLoadingFailedError(final String message, final Throwable e) {
+        super(message, e);
+    }
+}

--- a/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/ReportService.java
@@ -56,10 +56,12 @@ public class ReportService {
      */
     public ReportService(final File outputDirectory, final Collection<AcceptanceTestReporter> subscribedReporters) {
         this.outputDirectory = outputDirectory;
+        if(!this.outputDirectory.exists()){
+            this.outputDirectory.mkdirs();
+        }
         getSubscribedReporters().addAll(subscribedReporters);
         jUnitXMLOutcomeReporter = new JUnitXMLOutcomeReporter(outputDirectory);
         this.executorService = Injectors.getInjector().getInstance(ExecutorServiceProvider.class).getExecutorService();
-
     }
 
     public void setOutputDirectory(File outputDirectory) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 
@@ -59,6 +60,7 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
                 ReportType.JSON);
     }
 
+    @Override
     public void setOutputDirectory(final File outputDirectory) {
         this.outputDirectory = outputDirectory;
     }
@@ -68,18 +70,30 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
         this.qualifier = qualifier;
     }
 
+    @Override
     public void setResourceDirectory(String resourceDirectoryPath) {
     }
 
+    @Override
+    public Optional<TestOutcome> loadReportFrom(final Path reportFile) {
+        return loadReportFrom(reportFile.toFile());
+    }
+
+    @Override
     public Optional<TestOutcome> loadReportFrom(final File reportFile) {
         try (BufferedReader in = new BufferedReader(new FileReader(reportFile))) {
             TestOutcome fromJson = jsonConverter.fromJson(in);
             return Optional.fromNullable(fromJson);
         } catch (Throwable e) {
-            LOGGER.warn("this file was not a valid JSON Serenity test report: " + reportFile.getName()
-                        + System.lineSeparator() + e.getMessage());
+            LOGGER.warn("This file was not a valid JSON Serenity test report: " + reportFile.getName()
+                    + System.lineSeparator() + e.getMessage());
             return Optional.absent();
         }
+    }
+
+    @Override
+    public List<TestOutcome> loadReportsFrom(final Path outputDirectory) {
+        return loadReportsFrom(outputDirectory.toFile());
     }
 
     @Override

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
@@ -26,6 +26,8 @@ public class JUnitXMLOutcomeReporter  {
 
     private final JUnitXMLConverter junitXMLConverter;
 
+    public final static String FILE_PREFIX = "SERENITY-JUNIT-";
+
     public JUnitXMLOutcomeReporter(File outputDirectory) {
         this.outputDirectory = outputDirectory;
         junitXMLConverter = new JUnitXMLConverter();
@@ -56,7 +58,7 @@ public class JUnitXMLOutcomeReporter  {
 
     private String reportFilenameFor(TestOutcome testOutcome) {
         ReportNamer reportNamer = ReportNamer.forReportType(ReportType.XML);
-        return "SERENITY-JUNIT-"  + reportNamer.getNormalizedTestNameFor(testOutcome);
+        return FILE_PREFIX  + reportNamer.getNormalizedTestNameFor(testOutcome);
     }
 
     private Map<String, List<TestOutcome>> groupByTestCase(TestOutcomes testOutcomes) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
 
@@ -33,6 +34,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
 
     private transient String qualifier;
 
+    @Override
     public void setQualifier(final String qualifier) {
         this.qualifier = qualifier;
     }
@@ -40,9 +42,11 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
     /**
      * We don't need any resources for XML reports.
      */
+    @Override
     public void setResourceDirectory(final String resourceDirectoryPath) {
     }
 
+    @Override
     public String getName() {
         return "xml";
     }
@@ -55,6 +59,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
     /**
      * Generate an XML report for a given test run.
      */
+    @Override
     public File generateReportFor(final TestOutcome testOutcome, final TestOutcomes allTestOutcomes) throws IOException {
         TestOutcome storedTestOutcome = testOutcome.withQualifier(qualifier);
         Preconditions.checkNotNull(outputDirectory);
@@ -85,6 +90,12 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
         return testOutcome.withQualifier(qualifier).getReportName(XML);
     }
 
+    @Override
+    public Optional<TestOutcome> loadReportFrom(final Path reportFile) {
+        return loadReportFrom(reportFile.toFile());
+    }
+
+    @Override
     public Optional<TestOutcome> loadReportFrom(final File reportFile) {
         try(
                 InputStream input = new FileInputStream(reportFile);
@@ -110,10 +121,17 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
         return outputDirectory;
     }
 
+    @Override
     public void setOutputDirectory(final File outputDirectory) {
         this.outputDirectory = outputDirectory;
     }
 
+    @Override
+    public List<TestOutcome> loadReportsFrom(final Path outputDirectory) {
+        return loadReportsFrom(outputDirectory.toFile());
+    }
+
+    @Override
     public List<TestOutcome> loadReportsFrom(File outputDirectory) {
         File[] reportFiles = getAllXMLFilesFrom(outputDirectory);
         List<TestOutcome> testOutcomes = Lists.newArrayList();

--- a/serenity-core/src/test/groovy/net/thucydides/core/reports/WhenProcessingTestOutcomes.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/reports/WhenProcessingTestOutcomes.groovy
@@ -38,7 +38,7 @@ class WhenProcessingTestOutcomes extends Specification {
         when:
             loader.loadFrom(new File("/does-not-exist"))
         then:
-            thrown IOException
+            thrown ReportLoadingFailedError
     }
 
     def "should list all the tag types for the test outcomes"() {

--- a/serenity-core/src/test/groovy/net/thucydides/core/reports/WhenWritingAndReadingTestOutcomes.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/reports/WhenWritingAndReadingTestOutcomes.groovy
@@ -1,0 +1,167 @@
+package net.thucydides.core.reports
+
+import net.thucydides.core.model.Story
+import net.thucydides.core.model.TestOutcome
+import net.thucydides.core.model.TestResult
+import net.thucydides.core.model.TestStep
+import net.thucydides.core.model.TestTag
+import net.thucydides.core.model.features.ApplicationFeature
+import net.thucydides.core.reports.json.JSONTestOutcomeReporter
+import net.thucydides.core.reports.xml.XMLTestOutcomeReporter
+import org.joda.time.DateTime
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import com.google.common.base.Optional
+
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.ThreadLocalRandom
+
+class WhenWritingAndReadingTestOutcomes extends Specification {
+
+    @Rule
+    final TemporaryFolder temporary = new TemporaryFolder()
+
+    def loader = new TestOutcomeLoader()
+
+    def "should be possible write and load reports using different formats"(
+        def OutcomeFormat format, def AcceptanceTestReporter reporter) {
+        given:
+            def Set<TestOutcome> outcomes = generate(100)
+            def directory = temporary.getRoot()
+            Collection<AcceptanceTestReporter> reporters = new LinkedList<>()
+            reporters.add(reporter)
+            def TestOutcomeLoader loader = new TestOutcomeLoader().forFormat(format);
+        when:
+            def ReportService service = new ReportService(directory, reporters)
+            service.generateReportsFor(new ArrayList<TestOutcome>(outcomes))
+            def Set<TestOutcome> result = loader.loadFrom(directory)
+            def notFound = {
+                outcomes.removeAll(result)
+                outcomes.size()
+            }
+            def int generated = outcomes.size()
+            def int read = result.size()
+        then:
+            generated == read
+            0 == notFound.call()
+        where:
+            format             | reporter
+            OutcomeFormat.XML  | new XMLTestOutcomeReporter()
+            OutcomeFormat.JSON | new JSONTestOutcomeReporter()
+
+    }
+
+    def "should be possible generate and load reports concurrently"(
+        def AcceptanceTestReporter reporter, def AcceptanceTestLoader loader) {
+        given:
+            def directory = temporary.getRoot()
+            def Set<TestOutcome> outcomes = generate(10)
+            def TestOutcomes testOutcomes = TestOutcomes.of(new ArrayList<TestOutcome>(outcomes))
+            reporter.setOutputDirectory(directory)
+            def executor = Executors.newFixedThreadPool(10);
+            def List<Future<File>> result = new ArrayList<>()
+        when:
+            100.times {
+                outcomes.each { outcome ->
+                    result.add(executor.submit(new Callable<File>() {
+                        @Override
+                        File call() throws Exception {
+                            reporter.generateReportFor(outcome, testOutcomes)
+                        }
+                    }))
+                }
+            }
+            def notFountOutcomes = {
+                result.findAll { future ->
+                    def File generated = future.get()
+                    Optional<TestOutcome> outcome = loader.loadReportFrom(generated)
+                    return !(outcome.isPresent() && outcomes.contains(outcome.get()))
+                }.size()
+            }
+        then:
+            reporter.getFormat() == loader.getFormat() && notFountOutcomes.call() == 0
+        where:
+            reporter                      | loader
+            new XMLTestOutcomeReporter()  | new XMLTestOutcomeReporter()
+            new JSONTestOutcomeReporter() | new JSONTestOutcomeReporter()
+    }
+
+
+    def "should be possible generate and load reports in series"(
+        def AcceptanceTestReporter reporter, def AcceptanceTestLoader loader) {
+        given:
+            def directory = temporary.getRoot()
+            def Set<TestOutcome> outcomes = generate(10)
+            def TestOutcomes testOutcomes = TestOutcomes.of(new ArrayList<TestOutcome>(outcomes))
+            reporter.setOutputDirectory(directory)
+            def List<Future<File>> result = new ArrayList<>()
+        when:
+            100.times {
+                outcomes.each { outcome ->
+                    reporter.generateReportFor(outcome, testOutcomes)
+                }
+            }
+            def notFountOutcomes = {
+                result.findAll { future ->
+                    def File generated = future.get()
+                    Optional<TestOutcome> outcome = loader.loadReportFrom(generated)
+                    return !(outcome.isPresent() && outcomes.contains(outcome.get()))
+                }.size()
+            }
+        then:
+            reporter.getFormat() == loader.getFormat() && notFountOutcomes.call() == 0
+        where:
+            reporter                      | loader
+            new XMLTestOutcomeReporter()  | new XMLTestOutcomeReporter()
+            new JSONTestOutcomeReporter() | new JSONTestOutcomeReporter()
+    }
+
+    def private static List<TestOutcome> generate(def int amount) {
+        List<TestOutcome> outcomes = new ArrayList<>(amount)
+        amount.times {
+            def method = word()
+            def ThreadLocalRandom random = ThreadLocalRandom.current()
+            def TestOutcome outcome = new TestOutcome(method)
+            outcome.setStartTime(DateTime.now())
+            outcome.setDuration(random.nextLong(10, 100))
+            if (random.nextBoolean()) {
+                outcome.asManualTest()
+            }
+            outcome.setTitle(word())
+
+            (amount + 1).times {
+                def TestStep step = new TestStep(DateTime.now(), word())
+                step.setDuration(random.nextLong(10, 100))
+                step.renumberFrom(it)
+                outcome.recordStep(step)
+            }
+
+            outcome.setUserStory(new Story(
+                word(),
+                word(),
+                word(),
+                word(),
+                new ApplicationFeature(word(), word())))
+            (amount + 1).times {
+                def TestTag tag = TestTag.withValue("${word()}:${word()}");
+                outcome.addTag(tag)
+            }
+            if (random.nextBoolean()) {
+                outcome.setAnnotatedResult(TestResult.FAILURE);
+                outcome.setAllStepsTo(TestResult.FAILURE)
+            } else {
+                outcome.setAnnotatedResult(TestResult.SUCCESS);
+                outcome.setAllStepsTo(TestResult.SUCCESS)
+            }
+            outcomes.add(outcome)
+        }
+        outcomes
+    }
+
+    def private static String word() {
+        return UUID.randomUUID().toString()
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
Updated loader and reporter to load and generate testoutcomes concurrently, add tests for checking if reports can be generated and loaded in series, updated gson core to 2.4.
#### Intended effect
Here is test that should be successful if loaders and reports can work concurrently, some bugs already fixed in gson lib so it was updated. Also loader now can be executed concurrently as well. 
#### How should this be manually tested?
Some test project with very fast tests should be created. After executing goals "test aggregate" report should contains all tests. 
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
serenity-bdd/serenity-jbehave/issues/45, #322 
#### Screenshots (if appropriate)
N/A