### PR TITLE
Fixed isAlive function to work with appium

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
@@ -793,12 +793,19 @@ public class WebDriverFactory {
 
     public static boolean isAlive(final WebDriver driver) {
         try {
-            driver.getCurrentUrl();
+            WebDriver local = driver;
+            if(driver instanceof WebDriverFacade){
+                local = ((WebDriverFacade)driver).getDriverInstance();
+            }
+            if(!(local instanceof AppiumDriver)){
+                local.getCurrentUrl();
+            }
         } catch (Exception e) {
             return false;
         }
         return true;
     }
+    
     public static boolean isNotAlive(final WebDriver driver){
         return !isAlive(driver);
     }

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
@@ -805,7 +805,7 @@ public class WebDriverFactory {
         }
         return true;
     }
-    
+
     public static boolean isNotAlive(final WebDriver driver){
         return !isAlive(driver);
     }

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
@@ -790,10 +790,10 @@ public class WebDriverFactory {
                                            : DefaultTimeouts.DEFAULT_IMPLICIT_WAIT_TIMEOUT;
 
     }
-    
+
     public static boolean isAlive(final WebDriver driver) {
         try {
-            driver.getTitle();
+            driver.getCurrentUrl();
         } catch (Exception e) {
             return false;
         }

--- a/serenity-core/src/test/groovy/net/serenitybdd/core/photography/WhenTakingScreenshotsFromDiedBrowser.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/photography/WhenTakingScreenshotsFromDiedBrowser.groovy
@@ -15,7 +15,7 @@ class WhenTakingScreenshotsFromDiedBrowser extends Specification {
     def "when a photo session with died browser is used it should not take a photo"() {
         given:
             def driver = Mock(WebDriver)
-            driver.getTitle() >> { throw new NoSuchWindowException("Some exception ") };
+            driver.getCurrentUrl() >> { throw new NoSuchWindowException("Some exception ") };
             def session = new PhotoSession(driver, folder.newFolder().toPath(), BlurLevel.NONE)
         when:
             def photo = session.takeScreenshot()
@@ -26,7 +26,7 @@ class WhenTakingScreenshotsFromDiedBrowser extends Specification {
     def "when a for saving page source died  is used browser it should not try to save page source"() {
         given:
             def driver = Mock(WebDriver)
-            driver.getTitle() >> { throw new NoSuchWindowException("Some exception ") };
+            driver.getCurrentUrl() >> { throw new NoSuchWindowException("Some exception ") };
             def recorder = new PageSourceRecorder(driver)
         when:
             def photo = recorder.intoDirectory(folder.newFolder().toPath())


### PR DESCRIPTION
#### Summary of this PR
Fixed isAlive function to work with appium
#### Intended effect
It is possible that drover closed during test execution (some error for example). This function helps Serenity reinit driver in this case. 
#### How should this be manually tested?
You can test with some other driver - firefox or chrome, for this you should create test class with multiple test cases (web tests), run it and after some of test opens browser - close it. Only current test should fail, other tests should be fine
#### Side effects
N/A
#### Documentation
If the pull request is user facing, how is it documented?
Are there examples of how to use the new behavior that users need to know about?
#### Relevant tickets
#408
#### Screenshots (if appropriate)
N/A