### PR TITLE
fix: added SERENITY_MAXIMUM_STEP_NESTING_DEPTH property for #1288

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepAnnotations.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepAnnotations.java
@@ -9,12 +9,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static net.thucydides.core.ThucydidesSystemProperty.SERENITY_MAXIMUM_STEP_NESTING_DEPTH;
+
 /**
  * Utility class used to inject fields into a test case.
  */
 public final class StepAnnotations {
 
-    public static final int MAX_ALLOWED_STEP_LIBRARY_NESTING = 16;
     private final EnvironmentVariables environmentVariables;
 
     private StepAnnotations() {
@@ -85,7 +86,8 @@ public final class StepAnnotations {
         long levelsOfNesting = Stream.of(stackTrace).filter( element -> element.getMethodName().equals("instantiateAnyUnitiaializedSteps"))
                                      .count();
 
-        if (levelsOfNesting > MAX_ALLOWED_STEP_LIBRARY_NESTING) {
+        int maxAllowedNesting = SERENITY_MAXIMUM_STEP_NESTING_DEPTH.integerFrom(environmentVariables, 32);
+        if (levelsOfNesting > maxAllowedNesting) {
             String message = String.format(
                     "A recursive or cyclic reference was detected for the @Steps-annotated field %s in class %s. " +
                     "You may need to use @Steps(shared=true) to ensure that the same step library instance is used everywhere.",

--- a/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -1237,6 +1237,14 @@ public enum ThucydidesSystemProperty {
      * Disable Webdriver integration. Turn this off to avoid Serenity loading WebDriver classes unnecessarily.
      */
     SERENITY_WEBDRIVER_INTEGRATION,
+
+    /**
+     * When creating steps that contain references to other steps serenity does a recursion check to prevent cyclic references.
+     * This property determines how many levels deep the step classes can be nested before it triggers a recursion exception.
+     * By default it is set to 32, but can be increased if you start getting RecursiveOrCyclicStepLibraryReferenceException
+     * due to step nesting rather than actual infinite recursion.
+     */
+    SERENITY_MAXIMUM_STEP_NESTING_DEPTH,
     ;
 
     private String propertyName;


### PR DESCRIPTION
#### Summary of this PR
Made it possible to define maximum step nesting level to facilitate projects with huge amounts of step classes, also increased the default maximum step nesting from 16 to 32.
#### Side effects
If actual infinite recursion happens it may take a tiny bit longer to detect it.
#### Relevant tickets
#1288 