### PR TITLE
Fix 1468: update capability passed to sauce from version to browserVersion

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/SaucelabsRemoteDriverCapabilities.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/SaucelabsRemoteDriverCapabilities.java
@@ -44,7 +44,6 @@ public class SaucelabsRemoteDriverCapabilities implements RemoteDriverCapabiliti
 
         for(String propertyName : saucelabsProperties.stringPropertyNames()) {
             String unprefixedPropertyName = unprefixed(propertyName);
-            sauceCaps.setCapability(propertyName, typed(saucelabsProperties.getProperty(propertyName)));
             sauceCaps.setCapability(unprefixedPropertyName, typed(saucelabsProperties.getProperty(propertyName)));
         }
 
@@ -65,9 +64,9 @@ public class SaucelabsRemoteDriverCapabilities implements RemoteDriverCapabiliti
 
 
     private void configureBrowserVersion(MutableCapabilities capabilities) {
-        String driverVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables);
-        if (isNotEmpty(driverVersion)) {
-            capabilities.setCapability("version", driverVersion);
+        String browserVersion = ThucydidesSystemProperty.SAUCELABS_BROWSER_VERSION.from(environmentVariables);
+        if (isNotEmpty(browserVersion)) {
+            capabilities.setCapability("browserVersion", browserVersion);
         }
     }
 

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/SetAppropriateSaucelabsPlatformVersion.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/SetAppropriateSaucelabsPlatformVersion.java
@@ -73,7 +73,7 @@ class SetAppropriateSaucelabsPlatformVersion {
 
     private void setAppropriateSaucelabsPlatformVersionForSafariFrom(EnvironmentVariables environmentVariables) {
         if (ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM.from(environmentVariables).equalsIgnoreCase("mac")) {
-            String browserVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables);
+            String browserVersion = ThucydidesSystemProperty.SAUCELABS_BROWSER_VERSION.from(environmentVariables);
             if (MAC_OS_VERSIONS_PER_SAFARI_VERSION.containsKey(browserVersion)) {
                 capabilities.setCapability("platform", MAC_OS_VERSIONS_PER_SAFARI_VERSION.get(browserVersion));
             }

--- a/serenity-model/src/main/java/net/serenitybdd/core/buildinfo/BuildInfoProvider.java
+++ b/serenity-model/src/main/java/net/serenitybdd/core/buildinfo/BuildInfoProvider.java
@@ -64,8 +64,8 @@ public class BuildInfoProvider {
             if (ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM.from(environmentVariables) != null) {
                 buildProperties.put("Saucelabs target platform", ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM.from(environmentVariables));
             }
-            if (ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables) != null) {
-                buildProperties.put("Saucelabs driver version", ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables));
+            if (ThucydidesSystemProperty.SAUCELABS_BROWSER_VERSION.from(environmentVariables) != null) {
+                buildProperties.put("Saucelabs browser version", ThucydidesSystemProperty.SAUCELABS_BROWSER_VERSION.from(environmentVariables));
             }
             if (ThucydidesSystemProperty.WEBDRIVER_REMOTE_OS.from(environmentVariables) != null) {
                 buildProperties.put("Remote OS", ThucydidesSystemProperty.WEBDRIVER_REMOTE_OS.from(environmentVariables));

--- a/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -619,7 +619,7 @@ public enum ThucydidesSystemProperty {
 
     SAUCELABS_TARGET_PLATFORM,
 
-    SAUCELABS_DRIVER_VERSION,
+    SAUCELABS_BROWSER_VERSION,
 
     SAUCELABS_TEST_NAME,
     /**


### PR DESCRIPTION
Summary of this PR
Update version to browserVersion as per https://wiki.saucelabs.com/display/DOCS/Selenium+W3C+Capabilities+Support+-+Beta#SeleniumW3CCapabilitiesSupport-Beta-version

Intended effect
Able to use the intended browser version

How should this be manually tested?
Run tests against Saucelabs Firefox and Chrome. Be sure to specify the seleniumVersion corresponding to that in gradle.properties (not Saucelabs default)

Side effects
N/A

Documentation
N/A

Relevant tickets
#1468-this is a bit of an addendum to PR #1470.  Notes there about version->browserVersion were incorrect.

Screenshots (if appropriate)
N/A