### PR TITLE
set property "use.test.case.for.story.tag = false" by default

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -630,7 +630,7 @@ public enum ThucydidesSystemProperty {
     SHOW_RELATED_TAGS,
 
     /**
-     * If set to true (the default value), a story tag will be extracted from the test case or feature file
+     * If set to true (the default value is false), a story tag will be extracted from the test case or feature file
      * containing the test.
      */
     USE_TEST_CASE_FOR_STORY_TAG,

--- a/serenity-core/src/main/java/net/thucydides/core/statistics/service/FeatureStoryTagProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/statistics/service/FeatureStoryTagProvider.java
@@ -43,6 +43,11 @@ public class FeatureStoryTagProvider implements TagProvider, CoreTagProvider {
         }
     }
 
+    public static String getAddStoryTagsPropertyName()
+    {
+        return ThucydidesSystemProperty.USE_TEST_CASE_FOR_STORY_TAG.getPropertyName();
+    }
+
     private boolean shouldAddStoryTags() {
         return ThucydidesSystemProperty.USE_TEST_CASE_FOR_STORY_TAG.booleanFrom(environmentVariables, false);
     }

--- a/serenity-core/src/main/java/net/thucydides/core/statistics/service/FeatureStoryTagProvider.java
+++ b/serenity-core/src/main/java/net/thucydides/core/statistics/service/FeatureStoryTagProvider.java
@@ -44,7 +44,7 @@ public class FeatureStoryTagProvider implements TagProvider, CoreTagProvider {
     }
 
     private boolean shouldAddStoryTags() {
-        return ThucydidesSystemProperty.USE_TEST_CASE_FOR_STORY_TAG.booleanFrom(environmentVariables, true);
+        return ThucydidesSystemProperty.USE_TEST_CASE_FOR_STORY_TAG.booleanFrom(environmentVariables, false);
     }
 
     private void addFeatureTagIfPresent(TestOutcome testOutcome, Set<TestTag> tags) {

--- a/serenity-core/src/test/groovy/net/thucydides/core/reports/WhenManagingTestResultTags.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/reports/WhenManagingTestResultTags.groovy
@@ -1,28 +1,63 @@
 package net.thucydides.core.reports
 
+import net.serenitybdd.core.injectors.EnvironmentDependencyInjector
+import net.thucydides.core.guice.Injectors
 import net.thucydides.core.model.TestTag
+import net.thucydides.core.statistics.service.FeatureStoryTagProvider
+import net.thucydides.core.util.EnvironmentVariables
+import net.thucydides.core.util.MockEnvironmentVariables
+import net.thucydides.core.util.SystemEnvironmentVariables
+import net.thucydides.core.webdriver.Configuration
+import net.thucydides.core.webdriver.SystemPropertiesConfiguration
 import spock.lang.Specification
 
 class WhenManagingTestResultTags extends Specification {
 
+    def SystemEnvironmentVariables environmentVariables = Injectors.getInjector().getProvider(EnvironmentVariables.class).get();
+
+    def cleanup() {
+        environmentVariables.clearProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName())
+    }
+
     def testOutcomes = new TestOutcomesBuilder().defaultResults
 
-    def "should list all of the tag names in a set of outcomes"() {
+    def "should list all of the tag names in a set of outcomes with story tag from test case"() {
+
         when:
+            environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "true")
             testOutcomes.tests[0].addTags([TestTag.withName("chocolate").andType("flavor")])
             testOutcomes.tests[0].addTags([TestTag.withName("orange").andType("color")])
         then:
             testOutcomes.tagNames == ['chocolate','orange','purchase new widget', 'widget feature']
     }
 
-    def "should list all of the tag types"() {
+    def "should list all of the tag names in a set of outcomes"() {
+
         when:
+        environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "false")
+        testOutcomes.tests[0].addTags([TestTag.withName("chocolate").andType("flavor")])
+        testOutcomes.tests[0].addTags([TestTag.withName("orange").andType("color")])
+        then:
+        testOutcomes.tagNames == ['chocolate','orange','widget feature']
+    }
+
+    def "should list all of the tag types with story tag from test case"() {
+        when:
+            environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "true")
             testOutcomes.tests[0].addTags([TestTag.withName("chocolate").andType("flavor")])
             testOutcomes.tests[0].addTags([TestTag.withName("orange").andType("color")])
         then:
             testOutcomes.tagTypes == ['color','feature','flavor','story']
     }
 
+    def "should list all of the tag types"() {
+        when:
+        environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "false")
+        testOutcomes.tests[0].addTags([TestTag.withName("chocolate").andType("flavor")])
+        testOutcomes.tests[0].addTags([TestTag.withName("orange").andType("color")])
+        then:
+        testOutcomes.tagTypes == ['color','feature','flavor']
+    }
 
     def "should list all of the tag types that are not requirements"() {
         when:

--- a/serenity-core/src/test/groovy/net/thucydides/core/reports/adaptors/specflow/WhenLoadingSpecflowLogOutputAsTestOutcomes.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/reports/adaptors/specflow/WhenLoadingSpecflowLogOutputAsTestOutcomes.groovy
@@ -1,7 +1,11 @@
 package net.thucydides.core.reports.adaptors.specflow
 
+import net.thucydides.core.guice.Injectors
 import net.thucydides.core.model.TestResult
 import net.thucydides.core.reports.adaptors.TestOutcomeAdaptor
+import net.thucydides.core.statistics.service.FeatureStoryTagProvider
+import net.thucydides.core.util.EnvironmentVariables
+import net.thucydides.core.util.SystemEnvironmentVariables
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
@@ -23,8 +27,14 @@ class WhenLoadingSpecflowLogOutputAsTestOutcomes extends Specification {
    -> done: bla bla bla (0.9s)
 """
 
-    def "should find the scenario and story titles"() {
+    def SystemEnvironmentVariables environmentVariables = Injectors.getInjector().getProvider(EnvironmentVariables.class).get();
+    def cleanup() {
+        environmentVariables.clearProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName())
+    }
+
+    def "should find the scenario and story titles with story tags from test case"() {
         given:
+            environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "true")
             def specflowOutput = fileFrom(simpleSpecflowOutput)
             TestOutcomeAdaptor specflowLoader = new SpecflowAdaptor()
         when:
@@ -38,6 +48,23 @@ class WhenLoadingSpecflowLogOutputAsTestOutcomes extends Specification {
         and:
             testOutcomes.get(0).getTags()
             testOutcomes.get(0).path == "root.packages.MyCapability.SpecFlow.Features.MyFeature"
+    }
+
+    def "should find the scenario and story titles"() {
+        given:
+        environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "false")
+        def specflowOutput = fileFrom(simpleSpecflowOutput)
+        TestOutcomeAdaptor specflowLoader = new SpecflowAdaptor()
+        when:
+        def testOutcomes = specflowLoader.loadOutcomesFrom(specflowOutput)
+        then:
+        testOutcomes.size() == 1
+        and:
+        testOutcomes.get(0).title == "My scenario"
+        and:
+        testOutcomes.get(0).storyTitle == "My feature"
+        and:
+        testOutcomes.get(0).getTags().size() == 0
     }
 
     def "should find the scenario steps"() {
@@ -234,7 +261,6 @@ class WhenLoadingSpecflowLogOutputAsTestOutcomes extends Specification {
     def setup() {
         tmp = temporaryFolder.newFolder()
     }
-
 
     def fileFrom(def contents) {
         def outputFile = new File(tmp, "specflow-output-${System.currentTimeMillis()}.out")

--- a/serenity-core/src/test/groovy/net/thucydides/core/reports/json/WhenStoringTestOutcomesAsJSON.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/reports/json/WhenStoringTestOutcomesAsJSON.groovy
@@ -3,7 +3,9 @@ package net.thucydides.core.reports.json
 import net.serenitybdd.core.rest.RestMethod
 import net.serenitybdd.core.rest.RestQuery
 import net.thucydides.core.annotations.*
+import net.thucydides.core.annotations.Story
 import net.thucydides.core.digest.Digest
+import net.thucydides.core.guice.Injectors
 import net.thucydides.core.issues.IssueTracking
 import net.thucydides.core.model.*
 import net.thucydides.core.reports.AcceptanceTestLoader
@@ -12,7 +14,10 @@ import net.thucydides.core.reports.TestOutcomes
 import net.thucydides.core.reports.integration.TestStepFactory
 import net.thucydides.core.reports.json.gson.GsonJSONConverter
 import net.thucydides.core.screenshots.ScreenshotAndHtmlSource
+import net.thucydides.core.statistics.service.FeatureStoryTagProvider
+import net.thucydides.core.util.EnvironmentVariables
 import net.thucydides.core.util.MockEnvironmentVariables
+import net.thucydides.core.util.SystemEnvironmentVariables
 import org.joda.time.DateTime
 import org.joda.time.LocalDateTime
 import org.junit.ComparisonFailure
@@ -30,12 +35,7 @@ class WhenStoringTestOutcomesAsJSON extends Specification {
     def AcceptanceTestReporter reporter
     def AcceptanceTestLoader loader
 
-    File outputDirectory
-
-    @Rule
-    TemporaryFolder temporaryFolder
-
-    TestOutcomes allTestOutcomes = Mock();
+    def SystemEnvironmentVariables environmentVariables = Injectors.getInjector().getProvider(EnvironmentVariables.class).get();
 
     def setup() {
         outputDirectory = temporaryFolder.newFolder()
@@ -44,6 +44,17 @@ class WhenStoringTestOutcomesAsJSON extends Specification {
         reporter.setOutputDirectory(outputDirectory);
         loader.setOutputDirectory(outputDirectory);
     }
+
+    def cleanup() {
+        environmentVariables.clearProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName())
+    }
+
+    File outputDirectory
+
+    @Rule
+    TemporaryFolder temporaryFolder
+
+    TestOutcomes allTestOutcomes = Mock();
 
     class AUserStory {
     }
@@ -291,8 +302,9 @@ class WhenStoringTestOutcomesAsJSON extends Specification {
     }
 
 
-    def "should store annotated tags and issues in the JSON reports"() {
+    def "should store annotated tags and issues in the JSON reports with story tag from test case"() {
         given:
+        environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "true")
         def testOutcome = TestOutcome.forTest("should_do_this", SomeTestScenarioWithTags.class);
         testOutcome.startTime = FIRST_OF_JANUARY
         testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1").startingAt(FIRST_OF_JANUARY))
@@ -305,6 +317,21 @@ class WhenStoringTestOutcomesAsJSON extends Specification {
         reloadedOutcome.tags.containsAll([TestTag.withName("Some test scenario with tags").andType("story"),
                                           TestTag.withName("simple story").andType("story"),
                                           TestTag.withName("important feature").andType("feature")])
+    }
+
+    def "should store annotated tags and issues in the JSON reports"() {
+        given:
+        environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "false")
+        def testOutcome = TestOutcome.forTest("should_do_this", SomeTestScenarioWithTags.class);
+        testOutcome.startTime = FIRST_OF_JANUARY
+        testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1").startingAt(FIRST_OF_JANUARY))
+        when:
+        def jsonReport = reporter.generateReportFor(testOutcome, allTestOutcomes)
+        TestOutcome reloadedOutcome = loader.loadReportFrom(jsonReport).get()
+        then:
+        reloadedOutcome.issues == ["PROJ-123"]
+        and:
+        reloadedOutcome.tags.containsAll([TestTag.withName("important feature").andType("feature")])
     }
 
 
@@ -400,19 +427,6 @@ class WhenStoringTestOutcomesAsJSON extends Specification {
         reloadedOutcome.feature.name == "A feature"
     }
 
-
-    def "should record features and stories as tags"() {
-        given:
-        def testOutcome = TestOutcome.forTest("should_do_this", SomeTestScenarioInAFeature.class);
-        testOutcome.startTime = FIRST_OF_JANUARY
-        testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1").startingAt(FIRST_OF_JANUARY));
-        when:
-        def jsonReport = reporter.generateReportFor(testOutcome, allTestOutcomes)
-        TestOutcome reloadedOutcome = loader.loadReportFrom(jsonReport).get()
-        then:
-        reloadedOutcome.tags.contains(TestTag.withName("A user story in a feature").andType("story"))
-        reloadedOutcome.tags.contains(TestTag.withName("A feature").andType("feature"))
-    }
 
     def "should generate an JSON report with a name based on the test run title"() {
         when:
@@ -748,4 +762,32 @@ class WhenStoringTestOutcomesAsJSON extends Specification {
         then:
         loadedOutcome.tags
     }
+
+    def "should record features and stories as tags when story tag from test case"() {
+        given:
+        environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "true")
+        def testOutcome = TestOutcome.forTest("should_do_this", SomeTestScenarioInAFeature.class);
+        testOutcome.startTime = FIRST_OF_JANUARY
+        testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1").startingAt(FIRST_OF_JANUARY));
+        when:
+        def jsonReport = reporter.generateReportFor(testOutcome, allTestOutcomes)
+        TestOutcome reloadedOutcome = loader.loadReportFrom(jsonReport).get()
+        then:
+        reloadedOutcome.tags.contains(TestTag.withName("A user story in a feature").andType("story"))
+        reloadedOutcome.tags.contains(TestTag.withName("A feature").andType("feature"))
+    }
+
+    def "should record features as tags"() {
+        given:
+
+        def testOutcome = TestOutcome.forTest("should_do_this", SomeTestScenarioInAFeature.class);
+        testOutcome.startTime = FIRST_OF_JANUARY
+        testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1").startingAt(FIRST_OF_JANUARY));
+        when:
+        def jsonReport = reporter.generateReportFor(testOutcome, allTestOutcomes)
+        TestOutcome reloadedOutcome = loader.loadReportFrom(jsonReport).get()
+        then:
+        reloadedOutcome.tags.contains(TestTag.withName("A feature").andType("feature"))
+    }
+
 }

--- a/serenity-core/src/test/groovy/net/thucydides/core/tags/WhenFindingTestOutcomeTags.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/tags/WhenFindingTestOutcomeTags.groovy
@@ -20,8 +20,9 @@ class WhenFindingTestOutcomeTags extends Specification {
         def aTest() {}
     }
 
-    def "should get story tag from the test class by default"() {
+    def "should get story tag from the test class if property set"() {
         given:
+            environmentVariables.setProperty(FeatureStoryTagProvider.getAddStoryTagsPropertyName(), "true")
             def tagProvider = new FeatureStoryTagProvider(environmentVariables)
             def testOutcome = TestOutcome.forTest("aTest", SomeTest)
         when:
@@ -30,10 +31,8 @@ class WhenFindingTestOutcomeTags extends Specification {
             tags.contains(TestTag.withName("Some test").andType("story"))
     }
 
-    def "should not get story tag from the test class if "() {
+    def "should not get story tag from the test class by default "() {
         given:
-            environmentVariables.setProperty("use.test.case.for.story.tag","false")
-        and:
             def tagProvider = new FeatureStoryTagProvider(environmentVariables)
             def testOutcome = TestOutcome.forTest("aTest", SomeTest)
         when:


### PR DESCRIPTION
https://github.com/serenity-bdd/serenity-jbehave/issues/17
FeatureStoryTagProvider causes the story duplicated in report home if story title differs from filename. 
FeatureStoryTagProvider is legacy code to support the @Feature annotation
When setting the property use.test.case.for.story.tag = false , there will be no story tags defined by this tag provider for the test cases.