### PR TITLE
feat: #783 - add Described Task for dynamic test expression

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/described/DescribedTask.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/described/DescribedTask.java
@@ -1,0 +1,37 @@
+package net.serenitybdd.screenplay.described;
+
+import net.serenitybdd.screenplay.Performable;
+import net.serenitybdd.screenplay.Task;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class DescribedTask {
+
+    private RunStep.StepType stepType;
+    private final String taskDescription;
+
+    private DescribedTask(RunStep.StepType stepType, String taskDescription) {
+        this.stepType = stepType;
+        this.taskDescription = taskDescription;
+    }
+
+    public static DescribedTask using(RunStep.StepType stepType, String taskDescription) {
+        return new DescribedTask(stepType, taskDescription);
+    }
+
+    public Task tasksAreRun(Performable... tasks) {
+        return instrumented(DescribedTaskRunner.class, stepType, taskDescription, tasks);
+    }
+
+    public Task taskIsRun(Performable task) {
+        return tasksAreRun(task);
+    }
+
+    public Performable runTasks(Performable... tasks) {
+        return tasksAreRun(tasks);
+    }
+
+    public Performable runTask(Performable tasks) {
+        return tasksAreRun(tasks);
+    }
+}

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/described/DescribedTaskRunner.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/described/DescribedTaskRunner.java
@@ -1,0 +1,28 @@
+package net.serenitybdd.screenplay.described;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Performable;
+import net.serenitybdd.screenplay.Task;
+import net.thucydides.core.annotations.Step;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DescribedTaskRunner implements Task {
+
+    static final Logger LOGGER = LoggerFactory.getLogger(DescribedTaskRunner.class);
+    private final String taskDescription;
+    private Performable[] performTasks;
+
+    public DescribedTaskRunner(RunStep.StepType stepType, String taskDescription, Performable... performTasks) {
+        this.taskDescription = stepType + " " + taskDescription;
+        this.performTasks = performTasks;
+    }
+
+    @Override
+    @Step("#taskDescription")
+    public <T extends Actor> void performAs(T actor) {
+        LOGGER.debug(taskDescription);
+        actor.attemptsTo(performTasks);
+    }
+
+}

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/described/RunStep.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/described/RunStep.java
@@ -1,0 +1,38 @@
+
+package net.serenitybdd.screenplay.described;
+
+import static net.serenitybdd.screenplay.described.RunStep.StepType.AND;
+import static net.serenitybdd.screenplay.described.RunStep.StepType.GIVEN;
+import static net.serenitybdd.screenplay.described.RunStep.StepType.THEN;
+import static net.serenitybdd.screenplay.described.RunStep.StepType.WHEN;
+import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
+
+public class RunStep {
+
+    enum StepType {
+
+        GIVEN, WHEN, THEN, AND;
+
+        @Override
+        public String toString() {
+            return  capitalizeFully(name().replace("_", " ").toLowerCase());
+        }
+    }
+
+    public static DescribedTask given(String taskDescription) {
+        return DescribedTask.using(GIVEN, taskDescription);
+    }
+
+    public static DescribedTask and(String taskDescription) {
+        return DescribedTask.using(AND, taskDescription);
+    }
+
+    public static DescribedTask when(String taskDescription) {
+        return DescribedTask.using(WHEN, taskDescription);
+    }
+
+    public static DescribedTask then(String taskDescription) {
+        return DescribedTask.using(THEN, taskDescription);
+    }
+
+}


### PR DESCRIPTION
I've found on my projects that I want to be able to express steps using a very close vocabulary to the BAs or Product owners. This then allows them to very clearly relate the originally agreed acceptance criteria language to what was eventually implemented. In order to do this with 'vanilla' screenplay requires (AFAIK) me to create a separate `Interaction` class with the appropriate `@Step` description. This is quite labour intensive and actually creates an undesirable level of indirection to the reader of the `@Test`. I would prefer to write this description inside the feature file so that it's very easy to see how the final report will look. 

To this effect I've created in this PR a `DescribedTask` which allows a description to be passed prepended with a StepType (GIVEN, WHEN, THEN, AND) which then produces exactly the right looking report. The Step type is needed because the Serenity reporter doesn't seem to take note of the `givenThat(), when(), then()` sugar around the actor. 

Here is an example of the `DescribedTask` being used on some of the steps in my feature:

![image](https://cloud.githubusercontent.com/assets/626941/25891897/8d94cc24-356a-11e7-9865-54ab3f8a9a00.png)

In the above example, without the described task, the first step would have rendered in the report as 6 top level steps which creates quite a lot of noise for the reader trying to glean the 'essentials' of the scenario.