### PR TITLE
Updated story/load of outcomes - serenity.report.encoding property will be used with UTF-8 as default 

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -94,7 +95,7 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
 
     @Override
     public Optional<TestOutcome> loadReportFrom(final File reportFile) {
-        try (BufferedReader in = new BufferedReader(new FileReader(reportFile))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(reportFile), StandardCharsets.UTF_8))) {
             TestOutcome fromJson = jsonConverter.fromJson(in);
             return Optional.fromNullable(fromJson);
         } catch (Throwable e) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -3,6 +3,7 @@ package net.thucydides.core.reports.json;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.model.ReportType;
 import net.thucydides.core.model.TestOutcome;
@@ -10,6 +11,8 @@ import net.thucydides.core.reports.AcceptanceTestLoader;
 import net.thucydides.core.reports.AcceptanceTestReporter;
 import net.thucydides.core.reports.OutcomeFormat;
 import net.thucydides.core.reports.TestOutcomes;
+import net.thucydides.core.util.EnvironmentVariables;
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +34,10 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
 
     private transient String qualifier;
 
+    private final EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+
+    private final String encoding;
+
     @Override
     public String getName() {
         return "json";
@@ -39,6 +46,7 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
     JSONConverter jsonConverter;
 
     public JSONTestOutcomeReporter() {
+        encoding = ThucydidesSystemProperty.THUCYDIDES_REPORT_ENCODING.from(environmentVariables, StandardCharsets.UTF_8.name());
         jsonConverter = Injectors.getInjector().getInstance(JSONConverter.class);
     }
 
@@ -95,7 +103,7 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
 
     @Override
     public Optional<TestOutcome> loadReportFrom(final File reportFile) {
-        try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(reportFile), StandardCharsets.UTF_8))) {
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(new FileInputStream(reportFile), encoding))) {
             TestOutcome fromJson = jsonConverter.fromJson(in);
             return Optional.fromNullable(fromJson);
         } catch (Throwable e) {

--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/gson/GsonJSONConverter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/gson/GsonJSONConverter.java
@@ -29,9 +29,12 @@ public class GsonJSONConverter implements JSONConverter {
         return gson;
     }
 
+    private final String encoding;
+
     @Inject
     public GsonJSONConverter(EnvironmentVariables environmentVariables) {
         this.environmentVariables = environmentVariables;
+        encoding = ThucydidesSystemProperty.THUCYDIDES_REPORT_ENCODING.from(environmentVariables, StandardCharsets.UTF_8.name());
         GsonBuilder gsonBuilder = new GsonBuilder()
                                             .registerTypeAdapterFactory(OptionalTypeAdapter.FACTORY)
                                             .registerTypeHierarchyAdapter(Collection.class, new CollectionAdapter())
@@ -43,7 +46,7 @@ public class GsonJSONConverter implements JSONConverter {
 
     @Override
     public TestOutcome fromJson(InputStream inputStream) throws IOException {
-        return fromJson(new InputStreamReader(inputStream, Charsets.UTF_8));
+        return fromJson(new InputStreamReader(inputStream, encoding));
     }
 
     @Override
@@ -57,10 +60,11 @@ public class GsonJSONConverter implements JSONConverter {
         return isNotEmpty(testOutcome.getName());
     }
 
+
     @Override
     public void toJson(TestOutcome testOutcome, OutputStream outputStream) throws IOException {
         testOutcome.calculateDynamicFieldValues();
-        try(Writer out = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+        try(Writer out = new OutputStreamWriter(outputStream, encoding)) {
             gson.toJson(testOutcome, out);
         }
     }

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -5,11 +5,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.mapper.CannotResolveClassException;
+import net.thucydides.core.ThucydidesSystemProperty;
+import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.reports.AcceptanceTestLoader;
 import net.thucydides.core.reports.AcceptanceTestReporter;
 import net.thucydides.core.reports.OutcomeFormat;
 import net.thucydides.core.reports.TestOutcomes;
+import net.thucydides.core.util.EnvironmentVariables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +39,14 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
     private static final Logger LOGGER = LoggerFactory.getLogger(XMLTestOutcomeReporter.class);
 
     private transient String qualifier;
+
+    private final EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+
+    private final String encoding;
+
+    public XMLTestOutcomeReporter() {
+        encoding = ThucydidesSystemProperty.THUCYDIDES_REPORT_ENCODING.from(environmentVariables, StandardCharsets.UTF_8.name());
+    }
 
     @Override
     public void setQualifier(final String qualifier) {
@@ -81,7 +92,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
 
         try(
            OutputStream outputStream = new FileOutputStream(temporary);
-           OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+           OutputStreamWriter writer = new OutputStreamWriter(outputStream, encoding)) {
            xstream.toXML(storedTestOutcome, writer);
            writer.flush();
            Files.move(temporary.toPath(), report.toPath(),
@@ -109,7 +120,7 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
     public Optional<TestOutcome> loadReportFrom(final File reportFile) {
         try(
                 InputStream input = new FileInputStream(reportFile);
-                InputStreamReader reader = new InputStreamReader(input, StandardCharsets.UTF_8);
+                InputStreamReader reader = new InputStreamReader(input, encoding);
         ) {
             XStream xstream = new XStream();
             xstream.alias("acceptance-test-run", TestOutcome.class);


### PR DESCRIPTION
 triggered by https://github.com/serenity-bdd/serenity-cucumber/issues/41