### PR TITLE
Fixed closing web driver when appium is used, it seems that window handles still does not implemented for Android devices, only for iOS

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFacade.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFacade.java
@@ -1,6 +1,7 @@
 package net.thucydides.core.webdriver;
 
 import com.gargoylesoftware.htmlunit.ScriptException;
+import io.appium.java_client.android.AndroidDriver;
 import net.serenitybdd.core.pages.DefaultTimeouts;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
@@ -272,13 +273,18 @@ public class WebDriverFacade implements WebDriver, TakesScreenshot, HasInputDevi
     public void close() {
         if (proxyInstanciated()) {
         	//if there is only one window closing it means quitting the web driver
-        	if (getDriverInstance().getWindowHandles() != null && getDriverInstance().getWindowHandles().size() == 1){
+        	if (areWindowHandlesAllowed(getDriverInstance()) &&
+                    getDriverInstance().getWindowHandles() != null && getDriverInstance().getWindowHandles().size() == 1){
         		this.quit();
         	} else{
         		getDriverInstance().close();
         	}
             webDriverFactory.shutdownFixtureServices();
         }
+    }
+
+    private boolean areWindowHandlesAllowed(final WebDriver driver){
+        return !(driver instanceof AndroidDriver);
     }
 
     public void quit() {
@@ -339,7 +345,7 @@ public class WebDriverFacade implements WebDriver, TakesScreenshot, HasInputDevi
     public boolean canTakeScreenshots() {
     	if (driverClass != null) {
     		if (driverClass == ProvidedDriver.class) {
-    			return TakesScreenshot.class.isAssignableFrom(getProxiedDriver().getClass()) 
+    			return TakesScreenshot.class.isAssignableFrom(getProxiedDriver().getClass())
     					|| (getProxiedDriver().getClass() == RemoteWebDriver.class);
     		} else {
     			return TakesScreenshot.class.isAssignableFrom(driverClass)


### PR DESCRIPTION
#### Summary of this PR
Fixed issue with closing web driver initialized with appium
#### Intended effect
Before closing webdriver we trying to get windows handles, but this function throw exception for Android devices, because it is still not implemented (works fine for iOS). So before getting window handles we should check if Android is used. 
#### How should this be manually tested?
Any tests should be created, with using appium and android
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#359 
#### Screenshots (if appropriate)
N/A