### PR TITLE
Fix report (index.html) Favicon for #890

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/libraries/favicon.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/libraries/favicon.ftl
@@ -1,17 +1,17 @@
-<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
-<link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png">
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png">
-<link rel="icon" type="image/png" sizes="192x192"  href="/android-icon-192x192.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="apple-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="apple-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="apple-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="apple-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="apple-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="apple-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="apple-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="apple-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="apple-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="192x192"  href="android-icon-192x192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
 <meta name="msapplication-TileColor" content="#ffffff">
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
 <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
#### Summary of this PR
This PR fixes the Favicon not being shown when serenity reports (index.html) are generated.
#### Intended effect
Serenity reports should show a Favicon when opened in browser. Currently the favicon file itself is outdated. It is the old favicon which does not match the below logo but the favicon will be visible after this fix. To match the favicon with logo, We need to update the resource files in `serenity-report-resources/src/main/resources/report-resources`

<img width="97" alt="latest logo" src="https://user-images.githubusercontent.com/1898545/42537155-fe6a286a-848b-11e8-93f7-e244b3afbae7.png">

#### How should this be manually tested?
Go to `serenity-spring`
From terminal run `./gradlew clean test`
This should generate a target folder. Go to `target/site/serenity` and open any file (which are individual screenshots) with .html
The page should open and Favicon can be seen on browser tab.

#### Relevant tickets
https://github.com/serenity-bdd/serenity-core/issues/890
#### Screenshots (if appropriate)
<img width="102" alt="favicon chrome" src="https://user-images.githubusercontent.com/1898545/42537072-c376e342-848b-11e8-8082-3f4e71669ef8.png">
