### PR TITLE
refactoring as per appium driver related changes

### DIFF
--- a/serenity-appium/README.md
+++ b/serenity-appium/README.md
@@ -1,3 +1,6 @@
+### Running in Sauce Labs ###
+mvn surefire:test -Dtest=WordPressAppTest -Dsaucelabs.url=http://**sauceId**:**sauceKey**@ondemand.saucelabs.com:80/wd/hub -Dsaucelabs.access.key=**sauceKey** -Dsaucelabs.user.id=**sauceId**
+
 
 ### Before Run ###
 

--- a/serenity-appium/pom.xml
+++ b/serenity-appium/pom.xml
@@ -12,9 +12,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>1.6.3</serenity.version>
-        <serenity.cucumber.version>1.5.10</serenity.cucumber.version>
-        <serenity.maven.version>1.6.0</serenity.maven.version>
+        <serenity.version>1.7.4</serenity.version>
+        <serenity.cucumber.version>1.6.3</serenity.cucumber.version>
+        <serenity.maven.version>1.7.4</serenity.maven.version>
     </properties>
 
     <repositories>

--- a/serenity-appium/serenity.properties
+++ b/serenity-appium/serenity.properties
@@ -1,8 +1,17 @@
 webdriver.driver= appium
-appium.hub = http://localhost:4723/wd/hub
+#appium.hub = http://localhost:4723/wd/hub
+saucelabs.test.name=AppiumWordPressWithSauce
+saucelabs.target.platform=Mac
+
+##### Running From IDE ####
+#saucelabs.url=http://<sauce_username>:<sauce_access_key>@ondemand.saucelabs.com:80/wd/hub
+#saucelabs.user.id=<sauce_username>
+#saucelabs.access.key=<sauce_access_key>
+
 ####### iOS CAPS ######
 appium.automationName = XCUITest
 appium.platformName=IOS
-appium.platformVersion = 10.3
+appium.platformVersion = 11.0
 appium.deviceName  = iPhone 7
 #appium.app = FULL_PATH/serenity-core/serenity-appium/src/test/java/integration/resources/WordPress.app
+appium.app = sauce-storage:WordPress.zip

--- a/serenity-appium/src/test/java/integration/WordPressAppTest.java
+++ b/serenity-appium/src/test/java/integration/WordPressAppTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import integration.serenitySteps.WordPressLoginSteps;
 
+//@RunWith(SerenityRunner.class)
 @RunWith(CucumberWithSerenity.class)
 @CucumberOptions(features="src/test/java/integration/resources/features/invalid_login.feature" , plugin = {"json:target/cucumber_json/cucumber.json"} )
 public class WordPressAppTest {


### PR DESCRIPTION
- fixed script as per latest changes in framework related to appium driver handling in saucelabs

- https://github.com/serenity-bdd/serenity-core/commit/6f815a2153217e61c800c6efbe2d75c41586ba97

- "When you use saucelabs or browserstack, Serenity will now check if you are also using appium. If you are, it will use an IOSDriver or AndroidDriver. Otherwise, it will use a RemoteDriver."

@wakaleo Please review