### PR TITLE
Reove extra'.' for capability getPreparedPropertyKey

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/AddCustomCapabilities.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/AddCustomCapabilities.java
@@ -48,7 +48,7 @@ public class AddCustomCapabilities {
     }
 
     private String getPreparedPropertyKey(String propertyKey) {
-        String shortenedPropertyKey = propertyKey.replace(prefix + ".","");
+        String shortenedPropertyKey = propertyKey.replace(prefix,"");
         if (shortenedPropertyKey.equals("os.version")) {
             return "os_version";
         } else if (shortenedPropertyKey.equals("browser.version")) {


### PR DESCRIPTION
This is a fix for: #781

We call this method with: ["browserstack."](https://github.com/bebef1987/serenity-core/blob/077dbc9174f64c78f32e759598305058f7098d8c/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/BrowserStackRemoteDriverCapabilities.java#L47) and then add a extra '.' 

In the split we will have something like: remove browserstack.. from browserstack.build

This method will have no effect.



And add