### PR TITLE
Fixed JUNIT XML generation issue.

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLConverter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLConverter.java
@@ -194,7 +194,7 @@ public class JUnitXMLConverter {
         testSuiteElement.setAttribute("failures", Integer.toString(failures));
 
         testCaseOutcomes.getStartTime().ifPresent(
-                startTime -> testSuiteElement.setAttribute("timestamp", startTime.toString())
+                startTime -> testSuiteElement.setAttribute("timestamp", TIMESTAMP_FORMAT.format(startTime))
         );
 
         return testSuiteElement;


### PR DESCRIPTION
Hi,

I'm facing the same issue as the closed https://github.com/serenity-bdd/serenity-core/issues/843 issue.

The following deps are used:
    compile group: 'net.serenity-bdd', name: 'serenity-core', version: '1.8.21'
    compile group: 'net.serenity-bdd', name: 'serenity-junit', version: '1.8.21'
    compile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: '1.8.21'
    compile group: 'net.serenity-bdd', name: 'serenity-jbehave', version: '1.35.0'

Error message:
`Wrong timestamp format was generated: for example: "2018-01-09T16:38:20.646+02:00[Europe/Helsinki]"`

This is causing the report generation to break.

After some digging I traced this issue back to commit e655282e446bdb3bfbd78aca346577c15f2b8983

In the `JUnitXMLConverter` a `ZonedDateTime.toSting()` method is used on the starttime object.
This leads to an incorrect timestamp format.