### PR TITLE
#612: Apply user properties to recommended Internet Explorer defaults

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/InternetExplorerDriverProvider.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/InternetExplorerDriverProvider.java
@@ -45,9 +45,7 @@ public class InternetExplorerDriverProvider implements DriverProvider {
             return new WebDriverStub();
         }
 
-        DesiredCapabilities desiredCapabilities = enhancer.enhanced(DesiredCapabilities.internetExplorer());
-        addInternetExplorerCapabilitiesTo(desiredCapabilities);
-
+        DesiredCapabilities desiredCapabilities = enhancer.enhanced(recommendedDefaultInternetExplorerCapabilities());
         driverProperties.registerCapabilities("iexplorer", desiredCapabilities);
 
         try {
@@ -82,11 +80,13 @@ public class InternetExplorerDriverProvider implements DriverProvider {
         }
     }
 
-    private void addInternetExplorerCapabilitiesTo(DesiredCapabilities browserCapabilities) {
-        browserCapabilities.setCapability(InternetExplorerDriver.IGNORE_ZOOM_SETTING, true);
-        browserCapabilities.setCapability(InternetExplorerDriver.NATIVE_EVENTS, false);
-        browserCapabilities.setCapability(InternetExplorerDriver.REQUIRE_WINDOW_FOCUS, false);
-        browserCapabilities.setJavascriptEnabled(true);
-        browserCapabilities.setCapability(CapabilityType.TAKES_SCREENSHOT, true);
+    private DesiredCapabilities recommendedDefaultInternetExplorerCapabilities() {
+        DesiredCapabilities defaults = DesiredCapabilities.internetExplorer();
+        defaults.setCapability(InternetExplorerDriver.IGNORE_ZOOM_SETTING, true);
+        defaults.setCapability(InternetExplorerDriver.NATIVE_EVENTS, false);
+        defaults.setCapability(InternetExplorerDriver.REQUIRE_WINDOW_FOCUS, false);
+        defaults.setCapability(CapabilityType.TAKES_SCREENSHOT, true);
+        defaults.setJavascriptEnabled(true);
+        return defaults;
     }
 }


### PR DESCRIPTION
#612: Apply user properties to recommended default Internet Explorer capabilities, not the other way around
- Prior to this PR, the user properties containing driver capabilities e.g. `serenity.driver.capabilities=unexpectedAlertBehavior:ignore;ie.ensureCleanSession:true;logLevel:INFO;logFile:target/ie.log` were used as a basis for capability creation, but then they were overidden with sensible defaults in InternetExplorerDriverProvider. This seems back to front as the user properties should always be last in the order of resolution, so the order has now been changed to reflect that.