### PR TITLE
refactor: replace System.out.println with logger API call

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/model/featuretags/StoryFileStrategy.java
+++ b/serenity-core/src/main/java/net/thucydides/core/model/featuretags/StoryFileStrategy.java
@@ -3,13 +3,17 @@ package net.thucydides.core.model.featuretags;
 import com.google.common.base.Optional;
 import net.thucydides.core.model.Story;
 import net.thucydides.core.model.TestTag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StoryFileStrategy implements FeatureTagStrategy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StoryFileStrategy.class);
 
     @Override
     public Optional<TestTag> getFeatureTag(Story story, String featureFilename) {
 
-        System.out.println("Story name for " + featureFilename + " => " + story.asTag());
+        LOGGER.debug("Story name for {} => {}", featureFilename, story.asTag());
         return Optional.of(story.asTag());
 //        File featureFile = FeatureOrStoryFile.forStoryDescribedIn(featureFilename).asFile();
 //

--- a/serenity-core/src/main/java/net/thucydides/core/reflection/ClassFinder.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reflection/ClassFinder.java
@@ -6,11 +6,15 @@ import java.net.URL;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Load classes from a given package.
  */
 public class ClassFinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClassFinder.class);
 
     private final ClassLoader classLoader;
     private final Class annotation;
@@ -98,7 +102,7 @@ public class ClassFinder {
                         classList.add(Class.forName(className));
                     }
                 } catch (Throwable e) {
-                    System.out.println("Could not load class " + className);
+                    LOGGER.debug("Could not load class {}", className);
                     //throw new RuntimeException("Could not load class", e);
                 }
             }


### PR DESCRIPTION
#### Summary of this PR
Minor refactoring - replace a few invocations of `System.out.println` with SLF4J API invocations 
#### Intended effect
For now class `net.thucydides.core.model.featuretags.StoryFileStrategy` produces 2 log lines like next while running Serenity-JBehave story file `stories/dir1/dir2/SomeTest.story`:
```
Story name for stories/dir1/dir2/SomeTest.story => TestTag{name='My Tag Name', type='story'}
Story name for stories/dir1/dir2/SomeTest.story => TestTag{name='My Tag Name', type='story'}
```
When set of stories is running, it becomes a bit annoying, because no way to turn it off. With this PR it be easily disabled from local logger framework configuration, e.g. via log4j2:
```
#src/main/resources/log4j2-test.properties

logger.mylog.name=net.thucydides.core.model.featuretags
logger.mylog.level=INFO
```
setting logger level to INFO will disable output, which now comes on DEBUG level.