### PR TITLE
Add ability to assert that matched element is not present in collection (#453)

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/matchers/BeanMatcherAsserts.java
+++ b/serenity-core/src/main/java/net/thucydides/core/matchers/BeanMatcherAsserts.java
@@ -112,6 +112,14 @@ public class BeanMatcherAsserts {
         }
     }
 
+    public static <T> void shouldNotMatch(List<T> items, BeanMatcher... matchers) {
+        if (matches(items, matchers)) {
+            throw new AssertionError("Found unneeded matching elements for " + join(matchers)
+                    + NEW_LINE
+                    +"Elements where " + join(items));
+        }
+    }
+
     private static String descriptionOf(Object bean) {
 
         if (isAMap(bean)) {

--- a/serenity-core/src/test/java/net/thucydides/core/matchers/WhenMatchingPropertyValueCollections.java
+++ b/serenity-core/src/test/java/net/thucydides/core/matchers/WhenMatchingPropertyValueCollections.java
@@ -276,6 +276,46 @@ public class WhenMatchingPropertyValueCollections {
     }
 
     @Test
+    public void should_check_field_similarities() {
+        List<Person> persons = Arrays.asList(billoddie, tim, graeme, billoddie);
+
+        BeanMatcher containsTwoEntries = the_count(is(2));
+        BeanMatcher lastNamesAreDifferent = each("lastName").isDifferent();
+        BeanMatcher firstNameIsBill = the("firstName", is("Bill"));
+
+        shouldNotMatch(persons, containsTwoEntries, firstNameIsBill, lastNamesAreDifferent);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void should_check_field_similarities_when_all_unique() {
+        List<Person> persons = Arrays.asList(billoddie, tim, graeme, billkidd);
+
+        BeanMatcher containsTwoEntries = the_count(is(2));
+        BeanMatcher lastNamesAreDifferent = each("lastName").isDifferent();
+        BeanMatcher firstNameIsBill = the("firstName", is("Bill"));
+
+        shouldNotMatch(persons, containsTwoEntries, firstNameIsBill, lastNamesAreDifferent);
+    }
+
+    @Test
+    public void should_check_element_is_not_present() {
+        List<Person> persons = Arrays.asList(billoddie, tim, graeme, billoddie);
+
+        BeanMatcher firstNameIsJohn = the("firstName", is("John"));
+
+        shouldNotMatch(persons, firstNameIsJohn);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void should_check_element_is_not_present_with_failing_case() {
+        List<Person> persons = Arrays.asList(billoddie, tim, graeme, billkidd);
+
+        BeanMatcher firstNameIsBill = the("firstName", is("Bill"));
+
+        shouldNotMatch(persons, firstNameIsBill);
+    }
+
+    @Test
     public void should_check_multiple_different_types_of_matches() {
         List<Person> persons = Arrays.asList(billoddie, tim, graeme, billkidd);
 

--- a/serenity-core/src/test/java/net/thucydides/core/matchers/WhenMatchingPropertyValuesWithMaps.java
+++ b/serenity-core/src/test/java/net/thucydides/core/matchers/WhenMatchingPropertyValuesWithMaps.java
@@ -192,5 +192,26 @@ public class WhenMatchingPropertyValuesWithMaps {
         BeanMatcherAsserts.shouldMatch(persons, containsTwoEntries, firstNameIsBill, lastNamesAreDifferent);
     }
 
+    @Test
+    public void should_check_field_absence() {
+        List<Map<String,String>> persons = Arrays.asList(mappedPerson("Bill", "Oddie"),
+                mappedPerson("Bill", "Kidd"),
+                mappedPerson("Graeam", "Garden"),
+                mappedPerson("Tim", "Brooke-Taylor"));
+
+        BeanMatcher firstNameIsJohn = BeanMatchers.the("firstName", is("John"));
+        BeanMatcherAsserts.shouldNotMatch(persons, firstNameIsJohn);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void should_check_field_absence_with_failing_case() {
+        List<Map<String,String>> persons = Arrays.asList(mappedPerson("Bill", "Oddie"),
+                mappedPerson("Bill", "Kidd"),
+                mappedPerson("Graeam", "Garden"),
+                mappedPerson("Tim", "Brooke-Taylor"));
+
+        BeanMatcher firstNameIsBill = BeanMatchers.the("firstName", is("Bill"));
+        BeanMatcherAsserts.shouldNotMatch(persons, firstNameIsBill);
+    }
 
 }


### PR DESCRIPTION
#### Summary of this PR
Add shouldNotMatch(List<T> items, BeanMatcher... matchers) method into BeanMatcherAsserts 
#### Intended effect
A user now has an ability to assert that matched element is not present in collection
#### How should this be manually tested?
The implementation is straightforward and Unit Tests written cover all required functionality of method added and also provide an example of new method usage.
#### Side effects
Existing code was not changed in any way so there are no any side effects
#### Documentation
Probably documentation section "8.8. Using Fluent Matcher expressions" should be updated to provide example of usage, e.g. 
```
   @Step
    public void should_not_see_artifacts_where(BeanMatcher... matchers) {
        shouldNotMatch(onSearchResultsPage().getSearchResults(), matchers);
    }
```
#### Relevant tickets
#453  