### PR TITLE
Address #1486 - Saucelabs/Chrome

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/ChromeDriverCapabilities.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/ChromeDriverCapabilities.java
@@ -90,6 +90,7 @@ public class ChromeDriverCapabilities implements DriverCapabilitiesProvider {
     }
 
     private void addExperimentalOptionsTo(ChromeOptions options) {
+        options.setExperimentalOption("w3c", true);
         Map<String, Object> chrome_experimental_options = ChromePreferences.startingWith("chrome_experimental_options.").from(environmentVariables);
         chrome_experimental_options.keySet().forEach(
                 key -> options.setExperimentalOption(key, chrome_experimental_options.get(key))


### PR DESCRIPTION
#### Summary of this PR
Update chromeOptions to set w3c=true as per https://wiki.saucelabs.com/display/DOCS/Selenium+W3C+Capabilities+Support+-+Beta#SeleniumW3CCapabilitiesSupport-Beta-chromeOptions 

#### Intended effect
Able to use both Google Chrome and Firefox on Saucelabs

#### How should this be manually tested?
Run tests against Saucelabs Firefox and Chrome.  Be sure to specify the seleniumVersion corresponding to that in gradle.properties (not Saucelabs default)

#### Side effects
N/A

#### Documentation
N/A

#### Relevant tickets
#1468

#### Screenshots (if appropriate)
N/A

#### Notes
Regarding all the changes listed in https://wiki.saucelabs.com/display/DOCS/Selenium+W3C+Capabilities+Support+-+Beta

* version -> browserVersion: This is not yet used in Selenium (https://github.com/SeleniumHQ/selenium/search?l=Java&q=BROWSER_VERSION) as of 2018-11-30.  The current corresponding line of code in Serenity is https://github.com/serenity-bdd/serenity-core/blob/master/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/SaucelabsRemoteDriverCapabilities.java#L70

* sauce:options (use Capabilities instead of DesiredCapabilities): Addressed in commit 3dd499eed088bc7120aead0a02fab69f18478935

* seleniumVersion set only within sauce:options: Already handled by specifying via serenity (thucydides) properties file saucelabs.seleniumVersion 

* platform -> platformName: This is not yet used in Selenium (https://github.com/SeleniumHQ/selenium/blob/master/java/client/src/org/openqa/selenium/remote/DesiredCapabilities.java#L73) as of 2018-11-30.  Corresponding code in Serenity is https://github.com/serenity-bdd/serenity-core/blob/master/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/SaucelabsRemoteDriverCapabilities.java#L79
https://github.com/serenity-bdd/serenity-core/blob/master/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java#L612

* chromeOptions w3c=true: this PR

* DesiredCapabilities.firefox() -> new FirefoxOptions(): This was addressed in PR #1416, but was reverted because it introduced other issues.  It should probably be revisited at some point though.
