### PR TITLE
Fixing  JUnitXMLConverter uses wrong timestamp format #1195

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLConverter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLConverter.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 public class JUnitXMLConverter {
 
-    private final static DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYY-MM-dd hh:mm:ss");
+    private final static DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
 
     public void write(String testCaseName, List<TestOutcome> outcomes, OutputStream outputStream) throws ParserConfigurationException, TransformerException {
         DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();

--- a/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLConverter.java
+++ b/serenity-core/src/main/java/net/thucydides/core/reports/junit/JUnitXMLConverter.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 public class JUnitXMLConverter {
 
-    private final static DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYY-MM-DD hh:mm:ss");
+    private final static DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYY-MM-dd hh:mm:ss");
 
     public void write(String testCaseName, List<TestOutcome> outcomes, OutputStream outputStream) throws ParserConfigurationException, TransformerException {
         DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();


### PR DESCRIPTION
Corrected date format to use day of month. Currently its using day-of-year which causes to fail from today.