### PR TITLE
Fix #846 Test Name is not sent to Browserstack

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/RemoteTestName.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/RemoteTestName.java
@@ -20,7 +20,6 @@ class RemoteTestName {
                     return Optional.of(NameConverter.humanize(callingClass.getSimpleName()));
                 }
             } catch (ClassNotFoundException | NoSuchMethodException e) {
-                return Optional.empty();
             }
         }
         return Optional.empty();


### PR DESCRIPTION
This is a fix for #846 Test Name is not sent to Browserstack

Some of the methods in the stacktrace will return exception when calling `callingClass.getMethod(elt.getMethodName());` but when we reach the targeted method will return a valdi result.
Ignoring the exceptions will generate the desired result