### PR TITLE
#1528 allow the platformName to be specified in more ways

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/ElementLocatorFactorySelector.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/ElementLocatorFactorySelector.java
@@ -48,7 +48,7 @@ public class ElementLocatorFactorySelector {
         if (!WebDriverType.isMobile(driver)) {
             return MobilePlatform.NONE;
         }
-        return appiumConfiguration.getTargetPlatform();
+        return appiumConfiguration.getTargetPlatform(driver);
     }
 
     public ElementLocatorFactorySelector withTimeout(int timeoutInSeconds) {


### PR DESCRIPTION
If there's a platformName specified in the desiredCapabilities, use that. Otherwise, use the context for the platformName. If that doesn't work use the property appium.platformName.