### PR TITLE
feat: Expand references to environment variables and system propertiesin serenity.conf & serenity.properties.

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/PropertiesFileLocalPreferences.java
@@ -6,6 +6,7 @@ import com.typesafe.config.ConfigValue;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.configuration.SystemPropertiesConfiguration;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,11 +14,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Enumeration;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import static java.util.regex.Pattern.compile;
 import static org.apache.commons.lang3.StringUtils.strip;
 
 /**
@@ -100,10 +100,10 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
         }
         return properties;
     }
-
-
+    
     private void updatePreferencesFrom(Properties... propertySets) throws IOException {
         for (Properties localPreferences : propertySets) {
+            PropertiesUtil.expandPropertyAndEnvironmentReferences(System.getenv(), localPreferences);
             setUndefinedSystemPropertiesFrom(localPreferences);
         }
     }
@@ -173,5 +173,6 @@ public class PropertiesFileLocalPreferences implements LocalPreferences {
     private String legacyPropertiesFileName() {
         return ThucydidesSystemProperty.PROPERTIES.from(environmentVariables, "thucydides.properties");
     }
+
 
 }

--- a/serenity-core/src/main/java/net/thucydides/core/util/PropertiesUtil.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/PropertiesUtil.java
@@ -1,6 +1,10 @@
 package net.thucydides.core.util;
 
+import org.apache.commons.lang3.text.StrSubstitutor;
+
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 public class PropertiesUtil {
     public static Properties copyOf(Properties sourceProperties) {
@@ -11,5 +15,17 @@ public class PropertiesUtil {
             }
         }
         return copiedProperties;
+    }
+
+    public static void expandPropertyAndEnvironmentReferences(Map<String, String> runnerEnvironmentVariables,Properties properties) {
+        Set<String> names = properties.stringPropertyNames();
+        for (String name : names) {
+            String value = properties.getProperty(name);
+            // Replace System Property References ${sys.property.any}
+            String expandedValue = StrSubstitutor.replaceSystemProperties(value);
+            // Replace Environment  References ${A_DEFINED_ENVIRONMENT_VARIABLE}
+            expandedValue = StrSubstitutor.replace(expandedValue, runnerEnvironmentVariables);
+            properties.setProperty(name, expandedValue);
+        }
     }
 }

--- a/serenity-core/src/test/groovy/net/serenitybdd/core/WhenSettingSerenitySystemProperties.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/WhenSettingSerenitySystemProperties.groovy
@@ -42,7 +42,6 @@ class WhenSettingSerenitySystemProperties extends Specification{
             ThucydidesSystemProperty.THUCYDIDES_BATCH_SIZE.integerFrom(environmentVariables,0) == 4
     }
 
-
     def "serenity.* system properties should take priority over legacy thuycydides.* ones"() {
         given:
             def environmentVariables = new MockEnvironmentVariables()
@@ -52,6 +51,4 @@ class WhenSettingSerenitySystemProperties extends Specification{
         then:
             ThucydidesSystemProperty.THUCYDIDES_TAKE_SCREENSHOTS.from(environmentVariables) == "FOR_EACH_ACTION"
     }
-
-
 }

--- a/serenity-core/src/test/java/net/thucydides/core/util/WhenProcessingProperties.java
+++ b/serenity-core/src/test/java/net/thucydides/core/util/WhenProcessingProperties.java
@@ -1,0 +1,38 @@
+package net.thucydides.core.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class WhenProcessingProperties {
+
+	@Test
+	public void environment_variables_references_are_expanded() {
+        Properties properties = new Properties();
+        properties.setProperty("serenity.outputDirectory", "${CUSTOM_ENVIRONMENT_VARIABLE}");
+        Map<String,String> environment_variables = new HashMap<String,String>();
+        environment_variables.put("CUSTOM_ENVIRONMENT_VARIABLE", "/custom/folder/reports");
+
+        PropertiesUtil.expandPropertyAndEnvironmentReferences(environment_variables, properties);
+
+        assertThat(properties.get("serenity.outputDirectory"), is("/custom/folder/reports"));
+	}
+
+    @Test
+    public void system_properties_references_are_expanded() {
+        Properties properties = new Properties();
+        properties.setProperty("serenity.outputDirectory", "${custom.system.property}");
+        System.setProperty("custom.system.property", "/custom/folder/reports");
+
+        PropertiesUtil.expandPropertyAndEnvironmentReferences(new HashMap<>(), properties);
+
+        assertThat(properties.get("serenity.outputDirectory"), is("/custom/folder/reports"));
+    }
+}


### PR DESCRIPTION
Environment variables can be references using ${AN_ENVIRONMENT_VARIABLE} and System Properties using ${system.property.example}.