### PR TITLE
Disable marionette by default, 

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/FirefoxDriverProvider.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/FirefoxDriverProvider.java
@@ -65,6 +65,7 @@ public class FirefoxDriverProvider implements DriverProvider {
     }
 
     private WebDriver newFirefoxDriver(DesiredCapabilities capabilities) {
+        capabilities.setCapability("marionette", false);
         return new FirefoxDriver(enhancer.enhanced(capabilities));
     }
 


### PR DESCRIPTION
to allow drop in compatibility with Selenium 3 until Geckodriver is stable.  

Untested, and may be better ways of implementing.