### PR TITLE
add custom findBy

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/annotations/findby/di/ClasspathCustomFindByAnnotationProviderService.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/annotations/findby/di/ClasspathCustomFindByAnnotationProviderService.java
@@ -1,0 +1,31 @@
+package net.serenitybdd.core.annotations.findby.di;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * Created by Sergio Sacristan on 03/12/17.
+ *
+ * Load any implementations of the CustomFindByAnnotationService class declared on the classpath.
+ * CustomFindByAnnotationService implementations must be declared in a file called net.serenitybdd.core.annotations.findby.di.CustomFindByAnnotationService
+ * in the META-INF/services directory somewhere on the classpath.
+ */
+public class ClasspathCustomFindByAnnotationProviderService implements CustomFindByAnnotationProviderService {
+
+    private List<CustomFindByAnnotationService> findByAnnotationServices;
+
+    @Override
+    public List<CustomFindByAnnotationService> getCustomFindByAnnotationServices() {
+        if (findByAnnotationServices == null) {
+            findByAnnotationServices = new ArrayList<>();
+
+            ServiceLoader<CustomFindByAnnotationService> seleniumAnnotationServiceLoader = ServiceLoader.load(CustomFindByAnnotationService.class);
+
+            for (CustomFindByAnnotationService findByAnnotationService : seleniumAnnotationServiceLoader) {
+                findByAnnotationServices.add(findByAnnotationService);
+            }
+        }
+        return findByAnnotationServices;
+    }
+}

--- a/serenity-core/src/main/java/net/serenitybdd/core/annotations/findby/di/CustomFindByAnnotationProviderService.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/annotations/findby/di/CustomFindByAnnotationProviderService.java
@@ -1,0 +1,12 @@
+package net.serenitybdd.core.annotations.findby.di;
+
+import java.util.List;
+
+public interface CustomFindByAnnotationProviderService {
+
+    /**
+     *
+     * @return
+     */
+    List<CustomFindByAnnotationService> getCustomFindByAnnotationServices();
+}

--- a/serenity-core/src/main/java/net/serenitybdd/core/annotations/findby/di/CustomFindByAnnotationService.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/annotations/findby/di/CustomFindByAnnotationService.java
@@ -1,0 +1,29 @@
+package net.serenitybdd.core.annotations.findby.di;
+
+import org.openqa.selenium.By;
+
+import java.lang.reflect.Field;
+
+/**
+ * Created by Sergio Sacristan on 03/12/17.
+ *
+ * Implement this Interface to add custom findBy annotations
+ * @see  net.serenitybdd.core.annotations.findby.di.ClasspathCustomFindByAnnotationProviderService
+ */
+public interface CustomFindByAnnotationService {
+
+    /**
+     *  Returns true if the field has any custom annotation
+     * @param field
+     * @return true if the field has any custom annotation
+     */
+    boolean isAnnotatedByCustomFindByAnnotation(Field field);
+
+    /**
+     *  Retuns an org.openqa.selenium.By implementation
+     *  that will be used to find the "field" by Selenium
+     * @param field
+     * @return an org.openqa.selenium.By implementation
+     */
+    By buildByFromCustomFindByAnnotation(Field field);
+}

--- a/serenity-core/src/main/java/net/thucydides/core/guice/ThucydidesModule.java
+++ b/serenity-core/src/main/java/net/thucydides/core/guice/ThucydidesModule.java
@@ -3,6 +3,8 @@ package net.thucydides.core.guice;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import net.serenitybdd.core.annotations.findby.di.ClasspathCustomFindByAnnotationProviderService;
+import net.serenitybdd.core.annotations.findby.di.CustomFindByAnnotationProviderService;
 import net.serenitybdd.core.buildinfo.DriverCapabilityRecord;
 import net.serenitybdd.core.buildinfo.PropertyBasedDriverCapabilityRecord;
 import net.serenitybdd.core.history.FileSystemTestOutcomeSummaryRecorder;
@@ -63,6 +65,7 @@ public class ThucydidesModule extends AbstractModule {
         bind(RequirementsService.class).to(MultiSourceRequirementsService.class).in(Singleton.class);
         bind(DependencyInjectorService.class).to(ClasspathDependencyInjectorService.class).in(Singleton.class);
         bind(FixtureProviderService.class).to(ClasspathFixtureProviderService.class).in(Singleton.class);
+        bind(CustomFindByAnnotationProviderService.class).to(ClasspathCustomFindByAnnotationProviderService.class).in(Singleton.class);
 
         bind(StepListener.class).annotatedWith(ThucydidesLogging.class).to(ConsoleLoggingListener.class).in(Singleton.class);
         bind(ElementProxyCreator.class).to(SmartElementProxyCreator.class).in(Singleton.class);

--- a/serenity-core/src/test/groovy/net/serenitybdd/core/annotations/locators/FindByCustom.groovy
+++ b/serenity-core/src/test/groovy/net/serenitybdd/core/annotations/locators/FindByCustom.groovy
@@ -1,0 +1,5 @@
+package net.serenitybdd.core.annotations.locators
+
+@interface FindByCustom {
+
+}

--- a/serenity-core/src/test/java/net/serenitybdd/core/annotations/findby/di/ClasspathCustomFindByAnnotationProviderServiceTest.groovy
+++ b/serenity-core/src/test/java/net/serenitybdd/core/annotations/findby/di/ClasspathCustomFindByAnnotationProviderServiceTest.groovy
@@ -1,0 +1,31 @@
+package net.serenitybdd.core.annotations.findby.di
+
+import org.openqa.selenium.By
+import spock.lang.Specification
+
+import java.lang.reflect.Field
+
+class ClasspathCustomFindByAnnotationProviderServiceTest extends Specification {
+
+    class RocheFindByAnnotationService implements CustomFindByAnnotationService {
+
+        boolean isAnnotatedByCustomFindByAnnotation(Field field){
+          return true;
+        }
+
+        By buildByFromCustomFindByAnnotation(Field field){
+          return null;
+        }
+    }
+
+    def "GetCustomFindByAnnotationServices"() {
+        given:
+        ClasspathCustomFindByAnnotationProviderService classpathCustomFindByAnnotationProviderService = new ClasspathCustomFindByAnnotationProviderService();
+
+        when:
+        def result = classpathCustomFindByAnnotationProviderService.getCustomFindByAnnotationServices()
+
+        then:
+        result.size()==1
+    }
+}

--- a/serenity-core/src/test/java/net/serenitybdd/core/annotations/findby/di/CustomSampleFindByAnnotationService.java
+++ b/serenity-core/src/test/java/net/serenitybdd/core/annotations/findby/di/CustomSampleFindByAnnotationService.java
@@ -1,0 +1,18 @@
+package net.serenitybdd.core.annotations.findby.di;
+
+import org.openqa.selenium.By;
+
+import java.lang.reflect.Field;
+
+public class CustomSampleFindByAnnotationService implements CustomFindByAnnotationService {
+
+    @Override
+    public boolean isAnnotatedByCustomFindByAnnotation(Field field) {
+        return false;
+    }
+
+    @Override
+    public By buildByFromCustomFindByAnnotation(Field field) {
+        return null;
+    }
+}

--- a/serenity-core/src/test/resources/META-INF/services/net.serenitybdd.core.annotations.findby.di.CustomFindByAnnotationService
+++ b/serenity-core/src/test/resources/META-INF/services/net.serenitybdd.core.annotations.findby.di.CustomFindByAnnotationService
@@ -1,0 +1,1 @@
+net.serenitybdd.core.annotations.findby.di.CustomSampleFindByAnnotationService


### PR DESCRIPTION
Hi!
We are testing react components using https://www.npmjs.com/package/retractor. To facilitate the implementation of the tests we want to use a custom annotation. Like in this question: https://stackoverflow.com/questions/46039246/custom-annotation-creation-initialization-issue-with-serenity-framework

With this PR this is possible adding an implementation of the interface CustomFindByAnnotationService