### PR TITLE
appium.app is no longer required if appium.browserName is supplied

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
@@ -72,13 +72,13 @@ public class AppiumConfiguration {
             String simplifiedKey = key.replace("appium.", "");
             appiumProperties.setProperty(simplifiedKey, value.trim());
         }
-        ensureAppPathDefinedIn(appiumProperties);
+        ensureAppOrBrowserPathDefinedIn(appiumProperties);
         return appiumProperties;
     }
 
-    private void ensureAppPathDefinedIn(Properties appiumProperties) {
-        if (!appiumProperties.containsKey("app")) {
-            throw new ThucydidesConfigurationException("The path to the app needs to be provided in the appium.app property.");
+    private void ensureAppOrBrowserPathDefinedIn(Properties appiumProperties) {
+        if (!appiumProperties.containsKey("app") && !appiumProperties.containsKey("browserName")) {
+            throw new ThucydidesConfigurationException("The browser under test or path to the app needs to be provided in the appium.app or appium.browserName property.");
         }
     }
 

--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
@@ -101,7 +101,7 @@ class WhenConfiguringAnAppiumDriver extends Specification {
         appiumConfiguration.capabilities
         then:
         ThucydidesConfigurationException invalidConfiguration = thrown()
-        invalidConfiguration.message.contains("The path to the app needs to be provided in the appium.app property.")
+        invalidConfiguration.message.contains("The browser under test or path to the app needs to be provided in the appium.app or appium.browserName property.")
     }
 
 }


### PR DESCRIPTION
Appium 1.5 was released last week, and the initialization code has been refactored.  The way Serenity setups up its own Appium driver requires both browsername and app to be supplied.  This is no longer compatible with Appium.