### PR TITLE
Updated moving files. Now tmp files of reports will be moved only after stream will be closed

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/json/JSONTestOutcomeReporter.java
@@ -57,10 +57,10 @@ public class JSONTestOutcomeReporter implements AcceptanceTestReporter, Acceptan
         try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(temporary))){
             jsonConverter.toJson(storedTestOutcome, outputStream);
             outputStream.flush();
-            Files.move(temporary.toPath(), report.toPath(),
-                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
-            );
         }
+        Files.move(temporary.toPath(), report.toPath(),
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+        );
         return report;
     }
 

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLOutcomeReporter.java
@@ -56,14 +56,14 @@ public class JUnitXMLOutcomeReporter  {
             try(OutputStream outputStream = new BufferedOutputStream(new FileOutputStream(temporary))){
                 junitXMLConverter.write(testCase, testCaseOutcomes, outputStream);
                 outputStream.flush();
-                Files.move(temporary.toPath(), report.toPath(),
-                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
-                );
             } catch (ParserConfigurationException e) {
                 throw new IOException(e);
             } catch (TransformerException e) {
                 throw new IOException(e);
             }
+            Files.move(temporary.toPath(), report.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+            );
         }
     }
 

--- a/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/xml/XMLTestOutcomeReporter.java
@@ -84,11 +84,11 @@ public class XMLTestOutcomeReporter implements AcceptanceTestReporter, Acceptanc
            OutputStreamWriter writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
            xstream.toXML(storedTestOutcome, writer);
            writer.flush();
-           Files.move(temporary.toPath(), report.toPath(),
-                   StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
-           );
            LOGGER.debug("XML report generated ({} bytes) {}", report.getAbsolutePath(), report.length());
         }
+        Files.move(temporary.toPath(), report.toPath(),
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+        );
         return report;
     }
 


### PR DESCRIPTION
#### Summary of this PR
Updated moving files. 
#### Intended effect
Processing of tmp files for reports should work properly on windows
#### How should this be manually tested?
Simple build should be run on Windows
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#334
#### Screenshots (if appropriate)
N/A