### PR TITLE
Update AppiumConfiguration.java to relax check on app property

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
@@ -101,8 +101,8 @@ public class AppiumConfiguration {
     }
 
     private void ensureAppOrBrowserPathDefinedIn(Properties appiumProperties) {
-        if (!appiumProperties.containsKey("app") && !appiumProperties.containsKey("browserName")) {
-            throw new ThucydidesConfigurationException("The browser under test or path to the app needs to be provided in the appium.app or appium.browserName property.");
+        if (!(appiumProperties.containsKey("app") || (appiumProperties.containsKey("appPackage") && appiumProperties.containsKey("appActivity"))  && !appiumProperties.containsKey("browserName")) {
+            throw new ThucydidesConfigurationException("The browser under test or path to the app or (appPackage and appActivity) needs to be provided in the appium.app or appium.browserName property.");
         }
     }
 


### PR DESCRIPTION
appium does support opening an already installed app using its appPackage and appActivity properties.
As such, its not mandatory to have app property.  Even providing appPackage and appActivity could be fine. So, adding a check.