### PR TITLE
Support for webdriver.ie.driver system property

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-core/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -58,6 +58,11 @@ public enum ThucydidesSystemProperty {
     WEBDRIVER_REMOTE_OS,
 
     /**
+     * Path to the Internet Explorer driver, if it is not on the system path.
+     */
+    WEBDRIVER_IE_DRIVER,
+
+    /**
      * Path to the Chrome driver, if it is not on the system path.
      */
     WEBDRIVER_CHROME_DRIVER,

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/strategies/InternetExplorerDriverBuilder.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/strategies/InternetExplorerDriverBuilder.java
@@ -1,20 +1,31 @@
 package net.thucydides.core.webdriver.strategies;
 
 import net.serenitybdd.core.buildinfo.DriverCapabilityRecord;
+import net.serenitybdd.core.time.InternalSystemClock;
+import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.steps.StepEventBus;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.webdriver.CapabilityEnhancer;
 import net.thucydides.core.webdriver.stubs.WebDriverStub;
+import org.apache.commons.lang3.StringUtils;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.ie.InternetExplorerDriverService;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.safari.SafariDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
 
 public class InternetExplorerDriverBuilder implements DriverBuilder {
 
     private final EnvironmentVariables environmentVariables;
     private final CapabilityEnhancer enhancer;
     private final DriverCapabilityRecord driverProperties;
+    private static final Logger LOGGER = LoggerFactory.getLogger(InternetExplorerDriverBuilder.class);
 
     public InternetExplorerDriverBuilder(EnvironmentVariables environmentVariables, CapabilityEnhancer enhancer) {
         this.environmentVariables = environmentVariables;
@@ -27,8 +38,43 @@ public class InternetExplorerDriverBuilder implements DriverBuilder {
         if (StepEventBus.getEventBus().webdriverCallsAreSuspended()) {
             return new WebDriverStub();
         }
-        SafariDriver driver = new SafariDriver(enhancer.enhanced(DesiredCapabilities.internetExplorer()));
+
+        InternetExplorerDriverService.Builder builder = new InternetExplorerDriverService.Builder().usingAnyFreePort();
+        String environmentDefinedIEDriverPath = environmentVariables.getProperty(ThucydidesSystemProperty.WEBDRIVER_IE_DRIVER);
+        if (StringUtils.isNotEmpty(environmentDefinedIEDriverPath)) {
+            builder.usingDriverExecutable(new File(environmentDefinedIEDriverPath));
+        }
+        final InternetExplorerDriverService service = builder.build();
+
+        try {
+            service.start();
+        } catch (Exception e) {
+            throw new RuntimeException("InternetExplorerDriverService could not be started", e);
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                service.stop();
+            }
+        });
+        DesiredCapabilities browserCapabilities = DesiredCapabilities.internetExplorer();
+        browserCapabilities.setCapability(InternetExplorerDriver.IGNORE_ZOOM_SETTING, true);
+        browserCapabilities.setCapability(InternetExplorerDriver.NATIVE_EVENTS, false);
+        browserCapabilities.setCapability(InternetExplorerDriver.REQUIRE_WINDOW_FOCUS, false);
+        browserCapabilities.setJavascriptEnabled(true);
+        browserCapabilities.setCapability(CapabilityType.TAKES_SCREENSHOT, true);
+
+        InternetExplorerDriver driver = driver(service, browserCapabilities);
         driverProperties.registerCapabilities("iexplorer", driver.getCapabilities());
         return driver;
+    }
+
+    private InternetExplorerDriver driver(InternetExplorerDriverService service, DesiredCapabilities browserCapabilities) {
+        try {
+            return new InternetExplorerDriver(service, browserCapabilities);
+        } catch (NoSuchSessionException e) {
+            LOGGER.error(e.getClass().getCanonicalName() + " happened - retrying in 2 seconds");
+            new InternalSystemClock().pauseFor(2000);
+            return new InternetExplorerDriver(service, browserCapabilities);
+        }
     }
 }


### PR DESCRIPTION
This PR provides support for new **webdriver.ie.driver** property. Some details:
- Without this feature, If IE driver is not on the path then an exception like the following is thrown: 
```
Sep 20, 2016 3:56:40 PM org.openqa.selenium.safari.SafariDriverServer start
INFO: Server started on port 32491
Sep 20, 2016 3:56:43 PM org.openqa.selenium.safari.SafariDriverCommandExecutor stop
INFO: Shutting down
Sep 20, 2016 3:56:43 PM org.openqa.selenium.safari.SafariDriverCommandExecutor stop
INFO: Stopping server
Sep 20, 2016 3:56:43 PM org.openqa.selenium.safari.SafariDriverServer stop
INFO: Stopping server
Sep 20, 2016 3:56:43 PM org.openqa.selenium.safari.SafariDriverCommandExecutor stop
INFO: Shutdown complete
[main] ERROR net.thucydides.core.webdriver.WebDriverFacade - FAILED TO CREATE NEW WEBDRIVER_DRIVER INSTANCE class org.openqa.selenium.ie.InternetExplorerDriver: Could not instantiate class org.openqa.selenium.ie.InternetExplorerDriver
net.thucydides.core.webdriver.UnsupportedDriverException: Could not instantiate class org.openqa.selenium.ie.InternetExplorerDriver
(blah)
Caused by: java.lang.RuntimeException: Safari could not be found in the path!
Please add the directory containing ''Safari.exe'' to your PATH environment
variable, or explicitly specify a path to Safari like this:
*safari c:\blah\Safari.exe
```
This is confusing as in the current version of [InternetExplorerDriverBuilder.java](https://github.com/serenity-bdd/serenity-core/blob/master/serenity-core/src/main/java/net/thucydides/core/webdriver/strategies/InternetExplorerDriverBuilder.java) the IE capabilities are passed to a SafariDriver constructor which doesn't seem right, So a more conventional approach of using [InternetExplorerDriverService](https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/ie/InternetExplorerDriverService.html) builder has been used in this PR instead.
- some Capabilities have been added to overcome frequently reported problems with using the IE driver with Webdriver tests: NATIVE_EVENTS = false, REQUIRE_WINDOW_FOCUS = false.
- a delayed retry has also been added as the IE Driver often fails to create a new IE process and will fail the test 