### PR TITLE
Issue #551: added support for deselecting options

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/DropdownDeselector.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/DropdownDeselector.java
@@ -1,0 +1,53 @@
+package net.serenitybdd.core.pages;
+
+import org.openqa.selenium.support.ui.Select;
+
+class DropdownDeselector {
+
+    private final WebElementFacadeImpl webElementFacade;
+
+    public DropdownDeselector(WebElementFacadeImpl webElementFacade) {
+
+        this.webElementFacade = webElementFacade;
+    }
+
+    public WebElementFacade all() {
+        if (webElementFacade.driverIsDisabled()) { return webElementFacade; }
+
+        webElementFacade.waitUntilElementAvailable();
+        Select select = new Select(webElementFacade.getElement());
+        select.deselectAll();
+        webElementFacade.notifyScreenChange();
+        return webElementFacade;
+    }
+
+    public WebElementFacade byVisibleText(String label) {
+        if (webElementFacade.driverIsDisabled()) { return webElementFacade; }
+
+        webElementFacade.waitUntilElementAvailable();
+        Select select = new Select(webElementFacade.getElement());
+        select.deselectByVisibleText(label);
+        webElementFacade.notifyScreenChange();
+        return webElementFacade;
+    }
+
+    public WebElementFacade byValue(String value) {
+        if (webElementFacade.driverIsDisabled()) { return webElementFacade; }
+        webElementFacade.enableHighlightingIfRequired();
+        webElementFacade.waitUntilElementAvailable();
+        Select select = new Select(webElementFacade.getElement());
+        select.deselectByValue(value);
+        webElementFacade.notifyScreenChange();
+        return webElementFacade;
+    }
+
+    public WebElementFacade byIndex(int indexValue) {
+        if (webElementFacade.driverIsDisabled()) { return webElementFacade; }
+        webElementFacade.enableHighlightingIfRequired();
+        webElementFacade.waitUntilElementAvailable();
+        Select select = new Select(webElementFacade.getElement());
+        select.deselectByIndex(indexValue);
+        webElementFacade.notifyScreenChange();
+        return webElementFacade;
+    }
+}

--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacade.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacade.java
@@ -77,6 +77,14 @@ public interface WebElementFacade extends WebElement, WrapsElement, Locatable, W
 
     public void setWindowFocus();
 
+    public <T extends WebElementFacade> T deselectAll();
+
+    public <T extends WebElementFacade> T deselectByVisibleText(String label);
+
+    public <T extends WebElementFacade> T deselectByValue(String value);
+
+    public <T extends WebElementFacade> T deselectByIndex(int indexValue);
+
     public <T extends WebElementFacade> T selectByVisibleText(String label);
 
     public <T extends WebElementFacade> T selectByValue(String value);

--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
@@ -648,6 +648,30 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
         return new DropdownSelector(this);
     }
 
+    private DropdownDeselector deselect() {
+        return new DropdownDeselector(this);
+    }
+
+    @Override
+    public WebElementFacade deselectAll() {
+        return deselect().all();
+    }
+
+    @Override
+    public WebElementFacade deselectByIndex(int indexValue) {
+        return deselect().byIndex(indexValue);
+    }
+
+    @Override
+    public WebElementFacade deselectByVisibleText(String label) {
+        return deselect().byVisibleText(label);
+    }
+
+    @Override
+    public WebElementFacade deselectByValue(String value) {
+        return deselect().byValue(value);
+    }
+
     @Override
     public WebElementFacade selectByVisibleText(final String label) {
         return select().byVisibleText(label);

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/stubs/WebElementFacadeStub.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/stubs/WebElementFacadeStub.java
@@ -317,6 +317,26 @@ public class WebElementFacadeStub implements WebElementFacade {
     }
 
     @Override
+    public WebElementFacade deselectAll() {
+        return this;
+    }
+
+    @Override
+    public WebElementFacade deselectByVisibleText(String label) {
+        return this;
+    }
+
+    @Override
+    public WebElementFacade deselectByValue(String value) {
+        return this;
+    }
+
+    @Override
+    public WebElementFacade deselectByIndex(int indexValue) {
+        return this;
+    }
+
+    @Override
     public WebElementFacade selectByVisibleText(final String label) {
         return this;
     }
@@ -403,7 +423,7 @@ public class WebElementFacadeStub implements WebElementFacade {
     }
 
     @Override
-    public <T extends WebElementFacade> T waitUntilClickable() {
+    public WebElementFacade waitUntilClickable() {
         return null;
     }
 

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/DeselectFromOptions.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/DeselectFromOptions.java
@@ -1,0 +1,50 @@
+package net.serenitybdd.screenplay.actions;
+
+import net.serenitybdd.screenplay.Performable;
+import net.serenitybdd.screenplay.actions.deselectactions.*;
+import net.serenitybdd.screenplay.targets.Target;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class DeselectFromOptions {
+
+    private final SelectStrategy strategy;
+    private String theText;
+    private Integer indexValue;
+
+    public DeselectFromOptions(SelectStrategy strategy) {
+        this.strategy = strategy;
+    }
+
+    public static DeselectFromOptions byValue(String value) {
+        DeselectFromOptions enterAction = new DeselectFromOptions(SelectStrategy.ByValue);
+        enterAction.theText = value;
+        return enterAction;
+    }
+
+    public static DeselectFromOptions byVisibleText(String value) {
+        DeselectFromOptions enterAction = new DeselectFromOptions(SelectStrategy.ByVisibleText);
+        enterAction.theText = value;
+        return enterAction;
+    }
+
+    public static DeselectFromOptions byIndex(Integer indexValue) {
+        DeselectFromOptions enterAction = new DeselectFromOptions( SelectStrategy.ByIndex);
+        enterAction.indexValue = indexValue;
+        return enterAction;
+    }
+
+    public Performable from(String cssOrXpathForElement) {
+        return from(Target.the(cssOrXpathForElement).locatedBy(cssOrXpathForElement));
+    }
+
+    public Performable from(Target target) {
+        switch (strategy) {
+            case ByValue: return instrumented(DeselectByValueFromTarget.class, target, theText);
+            case ByVisibleText: return instrumented(DeselectByVisibleTextFromTarget.class, target, theText);
+            case ByIndex: return instrumented(DeselectByIndexFromTarget.class, target, indexValue);
+        }
+        throw new IllegalStateException("Unknown select strategy " + strategy);
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/SelectFromOptions.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/SelectFromOptions.java
@@ -6,9 +6,6 @@ import net.serenitybdd.screenplay.actions.selectactions.*;
 import net.serenitybdd.screenplay.targets.Target;
 import org.openqa.selenium.By;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static net.serenitybdd.screenplay.Tasks.instrumented;
 
 public class SelectFromOptions {
@@ -22,21 +19,21 @@ public class SelectFromOptions {
     }
 
     public static SelectFromOptions byValue(String value) {
-        SelectFromOptions enterAction = new SelectFromOptions(SelectStrategy.ByValue);
-        enterAction.theText = value;
-        return enterAction;
+        SelectFromOptions selectFromOptions = new SelectFromOptions(SelectStrategy.ByValue);
+        selectFromOptions.theText = value;
+        return selectFromOptions;
     }
 
     public static SelectFromOptions byVisibleText(String value) {
-        SelectFromOptions enterAction = new SelectFromOptions(SelectStrategy.ByVisibleText);
-        enterAction.theText = value;
-        return enterAction;
+        SelectFromOptions selectFromOptions = new SelectFromOptions(SelectStrategy.ByVisibleText);
+        selectFromOptions.theText = value;
+        return selectFromOptions;
     }
 
     public static SelectFromOptions byIndex(Integer indexValue) {
-        SelectFromOptions enterAction = new SelectFromOptions( SelectStrategy.ByIndex);
-        enterAction.indexValue = indexValue;
-        return enterAction;
+        SelectFromOptions selectFromOptions = new SelectFromOptions( SelectStrategy.ByIndex);
+        selectFromOptions.indexValue = indexValue;
+        return selectFromOptions;
     }
 
     public Performable from(String cssOrXpathForElement) {

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectAllOptions.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectAllOptions.java
@@ -1,0 +1,25 @@
+package net.serenitybdd.screenplay.actions.deselectactions;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.actions.ByAction;
+import net.serenitybdd.screenplay.targets.Target;
+import net.thucydides.core.annotations.Step;
+
+public class DeselectAllOptions extends ByAction {
+
+    private final Target target;
+
+    private DeselectAllOptions(Target target) {
+        this.target = target;
+    }
+
+    public static DeselectAllOptions from(Target target) {
+        return new DeselectAllOptions(target);
+    }
+
+    @Step("{0} deselects all options in #value")
+    public <T extends Actor> void performAs(T theUser) {
+        target.resolveFor(theUser).deselectAll();
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectByIndexFromTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectByIndexFromTarget.java
@@ -1,22 +1,22 @@
-package net.serenitybdd.screenplay.actions.selectactions;
+package net.serenitybdd.screenplay.actions.deselectactions;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Interaction;
 import net.serenitybdd.screenplay.targets.Target;
 import net.thucydides.core.annotations.Step;
 
-public class SelectByIndexFromTarget implements Interaction {
+public class DeselectByIndexFromTarget implements Interaction {
     private final Target target;
     private final Integer index;
 
-    public SelectByIndexFromTarget(Target target, Integer index) {
+    public DeselectByIndexFromTarget(Target target, Integer index) {
         this.target = target;
         this.index = index;
     }
 
-    @Step("{0} selects index #index in #target")
+    @Step("{0} deselects index #index in #target")
     public <T extends Actor> void performAs(T theUser) {
-        target.resolveFor(theUser).selectByIndex(index);
+        target.resolveFor(theUser).deselectByIndex(index);
     }
 
 

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectByValueFromTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectByValueFromTarget.java
@@ -1,23 +1,22 @@
-package net.serenitybdd.screenplay.actions.selectactions;
+package net.serenitybdd.screenplay.actions.deselectactions;
 
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Interaction;
 import net.serenitybdd.screenplay.targets.Target;
 import net.thucydides.core.annotations.Step;
 
-public class SelectByValueFromTarget implements Interaction {
+public class DeselectByValueFromTarget implements Interaction {
     private final Target target;
     private final String value;
 
-    public SelectByValueFromTarget(Target target, String value) {
+    public DeselectByValueFromTarget(Target target, String value) {
         this.target = target;
         this.value = value;
     }
 
-    @Step("{0} selects #value in #target")
+    @Step("{0} deselects #value in #target")
     public <T extends Actor> void performAs(T theUser) {
-        target.resolveFor(theUser).selectByVisibleText(value);
+        target.resolveFor(theUser).deselectByVisibleText(value);
     }
-
 
 }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectByVisibleTextFromTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/deselectactions/DeselectByVisibleTextFromTarget.java
@@ -1,0 +1,22 @@
+package net.serenitybdd.screenplay.actions.deselectactions;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Interaction;
+import net.serenitybdd.screenplay.targets.Target;
+import net.thucydides.core.annotations.Step;
+
+public class DeselectByVisibleTextFromTarget implements Interaction {
+    private final Target target;
+    private final String visibleText;
+
+    public DeselectByVisibleTextFromTarget(Target target, String visibleText) {
+        this.target = target;
+        this.visibleText = visibleText;
+    }
+
+    @Step("{0} deselects #visibleText in #target")
+    public <T extends Actor> void performAs(T theUser) {
+        target.resolveFor(theUser).deselectByVisibleText(visibleText);
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByIndexFromBy.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByIndexFromBy.java
@@ -14,7 +14,7 @@ public class SelectByIndexFromBy extends ByAction {
         this.index = index;
     }
 
-    @Step("{0} clicks on #target")
+    @Step("{0} selects index #index")
     public <T extends Actor> void performAs(T theUser) {
         BrowseTheWeb.as(theUser).find(locators).selectByIndex(index);
     }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByIndexFromElement.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByIndexFromElement.java
@@ -14,7 +14,7 @@ public class SelectByIndexFromElement implements Interaction {
         this.index = index;
     }
 
-    @Step("{0} clicks on #target")
+    @Step("{0} selects index #index")
     public <T extends Actor> void performAs(T theUser) {
         element.selectByIndex(index);
     }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByValueFromBy.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByValueFromBy.java
@@ -14,7 +14,7 @@ public class SelectByValueFromBy extends ByAction {
         this.value = value;
     }
 
-    @Step("{0} clicks on #target")
+    @Step("{0} selects #value in #target")
     public <T extends Actor> void performAs(T theUser) {
         BrowseTheWeb.as(theUser).find(locators).selectByValue(value);
     }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByValueFromElement.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByValueFromElement.java
@@ -14,9 +14,9 @@ public class SelectByValueFromElement implements Interaction {
         this.value = value;
     }
 
-    @Step("{0} clicks on #target")
+    @Step("{0} selects #value in #target")
     public <T extends Actor> void performAs(T theUser) {
-        element.selectByVisibleText(value);
+        element.selectByValue(value);
     }
 
 

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByVisibleTextFromBy.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByVisibleTextFromBy.java
@@ -14,7 +14,7 @@ public class SelectByVisibleTextFromBy extends ByAction {
         this.visibleText = visibleText;
     }
 
-    @Step("{0} clicks on #target")
+    @Step("{0} selects #visibleText")
     public <T extends Actor> void performAs(T theUser) {
         BrowseTheWeb.as(theUser).find(locators).selectByVisibleText(visibleText);
     }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByVisibleTextFromElement.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/selectactions/SelectByVisibleTextFromElement.java
@@ -14,7 +14,7 @@ public class SelectByVisibleTextFromElement implements Interaction {
         this.visibleText = visibleText;
     }
 
-    @Step("{0} clicks on #target")
+    @Step("{0} selects #visibleText")
     public <T extends Actor> void performAs(T theUser) {
         element.selectByVisibleText(visibleText);
     }

--- a/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/WhenDanaSelectsHerContactPreferences.java
+++ b/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/WhenDanaSelectsHerContactPreferences.java
@@ -1,0 +1,80 @@
+package net.serenitybdd.screenplay.webtests;
+
+import net.serenitybdd.junit.runners.SerenityRunner;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.serenitybdd.screenplay.webtests.questions.ContactPreferences;
+import net.serenitybdd.screenplay.webtests.tasks.*;
+import net.thucydides.core.annotations.Managed;
+import net.thucydides.core.annotations.Steps;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+import static net.serenitybdd.screenplay.GivenWhenThen.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+
+@RunWith(SerenityRunner.class)
+public class WhenDanaSelectsHerContactPreferences {
+
+    @Managed(driver = "htmlunit")
+    WebDriver firstBrowser;
+
+    @Test
+    public void danaCanSelectAdditionalContactPreferences() {
+
+        Actor dana = new Actor("Dana");
+        dana.can(BrowseTheWeb.with(firstBrowser));
+
+        givenThat(dana).has(openedTheApplication);
+
+        when(dana).attemptsTo(viewedHerProfile);
+        then(dana).should(seeThat(ContactPreferences.nowSelected(), hasItems("Email", "Post")));
+
+        and(dana).attemptsTo(SelectContactPreference.withText("SMS Message"));
+
+        then(dana).should(seeThat(ContactPreferences.nowSelected(), hasItems("Email", "Post", "SMS Message")));
+    }
+
+    @Test
+    public void danaCanDeselectExistingContactPreferences() {
+
+        Actor dana = new Actor("Dana");
+        dana.can(BrowseTheWeb.with(firstBrowser));
+
+        givenThat(dana).has(openedTheApplication);
+
+        when(dana).attemptsTo(viewedHerProfile);
+        then(dana).should(seeThat(ContactPreferences.nowSelected(), hasItems("Email", "Post")));
+
+        when(dana).attemptsTo(DeselectContactPreference.withText("Email"));
+        then(dana).should(seeThat(ContactPreferences.nowSelected(), hasItems("Post")));
+    }
+
+    @Test
+    public void danaCanDeselectAllContactPreferences() {
+
+        Actor dana = new Actor("Dana");
+        dana.can(BrowseTheWeb.with(firstBrowser));
+
+        givenThat(dana).has(openedTheApplication);
+
+        when(dana).attemptsTo(viewedHerProfile);
+        then(dana).should(seeThat(ContactPreferences.nowSelected(), hasItems("Email", "Post")));
+
+        when(dana).attemptsTo(DeselectAll.contactPreferences());
+        then(dana).should(seeThat(ContactPreferences.nowSelected(), empty()));
+    }
+
+
+    @Steps
+    OpenTheApplication openedTheApplication;
+
+    @Steps
+    LegacyViewMyProfile viewHerOldProfile;
+
+    @Steps
+    ViewMyProfile viewedHerProfile;
+
+}

--- a/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/pages/ProfilePage.java
+++ b/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/pages/ProfilePage.java
@@ -5,13 +5,15 @@ import net.serenitybdd.core.pages.PageObject;
 import net.serenitybdd.screenplay.targets.Target;
 
 public class ProfilePage extends PageObject {
-    // Journey-pattern selectors
+
+    // Screenplay selectors
     public static Target NAME = Target.the("Name").locatedBy("#name");
     public static Target COUNTRY = Target.the("Country of residence").located(By.cssSelector("#country"));
     public static Target COLOR = Target.the("Favorite Color").locatedBy("#color");
     public static Target DATE_OF_BIRTH = Target.the("Date of Birth").locatedBy("#dob");
+    public static Target CONTACT_PREFERENCES = Target.the("Contact Preferences").locatedBy("#contactPreferances");
 
-    // Illulstrations of classic page object methods
+    // Illustrations of classic page object methods
 
     public void updateNameTo(String name) {
         $("#name").type(name);

--- a/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/questions/ContactPreferences.java
+++ b/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/questions/ContactPreferences.java
@@ -1,0 +1,22 @@
+package net.serenitybdd.screenplay.webtests.questions;
+
+import net.serenitybdd.core.pages.WebElementFacade;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.serenitybdd.screenplay.webtests.pages.ProfilePage;
+
+import java.util.Set;
+
+public class ContactPreferences {
+
+    public static Question<Set<String>> nowSelected() {
+        return new Question<Set<String>>() {
+            @Override
+            public Set<String> answeredBy(Actor actor) {
+                WebElementFacade webElementFacade = ProfilePage.CONTACT_PREFERENCES.resolveFor(actor);
+                return BrowseTheWeb.as(actor).getSelectedOptionLabelsFrom(webElementFacade);
+            }
+        };
+    }
+}

--- a/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/tasks/DeselectAll.java
+++ b/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/tasks/DeselectAll.java
@@ -1,0 +1,21 @@
+package net.serenitybdd.screenplay.webtests.tasks;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Performable;
+import net.serenitybdd.screenplay.actions.deselectactions.DeselectAllOptions;
+import net.thucydides.core.annotations.Step;
+
+import static net.serenitybdd.screenplay.webtests.pages.ProfilePage.CONTACT_PREFERENCES;
+
+public class DeselectAll implements Performable {
+
+    public static DeselectAll contactPreferences() {
+        return new DeselectAll();
+    }
+
+    @Step("{0} deselects all options from #CONTACT_PREFERENCES")
+    public <T extends Actor> void performAs(T theUser) {
+        theUser.attemptsTo(DeselectAllOptions.from(CONTACT_PREFERENCES));
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/tasks/DeselectContactPreference.java
+++ b/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/tasks/DeselectContactPreference.java
@@ -1,0 +1,27 @@
+package net.serenitybdd.screenplay.webtests.tasks;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Performable;
+import net.serenitybdd.screenplay.actions.DeselectFromOptions;
+import net.thucydides.core.annotations.*;
+
+import static net.serenitybdd.screenplay.webtests.pages.ProfilePage.*;
+
+public class DeselectContactPreference implements Performable {
+
+    private final String existingValue;
+
+    private DeselectContactPreference(String existingValue) {
+        this.existingValue = existingValue;
+    }
+
+    public static DeselectContactPreference withText(String existingValue) {
+        return new DeselectContactPreference(existingValue);
+    }
+
+    @Step("{0} deselects #existingValue from #CONTACT_PREFERENCES")
+    public <T extends Actor> void performAs(T theUser) {
+        theUser.attemptsTo(DeselectFromOptions.byVisibleText(existingValue).from(CONTACT_PREFERENCES));
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/tasks/SelectContactPreference.java
+++ b/serenity-screenplay-webdriver/src/test/java/net/serenitybdd/screenplay/webtests/tasks/SelectContactPreference.java
@@ -1,0 +1,26 @@
+package net.serenitybdd.screenplay.webtests.tasks;
+
+import net.serenitybdd.screenplay.*;
+import net.serenitybdd.screenplay.actions.*;
+import net.thucydides.core.annotations.*;
+
+import static net.serenitybdd.screenplay.webtests.pages.ProfilePage.*;
+
+public class SelectContactPreference implements Performable {
+
+    final String value;
+
+    private SelectContactPreference(String value) {
+        this.value = value;
+    }
+
+    public static SelectContactPreference withText(String value) {
+        return new SelectContactPreference(value);
+    }
+
+    @Step("{0} selects #value from #CONTACT_PREFERENCES")
+    public <T extends Actor> void performAs(T theUser) {
+        theUser.attemptsTo(SelectFromOptions.byVisibleText(value).from(CONTACT_PREFERENCES));
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/test/resources/sample-web-site/profile.html
+++ b/serenity-screenplay-webdriver/src/test/resources/sample-web-site/profile.html
@@ -33,6 +33,15 @@
     </div>
 
     <div>
+        Contact Preferences:
+        <select id="contactPreferances" multiple>
+            <option selected value="EMAIL">Email</option>
+            <option selected value="POST">Post</option>
+            <option value="SMS">SMS Message</option>
+        </select>
+    </div>
+
+    <div>
         Bank Account:
         <p>BSB: <input id="bsb"></p>
         <p>Account Name: <input id="accountName"></p>


### PR DESCRIPTION
**Issue #551: added support for deselecting options**

There didn't seem to be a screenplay way to deselect options either in screenplay or core modules, so this PR adds to `WebElementFacade`:
- `deselectAll()` - often needed when we want to start off input with a 'clean slate' on a muli-select element.
- `deselectByVisibleText()`, `deselectByValue()`, `deselectByIndex()` - mirrors of the methods implemented for `Select`.

The following deselect actions were created in the screenplay webdriver module:
- `DeselectByIndexFromTarget`
- `DeselectByValueFromTarget`
- `DeselectByVisibleTextFromTarget`

The above were only created for Target as my assumption is that we should not be encouraging people to be working directly with `By` or `Element` and it ends up conflating the api anyway.

**Note**: I've also updated some of the  `@Step` annotations on `Select` as these lacked descriptiveness.