### PR TITLE
FIX: #1172: switch iframe using expected condition

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/IFrameSwitcher.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/IFrameSwitcher.java
@@ -3,6 +3,7 @@ package net.serenitybdd.screenplay.targets;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,10 +16,10 @@ class IFrameSwitcher {
 
     private final static ThreadLocal<IFrameSwitcher> threadDriverManager = new ThreadLocal<>();
 
-    static synchronized IFrameSwitcher getInstance(WebDriver driver) {
+    static synchronized IFrameSwitcher getInstance(WebDriver driver, TargetResolver resolver) {
         IFrameSwitcher iFrameSwitcher = threadDriverManager.get();
         if (iFrameSwitcher == null) {
-            iFrameSwitcher = new IFrameSwitcher(driver);
+            iFrameSwitcher = new IFrameSwitcher(driver, resolver);
             threadDriverManager.set(iFrameSwitcher);
         }
         return iFrameSwitcher;
@@ -27,10 +28,12 @@ class IFrameSwitcher {
     private static final Logger LOGGER = LoggerFactory.getLogger(IFrameSwitcher.class);
 
     private WebDriver driver;
+    private TargetResolver resolver;
     private IFrame currentIFrame;
 
-    private IFrameSwitcher(WebDriver driver) {
+    private IFrameSwitcher(WebDriver driver, TargetResolver resolver) {
         this.driver = driver;
+        this.resolver = resolver;
     }
 
     void switchToIFrame(final Target target) {
@@ -59,7 +62,7 @@ class IFrameSwitcher {
 
     private void switchToChildFrame(Target target, String frame) {
         logFrameState(target, "switching to", frame);
-        driver.switchTo().frame(frame);
+        resolver.waitFor(ExpectedConditions.frameToBeAvailableAndSwitchToIt(frame));
         logFrameState(target, "switched to", frame);
     }
 

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/TargetResolver.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/TargetResolver.java
@@ -14,7 +14,7 @@ class TargetResolver extends PageObject {
     static TargetResolver create(Actor theActor, Target target) {
         WebDriver driver = BrowseTheWeb.as(theActor).getDriver();
         TargetResolver resolver = new TargetResolver(driver);
-        IFrameSwitcher iFrameSwitcher = IFrameSwitcher.getInstance(driver);
+        IFrameSwitcher iFrameSwitcher = IFrameSwitcher.getInstance(driver, resolver);
         iFrameSwitcher.switchToIFrame(target);
         return resolver;
     }


### PR DESCRIPTION
- attempt to avoid `Unable to locate frame` exception as seen in the integration tests on master. Note that this is only likely to work if the DOM is in a state of transition to the correct content within the duration of the expected condition. This may not address the problem in  [jenkins integration build #251](http://34.248.197.198:8080/blue/rest/organizations/jenkins/pipelines/serenity-core/pipelines/integration-tests/runs/251/log/?start=0) where the browser page source on the failing tests seems fixed as follows:

```
<?xml version="1.0" encoding="UTF-8"?>
<html>
  <head/>
  <body/>
</html>
```