### PR TITLE
Ability to use SerenityRest from a plain JUnit runner, issue #695

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationDecorated.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationDecorated.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static com.jayway.restassured.internal.assertion.AssertParameter.notNull;
 import static net.serenitybdd.core.rest.RestMethod.*;
+import static net.thucydides.core.steps.StepEventBus.getEventBus;
 
 /**
  * User: YamStranger
@@ -252,9 +253,15 @@ public class RequestSpecificationDecorated extends RequestSpecificationAdvancedC
             } else {
                 response = stubbed();
             }
-            reporting.registerCall(method, this, path, exception, pathParams);
-        } else {
+            if (getEventBus().isBaseStepListenerRegistered()) {
+                reporting.registerCall(method, this, path, exception, pathParams);
+            } else {
+                log.info("No BaseStepListener, {} {} not registered.", method.toString(), path);
+            }
+        } else if (getEventBus().isBaseStepListenerRegistered()) {
             reporting.registerCall(method, response, this, path, pathParams);
+        } else {
+            log.info("No BaseStepListener, {} {} not registered.", method.toString(), path);
         }
         this.lastResponse = response;
         return response;

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenRunningRestTestsThroughJUnitWithoutSerenity.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenRunningRestTestsThroughJUnitWithoutSerenity.groovy
@@ -1,0 +1,81 @@
+package net.serenitybdd.rest
+
+import com.github.tomakehurst.wiremock.http.Fault
+import com.github.tomakehurst.wiremock.junit.WireMockRule
+import org.junit.Rule
+import spock.lang.Specification
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+import static net.serenitybdd.rest.SerenityRest.rest
+
+class WhenRunningRestTestsThroughJUnitWithoutSerenity extends Specification {
+    @Rule
+    WireMockRule wire = new WireMockRule(0)
+
+    def "Should allow RestAssured get() method calls without throwing NPE"() {
+        given:
+            def base = "http://localhost:${wire.port()}"
+            def path = "/test/number"
+            def url = "$base$path"
+
+            stubFor(get(urlEqualTo(path))
+                .withRequestBody(matching(".*"))
+                .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("test response")))
+        when:
+            def result = rest().get(url).then()
+        then: "there should be no NPE with message 'No BaseStepListener has been registered' thrown"
+            notThrown NullPointerException
+        and:
+            result.statusCode(200)
+    }
+
+    def "Should allow RestAssured post() method calls without throwing NPE"() {
+        given:
+            def base = "http://localhost:${wire.port()}"
+            def path = "/test/number"
+            def url = "$base$path"
+
+            stubFor(post(urlEqualTo(path))
+                .withRequestBody(matching(".*"))
+                .willReturn(aResponse()
+                .withStatus(500)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("test error response")))
+        when:
+            def result = rest().post(url).then()
+        then: "there should be no NPE with message 'No BaseStepListener has been registered' thrown"
+            notThrown NullPointerException
+        and:
+            result.statusCode(500)
+    }
+
+    def "Should allow RestAssured put() method calls without throwing NPE"() {
+        given:
+            def base = "http://localhost:${wire.port()}"
+            def path = "/test/number"
+            def url = "$base$path"
+
+            stubFor(post(urlEqualTo(path))
+                .withRequestBody(matching(".*"))
+                .willReturn(aResponse()
+                .withFault(Fault.RANDOM_DATA_THEN_CLOSE)))
+        when:
+            def result = rest().put(url).then()
+        then: "there should be no NPE with message 'No BaseStepListener has been registered' thrown"
+            notThrown NullPointerException
+        and:
+            result.statusCode(404)
+    }
+
+    def "Should allow RestAssured delete() method calls to an invalid URL without throwing NPE"() {
+        given:
+            def url = "this is not a valid url"
+        when:
+            rest().delete(url).then()
+        then: "there should be no NPE with message 'No BaseStepListener has been registered' thrown"
+            notThrown NullPointerException
+    }
+}

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenRunningRestTestsWithoutSerenity.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenRunningRestTestsWithoutSerenity.groovy
@@ -8,7 +8,7 @@ import spock.lang.Specification
 import static com.github.tomakehurst.wiremock.client.WireMock.*
 import static net.serenitybdd.rest.SerenityRest.rest
 
-class WhenRunningRestTestsThroughJUnitWithoutSerenity extends Specification {
+class WhenRunningRestTestsWithoutSerenity extends Specification {
     @Rule
     WireMockRule wire = new WireMockRule(0)
 


### PR DESCRIPTION
#### Summary of this PR
It allows to use SerenityRest without a proper setup of Serenity, particularly without any BaseStepListener registered.
The above makes possible to share test code between Serenity tests and plain JUnit tests. No need to implement the same in SerenityRest and in Rest Assured.

#### Intended effect
It only tries to register rest calls if a BaseStepListener is registered (which is the expected state while running SerenityRest code with Serenity runners). It logs an info message otherwise (expected behaviour while running SerenityRest code from non-Serenity runners, e.g. plain JUnit).
 
#### How should this be manually tested?
Run any SerenityRest code, e.g. rest().get("http://github.com"), from a plain JUnit test.

#### Side effects
A NullPointerException (with "No BaseStepListener has been registered" message) is not thrown when running tests which uses SerenityRest from a non-Serenity runner.

#### Documentation

#### Relevant tickets
#695
