### PR TITLE
Updated making screenshort with died browser - nothing should be taken

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/photography/PageSourceRecorder.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/photography/PageSourceRecorder.java
@@ -2,6 +2,8 @@ package net.serenitybdd.core.photography;
 
 
 import com.google.common.base.Optional;
+import net.thucydides.core.webdriver.WebDriverFacade;
+import net.thucydides.core.webdriver.WebDriverFactory;
 import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,12 +23,14 @@ public class PageSourceRecorder {
     }
 
     public Optional<File> intoDirectory(Path path) {
-        try {
-            Path pageSourceFile = Files.createTempFile(path, "pagesource", ".html.txt");
-            Files.write(pageSourceFile, pageSource());
-            return Optional.of(pageSourceFile.toFile());
-        } catch(IOException couldNotCreatePageSourcce) {
-            LOGGER.warn("Could not save the page source HTML file", couldNotCreatePageSourcce);
+        if (WebDriverFactory.isAlive(driver)) {
+            try {
+                Path pageSourceFile = Files.createTempFile(path, "pagesource", ".html.txt");
+                Files.write(pageSourceFile, pageSource());
+                return Optional.of(pageSourceFile.toFile());
+            } catch (IOException couldNotCreatePageSourcce) {
+                LOGGER.warn("Could not save the page source HTML file", couldNotCreatePageSourcce);
+            }
         }
         return Optional.absent();
     }

--- a/serenity-core/src/main/java/net/serenitybdd/core/photography/PhotoSession.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/photography/PhotoSession.java
@@ -1,6 +1,7 @@
 package net.serenitybdd.core.photography;
 
 import net.thucydides.core.screenshots.BlurLevel;
+import net.thucydides.core.webdriver.WebDriverFactory;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -29,8 +30,10 @@ public class PhotoSession {
     }
 
     public ScreenshotPhoto takeScreenshot() {
-
-        byte[] screenshotData = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+        byte[] screenshotData = null;
+        if(WebDriverFactory.isAlive(driver)){
+            screenshotData = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+        }
 
         if (screenshotData == null || screenshotData.length == 0) {
             return ScreenshotPhoto.None;

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
@@ -153,11 +153,11 @@ public class WebDriverFactory {
     public boolean usesSauceLabs() {
         return StringUtils.isNotEmpty(sauceRemoteDriverCapabilities.getUrl());
     }
-    
+
     public boolean usesBrowserStack() {
         return StringUtils.isNotEmpty(browserStackRemoteDriverCapabilities.getUrl());
     }
-    
+
     /**
      * This method is synchronized because multiple webdriver instances can be created in parallel.
      * However, they may use common system resources such as ports, so may potentially interfere
@@ -293,7 +293,7 @@ public class WebDriverFactory {
     private boolean browserStackUrlIsDefined() {
         return StringUtils.isNotEmpty(browserStackRemoteDriverCapabilities.getUrl());
     }
-    
+
     private WebDriver buildSaucelabsDriver() throws MalformedURLException {
         String saucelabsUrl = sauceRemoteDriverCapabilities.getUrl();
         WebDriver driver = webdriverInstanceFactory.newRemoteDriver(new URL(saucelabsUrl), findSaucelabsCapabilities());
@@ -305,13 +305,13 @@ public class WebDriverFactory {
         }
         return driver;
     }
-    
+
     private WebDriver buildBrowserStackDriver() throws MalformedURLException{
     	String browserStackUrl = browserStackRemoteDriverCapabilities.getUrl();
         WebDriver driver = webdriverInstanceFactory.newRemoteDriver(new URL(browserStackUrl), findbrowserStackCapabilities());
         return driver;
     }
-    
+
 
     public static String getDriverFrom(EnvironmentVariables environmentVariables, String defaultDriver) {
         String driver = getDriverFrom(environmentVariables);
@@ -333,13 +333,13 @@ public class WebDriverFactory {
 
         return sauceRemoteDriverCapabilities.getCapabilities(capabilities);
     }
-    
-    
+
+
     private Capabilities findbrowserStackCapabilities() {
 
     	String driver = getDriverFrom(environmentVariables);
     	DesiredCapabilities capabilities = capabilitiesForDriver(driver);
-    	
+
         return browserStackRemoteDriverCapabilities.getCapabilities(capabilities);
 
     }
@@ -774,5 +774,17 @@ public class WebDriverFactory {
         return (configuredTimeout != null) ? new Duration(configuredTimeout, TimeUnit.MILLISECONDS)
                                            : DefaultTimeouts.DEFAULT_IMPLICIT_WAIT_TIMEOUT;
 
+    }
+    
+    public static boolean isAlive(final WebDriver driver) {
+        try {
+            driver.getTitle();
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+    public static boolean isNotAlive(final WebDriver driver){
+        return !isAlive(driver);
     }
 }

--- a/serenity-core/src/test/groovy/net/serenitybdd/core/photography/WhenTakingScreenshotsFromDiedBrowser.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/photography/WhenTakingScreenshotsFromDiedBrowser.groovy
@@ -1,0 +1,37 @@
+package net.serenitybdd.core.photography
+
+import net.thucydides.core.screenshots.BlurLevel
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import org.openqa.selenium.NoSuchWindowException
+import org.openqa.selenium.WebDriver
+import spock.lang.Specification
+
+class WhenTakingScreenshotsFromDiedBrowser extends Specification {
+
+    @Rule
+    TemporaryFolder folder = new TemporaryFolder();
+
+    def "when a photo session died browser is used it should not take a photo"() {
+        given:
+            def driver = Mock(WebDriver)
+            driver.getTitle() >> { throw new NoSuchWindowException("Some exception ") };
+            def session = new PhotoSession(driver, folder.newFolder().toPath(), BlurLevel.NONE)
+        when:
+            def photo = session.takeScreenshot()
+        then:
+            photo == ScreenshotPhoto.None
+    }
+
+    def "when a for saving page source died  is used browser it should not try to save page source"() {
+        given:
+            def driver = Mock(WebDriver)
+            driver.getTitle() >> { throw new NoSuchWindowException("Some exception ") };
+            def recorder = new PageSourceRecorder(driver)
+        when:
+            def photo = recorder.intoDirectory(folder.newFolder().toPath())
+        then:
+            !photo.isPresent()
+    }
+
+}


### PR DESCRIPTION
#### Summary of this PR
Updaing making screenshort with died browser - nothing should be taken  
#### Intended effect
If screen shots or page sources tried to be taken with died browser - they should be absent 
#### How should this be manually tested?
N/A
#### Side effects
If browser died, and testFailed reported - during reporting screenshot is taken - it this situation screenshot or page source should be empty
#### Documentation
N/A
#### Relevant tickets
#363 
#### Screenshots (if appropriate)
before fix: 
![before](https://cloud.githubusercontent.com/assets/1667699/13978950/9a1e2a76-f0dd-11e5-85c5-c66cde4791f5.png)

after fix: 
![after](https://cloud.githubusercontent.com/assets/1667699/13978951/9a1efd66-f0dd-11e5-9bca-750a27019815.png)