### PR TITLE
Updated report generation to use temp files.

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -61,7 +61,7 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
                     StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
             );
         }
-        return temporary;
+        return report;
     }
 
     public File getOutputDirectory() {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -50,12 +50,16 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
         String unique = UUID.randomUUID().toString();
         File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
         File report = new File(getOutputDirectory(), reportFilename);
+        report.createNewFile();
+
         LOGGER.debug("Generating JSON report for {} to file {} (using temp file {})", testOutcome.getTitle(), report.getAbsolutePath(), temporary.getAbsolutePath());
 
         try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(temporary))){
             jsonConverter.toJson(storedTestOutcome, outputStream);
             outputStream.flush();
-            Files.move(temporary.toPath(),report.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.move(temporary.toPath(), report.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+            );
         }
         return temporary;
     }

--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -14,9 +14,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 public class JSONTestOutcomeReporter implements AcceptanceTestReporter, AcceptanceTestLoader {
 
@@ -44,11 +47,17 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
         TestOutcome storedTestOutcome = testOutcome.withQualifier(qualifier);
         Preconditions.checkNotNull(outputDirectory);
         String reportFilename = reportFor(storedTestOutcome);
+        String unique = UUID.randomUUID().toString();
+        File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
         File report = new File(getOutputDirectory(), reportFilename);
-        try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(report))){
+        LOGGER.debug("Generating JSON report for {} to file {} (using temp file {})", testOutcome.getTitle(), report.getAbsolutePath(), temporary.getAbsolutePath());
+
+        try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(temporary))){
             jsonConverter.toJson(storedTestOutcome, outputStream);
+            outputStream.flush();
+            Files.move(temporary.toPath(),report.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
-        return report;
+        return temporary;
     }
 
     public File getOutputDirectory() {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
@@ -14,8 +14,11 @@ import org.slf4j.LoggerFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class JUnitXMLOutcomeReporter  {
 
@@ -45,9 +48,14 @@ public class JUnitXMLOutcomeReporter  {
             List<TestOutcome> testCaseOutcomes = testOutcomesGroupedByTestCase.get(testCase);
             String reportFilename = reportFilenameFor(testCaseOutcomes.get(0));
             File report = new File(getOutputDirectory(), reportFilename);
-            LOGGER.debug("GENERATING JUNIT REPORT " + reportFilename);
+            String unique = UUID.randomUUID().toString();
+            File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
+            LOGGER.debug("GENERATING JUNIT REPORT {} using temporary file {}", reportFilename, temporary);
+
             try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(report))){
                 junitXMLConverter.write(testCase, testCaseOutcomes, outputStream);
+                outputStream.flush();
+                Files.move(temporary.toPath(), report.toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (ParserConfigurationException e) {
                 throw new IOException(e);
             } catch (TransformerException e) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
@@ -52,7 +52,7 @@ public class JUnitXMLOutcomeReporter  {
             File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
             LOGGER.debug("GENERATING JUNIT REPORT {} using temporary file {}", reportFilename, temporary);
 
-            try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(report))){
+            try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(temporary))){
                 junitXMLConverter.write(testCase, testCaseOutcomes, outputStream);
                 outputStream.flush();
                 Files.move(temporary.toPath(), report.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
@@ -47,15 +47,18 @@ public class JUnitXMLOutcomeReporter  {
         for(String testCase : testOutcomesGroupedByTestCase.keySet()) {
             List<TestOutcome> testCaseOutcomes = testOutcomesGroupedByTestCase.get(testCase);
             String reportFilename = reportFilenameFor(testCaseOutcomes.get(0));
-            File report = new File(getOutputDirectory(), reportFilename);
             String unique = UUID.randomUUID().toString();
             File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
-            LOGGER.debug("GENERATING JUNIT REPORT {} using temporary file {}", reportFilename, temporary);
+            File report = new File(getOutputDirectory(), reportFilename);
+            report.createNewFile();
 
+            LOGGER.debug("GENERATING JUNIT REPORT {} using temporary file {}", reportFilename, temporary);
             try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(temporary))){
                 junitXMLConverter.write(testCase, testCaseOutcomes, outputStream);
                 outputStream.flush();
-                Files.move(temporary.toPath(), report.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                Files.move(temporary.toPath(), report.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+                );
             } catch (ParserConfigurationException e) {
                 throw new IOException(e);
             } catch (TransformerException e) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -75,6 +75,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
         String unique = UUID.randomUUID().toString();
         File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
         File report = new File(getOutputDirectory(), reportFilename);
+        report.createNewFile();
 
         LOGGER.debug("Generating XML report for {} to file {} (using temp file {})", testOutcome.getTitle(), report.getAbsolutePath(), temporary.getAbsolutePath());
 
@@ -83,7 +84,9 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
            OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
            xstream.toXML(storedTestOutcome, writer);
            writer.flush();
-            Files.move(temporary.toPath(), report.toPath(), StandardCopyOption.REPLACE_EXISTING);
+           Files.move(temporary.toPath(), report.toPath(),
+                   StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+           );
            LOGGER.debug("XML report generated ({} bytes) {}", report.getAbsolutePath(), report.length());
         }
         return report;

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -79,7 +79,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
         LOGGER.debug("Generating XML report for {} to file {} (using temp file {})", testOutcome.getTitle(), report.getAbsolutePath(), temporary.getAbsolutePath());
 
         try(
-           OutputStream outputStream = new FileOutputStream(report);
+           OutputStream outputStream = new FileOutputStream(temporary);
            OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
            xstream.toXML(storedTestOutcome, writer);
            writer.flush();

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -16,9 +16,12 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 import static net.thucydides.core.model.ReportType.XML;
 
@@ -69,14 +72,18 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
 
         String reportFilename = reportFor(storedTestOutcome);
 
+        String unique = UUID.randomUUID().toString();
+        File temporary = new File(getOutputDirectory(), reportFilename.concat(unique));
         File report = new File(getOutputDirectory(), reportFilename);
 
-        LOGGER.debug("Generating XML report for {} to file {}", testOutcome.getTitle(), report.getAbsolutePath());
+        LOGGER.debug("Generating XML report for {} to file {} (using temp file {})", testOutcome.getTitle(), report.getAbsolutePath(), temporary.getAbsolutePath());
 
         try(
            OutputStream outputStream = new FileOutputStream(report);
            OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
            xstream.toXML(storedTestOutcome, writer);
+           writer.flush();
+            Files.move(temporary.toPath(), report.toPath(), StandardCopyOption.REPLACE_EXISTING);
            LOGGER.debug("XML report generated ({} bytes) {}", report.getAbsolutePath(), report.length());
         }
         return report;


### PR DESCRIPTION
#### Summary of this PR
Updated report generation to use temp files.
#### Intended effect
It seems that reporters in different runtime can rewrite same file, as result some artefacts can appear in the end or in the beginning for file. To avoid such behaving temporary files are used during generation of file, and after that report file renamed according expectation. 
#### How should this be manually tested?
Some project with a lot of tests with fast tests should be created, and tests should be executed in parallel several times. All tests should be included in aggregated report every time. 
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#322, serenity-bdd/serenity-jbehave/issues/45
#### Screenshots (if appropriate)
N/A