### PR TITLE
Made it possible to ignore invalid certificates when using BrowserMobProxy

### DIFF
--- a/serenity-browsermob-plugin/src/main/java/net/thucydides/browsermob/fixtureservices/BrowserMobFixtureService.java
+++ b/serenity-browsermob-plugin/src/main/java/net/thucydides/browsermob/fixtureservices/BrowserMobFixtureService.java
@@ -1,6 +1,5 @@
 package net.thucydides.browsermob.fixtureservices;
 
-
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import net.lightbody.bmp.BrowserMobProxy;
@@ -59,8 +58,14 @@ public class BrowserMobFixtureService implements FixtureService {
     }
 
     private void initializeProxy(int port) throws Exception {
+        boolean refuseUntrustedCertificates = environmentVariables.getPropertyAsBoolean(ThucydidesSystemProperty.REFUSE_UNTRUSTED_CERTIFICATES, false);
         setPort(port);
         threadLocalproxyServer.set(new BrowserMobProxyServer());
+        if(refuseUntrustedCertificates) {
+            threadLocalproxyServer.setTrustAllServers(false);
+        } else {
+            threadLocalproxyServer.setTrustAllServers(true);
+        }
         threadLocalproxyServer.get().start(getPort());
     }
 

--- a/serenity-browsermob-plugin/src/main/java/net/thucydides/browsermob/fixtureservices/BrowserMobFixtureService.java
+++ b/serenity-browsermob-plugin/src/main/java/net/thucydides/browsermob/fixtureservices/BrowserMobFixtureService.java
@@ -9,6 +9,7 @@ import net.thucydides.core.fixtureservices.FixtureException;
 import net.thucydides.core.fixtureservices.FixtureService;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.util.EnvironmentVariables;
+import net.thucydides.core.ThucydidesSystemProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.remote.CapabilityType;


### PR DESCRIPTION
Browsermobproxy tries to validates certificates by default, which is at odds with Selenium's default behaviour of ignoring invalid certificates.  I've tried to build on top of the existing refuse.untrusted.certificates property to make this optional.

It would be good if someone could review this, as I have had troubles getting Serenity to build locally, and whether untrusted.certificates would be a better candidate to hook into.

The end game is to be able to attach a proxy to a site being tested when access via HTTPS with a self signed certificate.
