### PR TITLE
add method with TestOutcomes, in a listener to generate reports

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestFullReporter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/AcceptanceTestFullReporter.java
@@ -1,0 +1,36 @@
+package net.thucydides.core.reports;
+
+import com.google.common.base.Optional;
+import net.thucydides.core.model.TestOutcome;
+
+import java.io.File;
+import java.io.IOException;
+
+public interface AcceptanceTestFullReporter {
+
+    /**
+     * A name used to identify a given reporter.
+     */
+    String getName();
+
+    /**
+     * Return the format that this reporter generates, if it is a format that can be activated or deactivated
+     * via the output.formats configuration property.
+     */
+    Optional<OutcomeFormat> getFormat();
+
+    /**
+     * Define the output directory in which the reports will be written.
+     */
+    void setOutputDirectory(final File outputDirectory);
+
+    /**
+     * Optional. Used to distinguish the report generated from other similar reports.
+     */
+    void setQualifier(final String qualifier);
+
+    /**
+     * Generate reports for a given acceptance test run.
+     */
+    void generateReportsFor(final TestOutcomes testOutcomes) throws IOException;
+}


### PR DESCRIPTION
Hi!

We are testing with Cucumber features. And we want to generate reports like JUnit, with the tag 

> "\<testsuites name=...>"


 with the attribute "name", the name of the feature, and where every scenario is a testsuite tag, and every step a testCase... 

But this can not be done with the current AcceptanceTestReporter as it sends a **TestOutcome** but not the **TestOutcomes**.

This new AcceptanceTestFullReporter (maybe you can find a better name!) can execute 
"_generateReportsFor(final TestOutcomes testOutcomes)_" (as done in **JUnitXMLOutcomeReporter**...)


