### PR TITLE
Included exception/assertion message into serenity report

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/model/stacktrace/FailureCause.java
+++ b/serenity-core/src/main/java/net/thucydides/core/model/stacktrace/FailureCause.java
@@ -142,9 +142,7 @@ public class FailureCause {
 
     private <T extends Throwable> T buildThrowable(String testFailureMessage, Class failureClass) throws Exception {
 
-        if (defaultConstructorFor(failureClass).isPresent()) {
-            return (T) defaultConstructorFor(failureClass).get().newInstance();
-        } else if (stringConstructorFor(failureClass).isPresent()) {
+        if (stringConstructorFor(failureClass).isPresent()) {
             return (T) stringConstructorFor(failureClass).get().newInstance(testFailureMessage);
         } else if (stringThrowableConstructorFor(failureClass).isPresent()) {
             return (T) stringThrowableConstructorFor(failureClass).get().newInstance(testFailureMessage, null);
@@ -152,6 +150,8 @@ public class FailureCause {
             return (T) throwableConstructorFor(failureClass).get().newInstance(new AssertionError(testFailureMessage));
         } else if (AssertionError.class.isAssignableFrom(failureClass)) {
             return (T) new AssertionError(testFailureMessage);
+        } else if (defaultConstructorFor(failureClass).isPresent()) {
+            return (T) defaultConstructorFor(failureClass).get().newInstance();
         }
         return null;
     }

--- a/serenity-core/src/test/java/net/thucydides/core/model/stacktrace/FailureCauseNoMsgException.java
+++ b/serenity-core/src/test/java/net/thucydides/core/model/stacktrace/FailureCauseNoMsgException.java
@@ -1,0 +1,15 @@
+package net.thucydides.core.model.stacktrace;
+
+/**
+ * Support Class for FailureCauseTest.
+ * Could not be inner class as then the test would turn into an UnrecognisedException
+ * 
+ * @author Robert Zimmermann
+ */
+public class FailureCauseNoMsgException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public FailureCauseNoMsgException() {
+        super();
+    }
+}

--- a/serenity-core/src/test/java/net/thucydides/core/model/stacktrace/FailureCauseTest.java
+++ b/serenity-core/src/test/java/net/thucydides/core/model/stacktrace/FailureCauseTest.java
@@ -1,0 +1,52 @@
+package net.thucydides.core.model.stacktrace;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import net.serenitybdd.core.exceptions.UnrecognisedException;
+import net.thucydides.core.model.stacktrace.FailureCause;
+
+/**
+ * @author Robert Zimmermann
+ */
+public class FailureCauseTest {
+    @Test
+    public void should_include_original_exception_message() {
+        Throwable testExc = new IllegalStateException("Important Message");
+        defaultExpectations(testExc, IllegalStateException.class, "Important Message");
+    }
+
+    @Test
+    public void should_include_original_exception_message_msg_null() {
+        Throwable testExc = new IllegalStateException();
+        defaultExpectations(testExc, IllegalStateException.class, null);
+    }
+
+    @Test
+    public void should_still_support_no_msg_exception_types() {
+        Throwable testExc = new FailureCauseNoMsgException();
+        defaultExpectations(testExc, FailureCauseNoMsgException.class, null);
+    }
+
+    @Test
+    public void should_report_unresolvable_exception_types() {
+        Throwable testExc = new InnerClassException();
+        defaultExpectations(testExc, UnrecognisedException.class, null);
+    }
+
+    private void defaultExpectations(Throwable testExc, Class<?> expectedInstance, String expectedMessage) {
+        FailureCause classUnderTest = new FailureCause(testExc);
+
+        Throwable restoredException = classUnderTest.toException();
+        Assertions.assertThat(restoredException).isExactlyInstanceOf(expectedInstance);
+        Assertions.assertThat(restoredException).hasMessage(expectedMessage);
+    }
+
+    public class InnerClassException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public InnerClassException() {
+            super();
+        }
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
Updates report to include exception/assertion message
#### Intended effect
If assertion fire with some message - it should appear in serenity report
#### How should this be manually tested?
Using serenity bdd some test with 
```
org.junit.Assert.assertTrue("this message should be visible", false);
```
should be executed - in reports such message must be visible
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#321 
#### Screenshots (if appropriate)
N/A
