### PR TITLE
Add ability to see response body for responses with  HTML content type in report

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestReportingHelper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestReportingHelper.java
@@ -36,7 +36,7 @@ public class RestReportingHelper {
     private static boolean shouldRecordResponseBodyFor(Response result) {
         final ContentType type = ContentType.fromContentType(result.contentType());
         return type != null && (ContentType.JSON == type || ContentType.XML == type
-                || ContentType.TEXT == type);
+                || ContentType.TEXT == type || ContentType.HTML == type);
     }
 
     public RestQuery recordRestSpecificationData(final RestMethod method, final RequestSpecificationDecorated spec,

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestResponseRecordingHelper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestResponseRecordingHelper.java
@@ -39,6 +39,7 @@ public class RestResponseRecordingHelper {
                     }
                     recordingStream.flush();
                     String recorded = new String(output.toByteArray(), StandardCharsets.UTF_8);
+                    output.reset();
                     recorded = recorded.replaceAll("^(" +
                             "(Proxy:)|(Body:)|(Cookies:)|(Headers:)|(Multiparts:)|(Request path:)" +
                             ")\\s*\\n*", "");


### PR DESCRIPTION
#### Summary of this PR
Fix for Rest-Assured Integration:
Fix two issues with report generation for REST Query responses
#### Intended effect
1. Now user has ability to see response body for responses with  HTML content type in report
2. Cookies field of Rest Query element in report now doesn't contain headers

#### How should this be manually tested?
Fix can be tested by performing post request with arbitrary post data using Rest-Assured integration to the following URL:
http://www.angularjshub.com:80/code/examples/servercalls/01_HTTPService/server.php?param1=first%20param&param2=second%20param
After that report should be generated and tester make sure that the report contains Response Body and the Cookies field is empty. Also, unit tests were written to cover changed functionality
#### Side effects
There are no sideffects
#### Documentation
Documentation update is not needed
#### Relevant tickets
#448 
#### Screenshots (if appropriate)
![beforechange](https://cloud.githubusercontent.com/assets/8802945/16154472/aa296a60-34b3-11e6-8b73-7e651a8d4e3e.PNG)
![afterchange](https://cloud.githubusercontent.com/assets/8802945/16154476/ada9aa92-34b3-11e6-95c4-32385c0b1dd5.PNG)







