### PR TITLE
fix #1346 - validate stopwatch started where appropriate

### DIFF
--- a/serenity-model/src/main/java/net/serenitybdd/core/time/Stopwatch.java
+++ b/serenity-model/src/main/java/net/serenitybdd/core/time/Stopwatch.java
@@ -20,28 +20,38 @@ public class Stopwatch {
     }
 
     public void start() {
-        startTime = System.currentTimeMillis();
+        startTime = currentTimeMillis();
     }
 
     public long stop() {
-        long result = System.currentTimeMillis() - startTime;
+        validateStarted();
+        long result = currentTimeMillis() - startTime;
         startTime = 0;
         return result;
     }
 
-    public String lapTimeFormatted() {
-        return lapTimeFormatted(startTime = currentTimeMillis());
+    private void validateStarted() {
+        if (startTime == 0) {
+            throw new IllegalStateException("stopwatch is already stopped");
+        }
     }
+
+    public String lapTimeFormatted() {
+        validateStarted();
+        return lapTimeFormatted(currentTimeMillis() - startTime);
+    }
+
     public String executionTimeFormatted() {
         return lapTimeFormatted(stop());
     }
 
     public String lapTimeFormatted(Long executionTimeInMilliseconds) {
-        return executionTimeInMilliseconds < 1000 ? executionTimeInMilliseconds + " ms" : new DecimalFormat("#,###.#").format(executionTimeInMilliseconds / 1000.0) + " secs";
+        return (executionTimeInMilliseconds < 1000) ? (executionTimeInMilliseconds + " ms") : (new DecimalFormat("#,###.#").format(executionTimeInMilliseconds / 1000.0) + " secs");
     }
 
     public long lapTime() {
-        return System.currentTimeMillis() - startTime;
+        validateStarted();
+        return currentTimeMillis() - startTime;
     }
 
     public long stop(String message) {

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
@@ -190,7 +190,7 @@ public class HtmlAggregateStoryReporter extends HtmlReporter implements UserStor
                 requirementsOutcomes
         ));
 
-        LOGGER.info("Starting generating reports: {}", stopwatch.lapTimeFormatted());
+        LOGGER.info("Starting generating reports after {}", stopwatch.lapTimeFormatted());
         Reporter.generateReportsFor(reportingTasks);
         LOGGER.info("Test results for {} tests generated in {}", testOutcomes.getTestCount(), stopwatch.executionTimeFormatted());
     }


### PR DESCRIPTION
- prevents accidental repeat calls to stop() method which will subsequrntly produce spurious timings