### PR TITLE
Updated processing of names to keep abbreviations of JSON CSV XML

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/util/NameConverter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/NameConverter.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 public final class NameConverter {
 
     private static final String INDEXED_METHOD_NAME = ".*\\[\\d+]";
+    private static final String[] abbreviations = {"CSV", "XML", "JSON"};
 
     private NameConverter() {
     }
@@ -35,8 +36,17 @@ public final class NameConverter {
         } else {
             String noUnderscores = name.replaceAll("_", " ");
             String splitCamelCase = splitCamelCase(noUnderscores);
-            return StringUtils.capitalize(splitCamelCase);
+            String capitalized = StringUtils.capitalize(splitCamelCase);
+            return restoreAbbreviations(capitalized);
         }
+    }
+
+    private static String restoreAbbreviations(final String sentence){
+        String processing = sentence;
+        for(String abbreviation: abbreviations){
+            processing = processing.replaceAll(StringUtils.capitalize(abbreviation), abbreviation);
+        }
+        return processing;
     }
 
     private static String humanizeNameWithParameters(final String name) {

--- a/serenity-core/src/test/java/net/thucydides/core/util/WhenMakingTestNamesMoreReadable.java
+++ b/serenity-core/src/test/java/net/thucydides/core/util/WhenMakingTestNamesMoreReadable.java
@@ -7,12 +7,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 public class WhenMakingTestNamesMoreReadable {
-    
+
     @Test
     public void null_should_be_converted_to_an_empty_string() {
         assertThat(NameConverter.humanize(null), is(""));
     }
-    
+
     @Test
     public void an_empty_string_should_be_converted_to_an_empty_string() {
         assertThat(NameConverter.humanize(""), is(""));
@@ -94,5 +94,19 @@ public class WhenMakingTestNamesMoreReadable {
         assertThat(NameConverter.withNoArguments("a_test_method[0]"), is("a_test_method"));
     }
 
+    @Test
+    public void humanized_camelCase_methods_can_contains_CSV() {
+        assertThat(NameConverter.humanize("aTestMethodForCSVFormat"), is("A test method for CSV format"));
+    }
+
+    @Test
+    public void humanized_camelCase_methods_can_contains_JSON() {
+        assertThat(NameConverter.humanize("aTestMethodForJSONFormat"), is("A test method for JSON format"));
+    }
+
+    @Test
+    public void humanized_camelCase_methods_can_contains_XML() {
+        assertThat(NameConverter.humanize("aTestMethodForXMLFormat"), is("A test method for XML format"));
+    }
 }
 


### PR DESCRIPTION
#### Summary of this PR
Updated name processing of test
#### Intended effect
If mothod contains CSV JSON XML this abbreviations will not be changed
`TestCaseForCSVFormat` will be transformed to `Test case for CSV format`
#### How should this be manually tested?
Some test class or test method should be created with CSV or JSON or XML in name and executed. Also aggregation report should be created. 
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#215 
#### Screenshots (if appropriate)
![csv](https://cloud.githubusercontent.com/assets/1667699/13464665/e710843a-e09a-11e5-8f22-5d667351537c.png)
