### PR TITLE
Step multiple implementation annotation

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reflection/MethodFinder.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reflection/MethodFinder.java
@@ -47,4 +47,19 @@ public class MethodFinder {
         }
         return methodFound;
     }
+
+    public Method getMethodNamed(String methodName, int argumentCount) {
+        List<Method> methods = getAllMethods();
+        Method methodFound = null;
+        for (Method method : methods) {
+            if (method.getName().equals(methodName)) {
+                methodFound = method;
+                if (method.getParameterTypes().length == argumentCount){
+                    methodFound = method;
+                    break;
+                }
+            }
+        }
+        return methodFound;
+    }
 }

--- a/serenity-core/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
@@ -64,14 +64,14 @@ public final class AnnotatedStepDescription {
 
     public Method getTestMethod() {
         if (getTestClass() != null) {
-            return methodCalled(withNoArguments(description.getName()), getTestClass());
+            return methodCalled(description, getTestClass());
         } else {
             return null;
         }
     }
 
     public Method getTestMethodIfPresent() {
-        return findMethodCalled(withNoArguments(description.getName()), getTestClass());
+        return findMethodCalled(description, getTestClass());
     }
 
     private String withNoArguments(final String methodName) {
@@ -96,7 +96,7 @@ public final class AnnotatedStepDescription {
         return description.getStepClass();
     }
 
-    private Method methodCalled(final String methodName, final Class<?> testClass) {
+    private Method methodCalled(final ExecutedStepDescription methodName, final Class<?> testClass) {
         Method methodFound = findMethodCalled(methodName, testClass);
         if (methodFound == null) {
             throw new IllegalArgumentException("No test method called " + methodName + " was found in " + testClass);
@@ -104,8 +104,8 @@ public final class AnnotatedStepDescription {
         return methodFound;
     }
 
-    private Method findMethodCalled(final String methodName, final Class<?> testClass) {
-        return MethodFinder.inClass(testClass).getMethodNamed(methodName);
+    private Method findMethodCalled(final ExecutedStepDescription method, final Class<?> testClass) {
+        return MethodFinder.inClass(testClass).getMethodNamed(withNoArguments(method.getName()), method.getArguments().size());
     }
 
     public String getAnnotatedTitle() {

--- a/serenity-core/src/test/java/net/thucydides/core/steps/WhenDescribingStepsUsingAnnotations.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/WhenDescribingStepsUsingAnnotations.java
@@ -53,8 +53,12 @@ public class WhenDescribingStepsUsingAnnotations {
         @Step("a step with a parameter called '{0}'")
         public void a_customized_step_with_parameters(String name) {}
 
+        @Step("a step with first parameter called '{0}' and second parameter called '{1}'")
+        public void a_customized_step_with_parameters(String first, String second) {}
+
         @Step("a step with a parameter called '{0}' and a field called #color")
         public void a_customized_step_with_parameters_and_fields(String name) {}
+
 
         @Step("a step with a parameter called '{0}' and a field called #emptyField")
         public void a_customized_step_with_parameters_and_empty_field_value(String name) {}
@@ -129,7 +133,6 @@ public class WhenDescribingStepsUsingAnnotations {
         assertThat(annotatedStepDescription.getName(), is("A step group with an annotation"));
     }
 
-
     @Test
     public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_a_parameter() {
         ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
@@ -139,6 +142,17 @@ public class WhenDescribingStepsUsingAnnotations {
         AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
 
         assertThat(annotatedStepDescription.getName(), is("a step with a parameter called 'Joe'"));
+    }
+
+    @Test
+    public void a_step_can_be_annotated_to_provide_a_more_readable_name_including_multiple_parameters() {
+        ExecutedStepDescription description = ExecutedStepDescription.of(SampleTestSteps.class,
+                "a_customized_step_with_parameters: Joe, Doe",
+                new Object[]{"Joe", "Doe"});
+
+        AnnotatedStepDescription annotatedStepDescription = AnnotatedStepDescription.from(description);
+
+        assertThat(annotatedStepDescription.getName(), is("a step with first parameter called 'Joe' and second parameter called 'Doe'"));
     }
 
     @Test


### PR DESCRIPTION
This is a fix for  #713
We need to check if we have multiple methods with the same name and use the one with the correct number of arguments.