### PR TITLE
Updated processing of @Qualifier tag in junit tests with data tables. Now it is possible add short description to steps based on parameters value

### DIFF
--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/QualifiedTestsRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/QualifiedTestsRunner.java
@@ -1,0 +1,121 @@
+package net.serenitybdd.junit.runners;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import net.thucydides.core.batches.BatchManager;
+import net.thucydides.core.model.DataTable;
+import net.thucydides.core.model.DataTableRow;
+import net.thucydides.core.model.TestOutcome;
+import net.thucydides.core.pages.Pages;
+import net.thucydides.core.webdriver.Configuration;
+import net.thucydides.core.webdriver.WebDriverFactory;
+import net.thucydides.core.webdriver.WebdriverManager;
+import net.thucydides.junit.listeners.JUnitStepListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+import java.util.List;
+
+/**
+ * User: YamStranger
+ * Date: 3/9/16
+ * Time: 4:28 PM
+ */
+abstract class QualifiedTestsRunner extends SerenityRunner {
+    private String qualifier;
+    private Object test;
+
+    public QualifiedTestsRunner(Class<?> klass, String qualifier, Object test) throws InitializationError {
+        super(klass);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, Module module, String qualifier, Object test) throws InitializationError {
+        super(klass, module);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, Injector injector, String qualifier, Object test) throws InitializationError {
+        super(klass, injector);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, WebDriverFactory webDriverFactory, String qualifier, Object test) throws InitializationError {
+        super(klass, webDriverFactory);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, WebDriverFactory webDriverFactory, Configuration configuration, String qualifier, Object test) throws InitializationError {
+        super(klass, webDriverFactory, configuration);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, WebDriverFactory webDriverFactory, Configuration configuration, BatchManager batchManager, String qualifier, Object test) throws InitializationError {
+        super(klass, webDriverFactory, configuration, batchManager);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, BatchManager batchManager, String qualifier, Object test) throws InitializationError {
+        super(klass, batchManager);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(Class<?> klass, WebdriverManager webDriverManager, Configuration configuration, BatchManager batchManager, String qualifier, Object test) throws InitializationError {
+        super(klass, webDriverManager, configuration, batchManager);
+        this.qualifier = qualifier;
+        this.test = test;
+    }
+
+    public QualifiedTestsRunner(final Class<?> type,
+                         final Configuration configuration,
+                         final WebDriverFactory webDriverFactory,
+                         final BatchManager batchManager) throws InitializationError {
+        super(type, webDriverFactory, configuration, batchManager);
+    }
+
+    @Override
+    public final Object createTest() throws Exception {
+        this.test = initializeTest();
+        return this.test;
+    }
+
+    abstract protected Object initializeTest() throws Exception;
+
+    @Override
+    public final void useQualifier(final String qualifier) {
+        this.qualifier = qualifier;
+        super.useQualifier(qualifier);
+    }
+
+    @Override
+    public final List<TestOutcome> getTestOutcomes() {
+        return enhance(qualified(super.getTestOutcomes()));
+    }
+
+    public List<TestOutcome> enhance(List<TestOutcome> outcomes) {
+        return outcomes;
+    }
+
+    private List<TestOutcome> qualified(List<TestOutcome> testOutcomes) {
+        List<TestOutcome> qualifiedOutcomes = Lists.newArrayList();
+
+        if (this.test != null) {
+            useQualifier(QualifierFinder.forTestCase(test).getQualifier());
+        }
+
+        for (TestOutcome outcome : testOutcomes) {
+            qualifiedOutcomes.add(outcome.withQualifier(qualifier));
+        }
+        return qualifiedOutcomes;
+    }
+}

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/TestClassRunnerForInstanciatedTestCase.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/TestClassRunnerForInstanciatedTestCase.java
@@ -11,11 +11,10 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 
-class TestClassRunnerForInstanciatedTestCase extends SerenityRunner {
+class TestClassRunnerForInstanciatedTestCase extends QualifiedTestsRunner {
     private final int parameterSetNumber;
     private final Object instanciatedTest;
     private final DataTable parametersTable;
-
 
     TestClassRunnerForInstanciatedTestCase(final Object instanciatedTest,
                                            Configuration configuration,
@@ -23,7 +22,7 @@ class TestClassRunnerForInstanciatedTestCase extends SerenityRunner {
                                            final BatchManager batchManager,
                                            final DataTable parametersTable,
                                            final int parameterSetNumber) throws InitializationError {
-        super(instanciatedTest.getClass(), webDriverFactory, configuration, batchManager);
+        super(instanciatedTest.getClass(), configuration, webDriverFactory, batchManager);
         this.instanciatedTest = instanciatedTest;
         this.parameterSetNumber = parameterSetNumber;
         this.parametersTable = parametersTable;
@@ -41,9 +40,10 @@ class TestClassRunnerForInstanciatedTestCase extends SerenityRunner {
     }
 
     @Override
-    public Object createTest() throws Exception {
+    protected Object initializeTest() throws Exception {
         return instanciatedTest;
     }
+
 
     @Override
     protected String getName() {
@@ -64,6 +64,4 @@ class TestClassRunnerForInstanciatedTestCase extends SerenityRunner {
     protected void generateReports() {
         //do not generate reports at example level
     }
-
-
 }

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/TestClassRunnerForParameters.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/TestClassRunnerForParameters.java
@@ -1,10 +1,8 @@
 package net.serenitybdd.junit.runners;
 
-import com.google.common.collect.Lists;
 import net.thucydides.core.batches.BatchManager;
 import net.thucydides.core.model.DataTable;
 import net.thucydides.core.model.DataTableRow;
-import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.pages.Pages;
 import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.WebDriverFactory;
@@ -16,10 +14,9 @@ import org.junit.runners.model.Statement;
 
 import java.util.List;
 
-class TestClassRunnerForParameters extends SerenityRunner {
+class TestClassRunnerForParameters extends QualifiedTestsRunner {
     private final int parameterSetNumber;
     private final DataTable parametersTable;
-    private String qualifier;
 
     TestClassRunnerForParameters(final Class<?> type,
                                  final Configuration configuration,
@@ -27,7 +24,7 @@ class TestClassRunnerForParameters extends SerenityRunner {
                                  final BatchManager batchManager,
                                  final DataTable parametersTable,
                                  final int i) throws InitializationError {
-        super(type, webDriverFactory, configuration, batchManager);
+        super(type, configuration, webDriverFactory, batchManager);
         this.parametersTable = parametersTable;
         parameterSetNumber = i;
     }
@@ -54,7 +51,7 @@ class TestClassRunnerForParameters extends SerenityRunner {
     }
 
     @Override
-    public Object createTest() throws Exception {
+    protected Object initializeTest() throws Exception {
         return getTestClass().getOnlyConstructor().newInstance(computeParams());
     }
 
@@ -96,25 +93,4 @@ class TestClassRunnerForParameters extends SerenityRunner {
     protected void generateReports() {
         //do not generate reports at example level
     }
-
-    @Override
-    public void useQualifier(final String qualifier) {
-        this.qualifier = qualifier;
-        super.useQualifier(qualifier);
-    }
-
-    @Override
-    public List<TestOutcome> getTestOutcomes() {
-        return qualified(super.getTestOutcomes());
-    }
-
-    private List<TestOutcome> qualified(List<TestOutcome> testOutcomes) {
-        List<TestOutcome> qualifiedOutcomes = Lists.newArrayList();
-        for (TestOutcome outcome : testOutcomes) {
-            qualifiedOutcomes.add(outcome.withQualifier(qualifier));
-        }
-        return qualifiedOutcomes;
-    }
-
-
 }

--- a/serenity-junit/src/test/groovy/net/serenitybdd/junit/finder/WhenRunningADataDrivenTestScenarioWithQualifier.groovy
+++ b/serenity-junit/src/test/groovy/net/serenitybdd/junit/finder/WhenRunningADataDrivenTestScenarioWithQualifier.groovy
@@ -1,0 +1,86 @@
+package net.serenitybdd.junit.finder
+
+import net.serenitybdd.junit.runners.ParameterizedTestsOutcomeAggregator
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner
+import net.thucydides.core.ThucydidesSystemProperty
+import net.thucydides.core.batches.BatchManager
+import net.thucydides.core.batches.BatchManagerProvider
+import net.thucydides.core.model.TestOutcome
+import net.thucydides.core.util.MockEnvironmentVariables
+import net.thucydides.core.webdriver.Configuration
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration
+import net.thucydides.core.webdriver.WebDriverFactory
+import net.thucydides.junit.rules.QuietThucydidesLoggingRule
+import net.thucydides.junit.rules.SaveWebdriverSystemPropertiesRule
+import net.thucydides.junit.sampletests.thucydidestests.SampleDataDrivenTestCase
+import net.thucydides.junit.sampletests.thucydidestests.SampleNonSerenityTestCase
+import net.thucydides.junit.sampletests.thucydidestests.SampleTestCase
+import net.thucydides.samples.SampleDataDrivenScenarioWithQualifier
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.notification.RunNotifier
+import spock.lang.Specification
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.is
+
+class WhenRunningADataDrivenTestScenarioWithQualifier extends Specification {
+
+    @Rule
+    def TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Rule
+    def SaveWebdriverSystemPropertiesRule saveWebdriverSystemPropertiesRule = new SaveWebdriverSystemPropertiesRule();
+
+    @Rule
+    def QuietThucydidesLoggingRule quietThucydidesLoggingRule = new QuietThucydidesLoggingRule();
+
+    def MockEnvironmentVariables environmentVariables;
+
+    def Configuration configuration;
+
+    def setup() {
+        environmentVariables = new MockEnvironmentVariables();
+        environmentVariables.setProperty(MAX_RETRIES, "1");
+        environmentVariables.setProperty(JUNIT_RETRY_TESTS, "true");
+        configuration = new SystemPropertiesConfiguration(environmentVariables);
+    }
+
+    def "when test contains test data"() {
+        given:
+            File outputDirectory = tempFolder.newFolder("serenitybdd");
+            environmentVariables.setProperty(ThucydidesSystemProperty.THUCYDIDES_OUTPUT_DIRECTORY.getPropertyName(),
+                outputDirectory.getAbsolutePath());
+
+            SerenityParameterizedRunner runner = getStubbedTestRunnerUsing(SampleDataDrivenScenarioWithQualifier.class);
+        when:
+            runner.run(new RunNotifier());
+            List<TestOutcome> outcomes = ParameterizedTestsOutcomeAggregator.from(runner).aggregateTestOutcomesByTestMethods();
+        then:
+            outcomes.size() == 2
+            def happyDayOutcomes = outcomes.get(0);
+            def happyDaySteps = happyDayOutcomes.getTestSteps()
+            happyDaySteps.size() == 12;
+        and:
+            happyDayOutcomes.getTitle().matches("Happy day scenario")
+            happyDaySteps.each { step ->
+                assert step.getDescription().matches("Happy day scenario for [a-zA-Z]{1} and \\d{1,2}")
+            }
+    }
+
+
+    def private SerenityParameterizedRunner getStubbedTestRunnerUsing(Class<?> testClass) throws Throwable {
+        Configuration configuration = new SystemPropertiesConfiguration(environmentVariables);
+        WebDriverFactory factory = new WebDriverFactory(environmentVariables);
+        BatchManager batchManager = new BatchManagerProvider(configuration).get();
+        return new SerenityParameterizedRunner(testClass, configuration, factory, batchManager) {
+            @Override
+            public void generateReports() {
+                //do nothing
+            }
+        };
+    }
+}

--- a/serenity-junit/src/test/java/net/thucydides/samples/SampleDataDrivenScenarioWithQualifier.java
+++ b/serenity-junit/src/test/java/net/thucydides/samples/SampleDataDrivenScenarioWithQualifier.java
@@ -1,0 +1,67 @@
+package net.thucydides.samples;
+
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.junit.annotations.Qualifier;
+import net.thucydides.junit.annotations.TestData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(SerenityParameterizedRunner.class)
+public class SampleDataDrivenScenarioWithQualifier {
+
+
+    @TestData
+    public static Collection testData() {
+            return Arrays.asList(new Object[][]{
+                    {"a", 1},
+                    {"B", 2},
+                    {"c", 3},
+                    {"D", 4},
+                    {"e", 5},
+                    {"F", 6},
+                    {"g", 7},
+                    {"h", 8},
+                    {"i", 9},
+                    {"j", 10},
+                    {"k", 11},
+                    {"l", 12},
+            });
+        }
+    private String option1;
+    private Integer option2;
+
+    public SampleDataDrivenScenarioWithQualifier(String option1, Integer option2) {
+        this.option1 = option1;
+        this.option2 = option2;
+    }
+
+    @Qualifier
+    public String description() {
+        return "for " + option1+" and " + option2;
+    }
+
+    @Steps
+    public SampleScenarioSteps steps;
+
+    @Test
+    public void happy_day_scenario() {
+        steps.stepWithParameters(option1, option2);
+    }
+
+    @Test
+    public void another_happy_day_scenario() {
+        steps.stepWithParameters(option1,option2);
+    }
+
+    public String getOption1() {
+        return this.option1;
+    }
+
+    public Integer getOption2() {
+        return this.option2;
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
Updated processing of @Qualifier tag in junit tests with data tables. Now it is possible add short description to steps based on parameters value
#### Intended effect
public method with annotation @Qualifier will be used to determine correct step name for test in aggregation report. 
#### How should this be manually tested?
You can use such test class: 
```
@RunWith(SerenityParameterizedRunner.class)
public class SampleDataDrivenScenarioWithQualifier {


    @TestData
    public static Collection testData() {
            return Arrays.asList(new Object[][]{
                    {"a", 1},
                    {"B", 2},
                    {"c", 3},
                    {"D", 4},
                    {"e", 5},
                    {"F", 6},
                    {"g", 7},
                    {"h", 8},
                    {"i", 9},
                    {"j", 10},
                    {"k", 11},
                    {"l", 12},
            });
        }
    private String option1;
    private Integer option2;

    public SampleDataDrivenScenarioWithQualifier(String option1, Integer option2) {
        this.option1 = option1;
        this.option2 = option2;
    }

    @Qualifier
    public String description() {
        return " for " + option1 +" and "+ option2;
    }

    @Steps
    public SampleScenarioSteps steps;

    @Test
    public void happy_day_scenario() {
        steps.stepWithParameters(option1, option2);
    }

    @Test
    public void another_happy_day_scenario() {
        steps.stepWithParameters(option1,option2);
    }

    public String getOption1() {
        return this.option1;
    }

    public Integer getOption2() {
        return this.option2;
    }
}

```
#### Side effects
Does the pull request contain any side effects? 
This should list non-obvious things that have changed in the request.
#### Documentation
If the pull request is user facing, how is it documented?
Are there examples of how to use the new behavior that users need to know about?
#### Relevant tickets
#338 
#### Screenshots (if appropriate)
Before fix: 
![before](https://cloud.githubusercontent.com/assets/1667699/13639488/a62ac424-e619-11e5-8293-6d60fc502ed3.png)

After fix: 
![after](https://cloud.githubusercontent.com/assets/1667699/13639708/a3387544-e61a-11e5-9487-5ae98d0806f1.png)
