### PR TITLE
fix: Treat subclasses of an Ability as the superclass Ability

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
@@ -83,7 +83,20 @@ public class Actor implements PerformsTasks, SkipNested {
 
     @SuppressWarnings("unchecked")
     public <T extends Ability> T abilityTo(Class<? extends T> doSomething) {
-        return (T) abilities.get(doSomething);
+        T ability = (T) abilities.get(doSomething);
+
+        if (ability == null) {
+            // See if any ability is a subclass of doSomething
+            for (Map.Entry<Class, Ability> entry: abilities.entrySet()) {
+                // Return the first subclass we find
+                if (doSomething.isAssignableFrom(entry.getKey())) {
+                    ability = (T) entry.getValue();
+                    break;
+                }
+            }
+        }
+
+        return ability;
     }
 
     /**

--- a/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/WhenActorsHaveAbilities.groovy
+++ b/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/WhenActorsHaveAbilities.groovy
@@ -16,6 +16,8 @@ class WhenActorsHaveAbilities extends Specification{
         }
     }
 
+    class ReachEnlightenment extends Meditate {}
+
     def "actors can be associated with Abilities"() {
         given:
         def actor = Actor.named("Bruce")
@@ -35,6 +37,17 @@ class WhenActorsHaveAbilities extends Specification{
         actor.abilityTo(Meditate) != null
         and:
         meditate.actor == actor;
+
+    }
+
+    def "actors associate extensions of Abilities with the superclass too"() {
+        given:
+        def actor = Actor.named("Bruce")
+        def reachEnlightenment = new ReachEnlightenment()
+        when:
+        actor.can(reachEnlightenment)
+        then:
+        actor.abilityTo(Meditate) instanceof ReachEnlightenment
 
     }
 


### PR DESCRIPTION
Per this question in the Users Group: https://groups.google.com/d/msg/thucydides-users/zhuJAmHe2Iw/p09T97eQAQAJ

Allow subclassing of Abilities e.g. BrowseTheWeb