### PR TITLE
Updated appium java client to version 3.4.1

### DIFF
--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         exclude group: 'net.sourceforge.htmlunit', module:'htmlunit'
     }
 
-    compile('io.appium:java-client:3.3.0') {
+    compile('io.appium:java-client:3.4.1') {
         exclude group: 'org.seleniumhq.selenium', module: 'selenium-java'
         exclude group: 'org.seleniumhq.selenium', module: 'selenium-remote-driver'
         exclude group: 'cglib', module: 'cglib'


### PR DESCRIPTION
Appium's java client 3.4 was released behind Appium 1.5, but was intended to be paired.  By.name locator for apps has been deprecated, but this shouldn't be a breaking change yet.

Release notes:
https://discuss.appium.io/t/java-client-version-3-4-0-released/8961
https://discuss.appium.io/t/java-client-version-3-4-1-released/9416