### PR TITLE
Revert "Gradle plugin class SerenityPlugin is not thread-safe"

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/di/WebDriverInjectors.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/di/WebDriverInjectors.java
@@ -1,9 +1,8 @@
 package net.serenitybdd.core.di;
 
-import com.google.inject.Injector;
-import com.google.inject.Module;
-import net.thucydides.core.guice.Injectors;
-import net.thucydides.core.guice.webdriver.WebDriverModule;
+import com.google.inject.*;
+import net.thucydides.core.guice.*;
+import net.thucydides.core.guice.webdriver.*;
 
 public class WebDriverInjectors {
 

--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -20,6 +20,9 @@ import org.slf4j.LoggerFactory;
 
 class SerenityPlugin implements Plugin<Project> {
 
+    Path reportDirectory
+    Path historyDirectory
+
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     @Override

--- a/serenity-model/src/main/java/net/thucydides/core/guice/Injectors.java
+++ b/serenity-model/src/main/java/net/thucydides/core/guice/Injectors.java
@@ -1,12 +1,8 @@
 package net.thucydides.core.guice;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.google.inject.Module;
+import com.google.inject.*;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Somewhere to hold the Guice injector.


### PR DESCRIPTION
Reverts serenity-bdd/serenity-core#1399 - causes an error "Could not set unknown property 'reportDirectory' for task ':checkOutcomes' of type org.gradle.api.DefaultTask"