### PR TITLE
Added configuration option to take screenshot of the screen instead of the browser.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=false
 
 # Dependency versions
 
-seleniumVersion = 3.141.0
+seleniumVersion = 3.141.5
 
 groovyVersion = 2.4.12
 gradleVersion = 4.9

--- a/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
@@ -4,7 +4,10 @@ import com.google.inject.Injector;
 import net.serenitybdd.core.PendingStepException;
 import net.serenitybdd.core.di.WebDriverInjectors;
 import net.serenitybdd.core.exceptions.TheErrorType;
-import net.serenitybdd.core.photography.*;
+import net.serenitybdd.core.photography.Darkroom;
+import net.serenitybdd.core.photography.Photographer;
+import net.serenitybdd.core.photography.ScreenshotPhoto;
+import net.serenitybdd.core.photography.SoundEngineer;
 import net.serenitybdd.core.photography.bluring.AnnotatedBluring;
 import net.serenitybdd.core.rest.RestQuery;
 import net.serenitybdd.core.strings.Joiner;
@@ -860,14 +863,15 @@ public class BaseStepListener implements StepListener, StepPublisher {
         java.util.Optional<File> pageSource = java.util.Optional.empty();
 
         if (pathOf(outputDirectory) != null) { // Output directory may be null for some tests
-                            newPhoto = getPhotographer().takesAScreenshot()
-                        .with(getDriver())
-                        .andWithBlurring(AnnotatedBluring.blurLevel())
-                        .andSaveToDirectory(pathOf(outputDirectory));
+            newPhoto = getPhotographer().takesAScreenshot()
+                    .with(getDriver())
+                    .andWithBlurring(AnnotatedBluring.blurLevel())
+                    .andSaveToDirectory(pathOf(outputDirectory));
 
-                pageSource = soundEngineer.ifRequiredForResult(result)
-                        .recordPageSourceUsing(getDriver())
-                        .intoDirectory(pathOf(outputDirectory));
+            pageSource = soundEngineer.ifRequiredForResult(result)
+                    .recordPageSourceUsing(getDriver())
+                    .intoDirectory(pathOf(outputDirectory));
+
             if (ThucydidesSystemProperty.SERENITY_USE_AWT_ROBOT_FOR_SCREENSHOTS.booleanFrom(configuration.getEnvironmentVariables())){
                 try {
                     String screenshotPath = newPhoto.getPathToScreenshot().toString();

--- a/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -210,6 +210,8 @@ public enum ThucydidesSystemProperty {
      */
     SERENITY_TAKE_SCREENSHOTS,
 
+    SERENITY_USE_AWT_ROBOT_FOR_SCREENSHOTS,
+
     @Deprecated
     THUCYDIDES_REPORTS_SHOW_STEP_DETAILS,
 


### PR DESCRIPTION
It is quick and dirty hack because it is not switching the way screenshot is created.
After the screenshot is created, the hack takes its name and creates another screenshot - of the screen with java.awt.Robot and saves it with the name of the original file.
This way the screenshot of the screen gets included in the serenity report.
The above behavior is turned on by including in serenity config the option:
serenity.use.awt.robot.for.screenshots=true

Actually I do not expect this to be merged, but to be used as an idea for improvement. Or as a discussion starter. 

My use of the SerenityBDD includes Sikuli - an actor that has ability to control windows desktop application so I needed screenshots that show what is visible on the screen.
