### PR TITLE
Updated scenario data driven steps processing for report - now report will contains steps as for first scenario

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/model/TestOutcome.java
+++ b/serenity-core/src/main/java/net/thucydides/core/model/TestOutcome.java
@@ -1959,7 +1959,7 @@ public class TestOutcome {
         for (TestStep step : getStepChildren()) {
             sampleScenario.append(getMethodNameWithoutParameters(step.getDescription())).append("\n");
         }
-        return sampleScenario.substring(0, sampleScenario.length() - 1);
+        return sampleScenario.length() > 1 ? sampleScenario.substring(0, sampleScenario.length() - 1) : "";
     }
 
 

--- a/serenity-junit/src/test/groovy/net/serenitybdd/junit/finder/WhenRunningADataDrivenTestScenarioWithGivenWhenThenSteps.groovy
+++ b/serenity-junit/src/test/groovy/net/serenitybdd/junit/finder/WhenRunningADataDrivenTestScenarioWithGivenWhenThenSteps.groovy
@@ -1,0 +1,77 @@
+package net.serenitybdd.junit.finder
+
+import net.serenitybdd.junit.runners.ParameterizedTestsOutcomeAggregator
+import net.serenitybdd.junit.runners.SerenityParameterizedRunner
+import net.thucydides.core.ThucydidesSystemProperty
+import net.thucydides.core.batches.BatchManagerProvider
+import net.thucydides.core.util.MockEnvironmentVariables
+import net.thucydides.core.webdriver.Configuration
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration
+import net.thucydides.core.webdriver.WebDriverFactory
+import net.thucydides.junit.rules.QuietThucydidesLoggingRule
+import net.thucydides.junit.rules.SaveWebdriverSystemPropertiesRule
+import net.thucydides.samples.SampleDataDrivenScenarioWithQualifier
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.notification.RunNotifier
+import spock.lang.Specification
+
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.JUNIT_RETRY_TESTS
+import static net.thucydides.core.webdriver.SystemPropertiesConfiguration.MAX_RETRIES
+
+class WhenRunningADataDrivenTestScenarioWithGivenWhenThenSteps extends Specification {
+
+    @Rule
+    def TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Rule
+    def SaveWebdriverSystemPropertiesRule saveWebdriverSystemPropertiesRule = new SaveWebdriverSystemPropertiesRule();
+
+    @Rule
+    def QuietThucydidesLoggingRule quietThucydidesLoggingRule = new QuietThucydidesLoggingRule();
+
+    def MockEnvironmentVariables environmentVariables;
+
+    def Configuration configuration;
+
+    def setup() {
+        environmentVariables = new MockEnvironmentVariables();
+        environmentVariables.setProperty(MAX_RETRIES, "1");
+        environmentVariables.setProperty(JUNIT_RETRY_TESTS, "true");
+        configuration = new SystemPropertiesConfiguration(environmentVariables);
+    }
+
+    def "when scenario contains given when then they should be included in report"() {
+        given:
+            def outputDirectory = tempFolder.newFolder("serenitybdd")
+            environmentVariables.setProperty(ThucydidesSystemProperty.THUCYDIDES_OUTPUT_DIRECTORY.getPropertyName(),
+                outputDirectory.getAbsolutePath())
+
+            def runner = getStubbedTestRunnerUsing(SampleDataDrivenScenarioWithQualifier.class)
+        when:
+            runner.run(new RunNotifier())
+            def outcomes = ParameterizedTestsOutcomeAggregator.from(runner).aggregateTestOutcomesByTestMethods()
+        then:
+            outcomes.size() == 2
+            def happyDayOutcomes = outcomes.get(0)
+            def happyDaySteps = happyDayOutcomes.getTestSteps()
+            happyDaySteps.size() == 12
+            happyDayOutcomes.getTitle().matches("Happy day scenario")
+        and:
+            happyDayOutcomes.getDataDrivenSampleScenario().contains("Step with parameters")
+            happyDayOutcomes.getDataDrivenSampleScenario().contains("More step with parameters")
+            happyDayOutcomes.getDataDrivenSampleScenario().contains("Step with two parameters")
+    }
+
+    def private SerenityParameterizedRunner getStubbedTestRunnerUsing(Class<?> testClass) throws Throwable {
+        def configuration = new SystemPropertiesConfiguration(environmentVariables)
+        def factory = new WebDriverFactory(environmentVariables)
+        def batchManager = new BatchManagerProvider(configuration).get()
+        return new SerenityParameterizedRunner(testClass, configuration, factory, batchManager) {
+            @Override
+            public void generateReports() {
+                //do nothing
+            }
+        }
+    }
+}

--- a/serenity-junit/src/test/java/net/thucydides/samples/SampleDataDrivenScenarioWithQualifier.java
+++ b/serenity-junit/src/test/java/net/thucydides/samples/SampleDataDrivenScenarioWithQualifier.java
@@ -50,6 +50,8 @@ public class SampleDataDrivenScenarioWithQualifier {
     @Test
     public void happy_day_scenario() {
         steps.stepWithParameters(option1, option2);
+        steps.moreStepWithParameters(option1, option2);
+        steps.stepWithTwoParameters(option1, option2);
     }
 
     @Test


### PR DESCRIPTION
#### Summary of this PR
Updated scenario data driven steps processing for report - now report will contains steps as for first scenario
#### Intended effect
For data driven junit test scenario in report will contains steps from first test case. For example: 
```
    @Test
    public void happy_day_scenario() {
        steps.GivenSomeParameter(option1, option2);
        steps.WhenDoingSome(option1, option2);
        steps.ThenShouldBeNext(option1, option2);

    }
```
will appear as 3 steps on scenario
#### How should this be manually tested?
You can create data driven test and steps used in test will be included in report under scenario as 3 steps
#### Side effects
N/A
#### Documentation
serenity-documentation/issues/63
#### Relevant tickets
#338 
#### Screenshots (if appropriate)
before: 
![before](https://cloud.githubusercontent.com/assets/1667699/13663103/e2db841a-e6a7-11e5-9891-b1aad234c51a.png)

after:
![after](https://cloud.githubusercontent.com/assets/1667699/13663102/e2d703a4-e6a7-11e5-8c06-74e134ee0236.png)
