### PR TITLE
Fixed internet explorer icon for context 'ie' for #1057

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/model/TitleBuilder.java
+++ b/serenity-core/src/main/java/net/thucydides/core/model/TitleBuilder.java
@@ -1,15 +1,13 @@
 package net.thucydides.core.model;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+
 import net.thucydides.core.ThucydidesSystemProperty;
-import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.issues.IssueTracking;
 import net.thucydides.core.reports.html.Formatter;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.Inflector;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class TitleBuilder {
 
@@ -19,20 +17,20 @@ public class TitleBuilder {
     private final EnvironmentVariables environmentVariables;
     private final boolean showContext;
 
-    private final static Map<String, String> FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS = new HashMap<>();
+    private final static Map<String, String> FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS = new HashMap<>();
     static {
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("chrome", "<i class=\"fa fa-chrome\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("firefox", "<i class=\"fa fa-firefox\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("safari", "<i class=\"fa fa-safari\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("opera", "<i class=\"fa fa-opera\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("ie", "<i class=\"fa fa-ie\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("phantomjs", "<i class=\"fa fa-snapchat-ghost\" aria-hidden=\"true\"></i>");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("chrome", "chrome");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("firefox", "firefox");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("safari", "safari");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("opera", "opera");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("ie", "internet-explorer");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("phantomjs", "snapchat-ghost");
 
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("linux", "<i class=\"fa fa-linux\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("mac", "<i class=\"fa fa-apple\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("windows", "<i class=\"fa fa-windows\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("android", "<i class=\"fa fa-android\" aria-hidden=\"true\"></i>");
-        FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.put("iphone", "<i class=\"fa fa-apple\" aria-hidden=\"true\"></i>");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("linux", "linux");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("mac", "apple");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("windows", "windows");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("android", "android");
+        FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.put("iphone", "apple");
     }
 
     public TitleBuilder(TestOutcome testOutcome, IssueTracking issueTracking, EnvironmentVariables environmentVariables, boolean qualified, boolean showContext) {
@@ -71,14 +69,16 @@ public class TitleBuilder {
             return "";
         }
 
-        if (testOutcome.getContext() == null) {
+        String context = testOutcome.getContext();
+        if (context == null) {
             return "";
         }
 
-        if (FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.containsKey(testOutcome.getContext().toLowerCase())) {
-            return FONTAWESOME_ICONS_FOR_COMMON_CONTEXTS.get(testOutcome.getContext().toLowerCase()) + " | ";
+        if (FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.containsKey(context.toLowerCase())) {
+            return String.format("<i class=\"fa fa-%s\" aria-hidden=\"true\"></i> | ",
+                    FONTAWESOME_CLASSES_FOR_COMMON_CONTEXTS.get(context.toLowerCase()));
         }
-        return testOutcome.getContext().toUpperCase() + " | ";
+        return context.toUpperCase() + " | ";
     }
 
 }

--- a/serenity-core/src/test/groovy/net/thucydides/core/model/WhenBuildingATitle.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/model/WhenBuildingATitle.groovy
@@ -1,0 +1,96 @@
+package net.thucydides.core.model
+
+import net.thucydides.core.util.MockEnvironmentVariables
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class WhenBuildingATitle extends Specification {
+
+    MockEnvironmentVariables environmentVariables
+    TestOutcome testOutcome
+    TitleBuilder titleBuilder
+
+    void setup() {
+        environmentVariables = new MockEnvironmentVariables()
+
+        testOutcome = new TestOutcome("Dummy")
+        testOutcome.setTitle("Test Title")
+        testOutcome.setEnvironmentVariables(environmentVariables)
+
+        titleBuilder = new TitleBuilder(testOutcome, null, environmentVariables, false)
+    }
+
+    def "it should return only the outcome title if the showContext attribute is set to false"() {
+        given:
+        environmentVariables.setProperty("context", "firefox")
+
+        when:
+        String title = titleBuilder.getTitle()
+
+        then:
+        title == testOutcome.getTitle()
+    }
+
+    def "it should return only the outcome title if there is no context"() {
+        given:
+        titleBuilder = titleBuilder.withContext()
+
+        when:
+        String title = titleBuilder.getTitle()
+
+        then:
+        title == testOutcome.getTitle()
+    }
+
+    @Unroll
+    def "it should return a context icon with outcome title for known contexts (#context -> #icon)"() {
+        given:
+        titleBuilder = titleBuilder.withContext()
+        environmentVariables.setProperty("context", context)
+
+        when:
+        String title = titleBuilder.getTitle()
+
+        then:
+        title == icon + " | " + testOutcome.getTitle()
+
+        where:
+        context     | icon
+        "chrome"    | "<i class=\"fa fa-chrome\" aria-hidden=\"true\"></i>"
+        "firefox"   | "<i class=\"fa fa-firefox\" aria-hidden=\"true\"></i>"
+        "safari"    | "<i class=\"fa fa-safari\" aria-hidden=\"true\"></i>"
+        "opera"     | "<i class=\"fa fa-opera\" aria-hidden=\"true\"></i>"
+        "ie"        | "<i class=\"fa fa-internet-explorer\" aria-hidden=\"true\"></i>"
+        "phantomjs" | "<i class=\"fa fa-snapchat-ghost\" aria-hidden=\"true\"></i>"
+        "linux"     | "<i class=\"fa fa-linux\" aria-hidden=\"true\"></i>"
+        "mac"       | "<i class=\"fa fa-apple\" aria-hidden=\"true\"></i>"
+        "windows"   | "<i class=\"fa fa-windows\" aria-hidden=\"true\"></i>"
+        "android"   | "<i class=\"fa fa-android\" aria-hidden=\"true\"></i>"
+        "iphone"    | "<i class=\"fa fa-apple\" aria-hidden=\"true\"></i>"
+    }
+
+    def "it should return the uppercase context name with outcome title for unknown contexts"() {
+        given:
+        titleBuilder = titleBuilder.withContext()
+        environmentVariables.setProperty("context", "blackberry")
+
+        when:
+        String title = titleBuilder.getTitle()
+
+        then:
+        title == "BLACKBERRY | " + testOutcome.getTitle()
+    }
+
+    def "it should return only the outcome title if the display context environment property is set to false"() {
+        given:
+        titleBuilder = titleBuilder.withContext()
+        environmentVariables.setProperty("context", "blackberry")
+        environmentVariables.setProperty("serenity.display.context", "false")
+
+        when:
+        String title = titleBuilder.getTitle()
+
+        then:
+        title == testOutcome.getTitle()
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
With this fix HTML reports display the correct font-awesome icon for the internet explorer (i.e. when the context was set to `ie`)

#### How should this be manually tested?
Perform some webtest with `-Dcontext=ie` and examine the HTML report. The icon for the internet explorer should be displayed.
Also a unit test for the `TitleBuilder` class has been added.

#### Relevant tickets
https://github.com/serenity-bdd/serenity-core/issues/1057