### PR TITLE
feat: support unique locators for iOS and Android (fixes #1531)

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/ThucydidesConfigurationException.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/ThucydidesConfigurationException.java
@@ -7,4 +7,8 @@ public class ThucydidesConfigurationException extends RuntimeException {
     public ThucydidesConfigurationException(String s) {
         super(s);
     }
+
+    public ThucydidesConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
@@ -1,17 +1,11 @@
 package net.thucydides.core.webdriver.appium
 
-import io.appium.java_client.android.AndroidDriver
-import net.serenitybdd.core.webdriver.driverproviders.RemoteWebdriverStub
 import net.thucydides.core.util.FileSeparatorUtil
 import net.thucydides.core.util.MockEnvironmentVariables
 import net.thucydides.core.util.PathProcessor
 import net.thucydides.core.webdriver.MobilePlatform
 import net.thucydides.core.webdriver.ThucydidesConfigurationException
-import net.thucydides.core.webdriver.stubs.AndroidWebDriverStub
-import org.openqa.selenium.By
 import org.openqa.selenium.Platform
-import org.openqa.selenium.WebDriver
-import org.openqa.selenium.WebElement
 import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.remote.RemoteWebDriver
 import spock.lang.Specification

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/ByTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/ByTarget.java
@@ -3,30 +3,65 @@ package net.serenitybdd.screenplay.targets;
 import net.serenitybdd.core.pages.WebElementFacade;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.abilities.BrowseTheWeb;
+import net.thucydides.core.webdriver.ThucydidesConfigurationException;
 import org.openqa.selenium.By;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.List;
 import java.util.Optional;
 
 public class ByTarget extends Target {
 
-    private final By locator;
+    private By locator;
+    private By androidLocator;
+    private By iosLocator;
 
     public ByTarget(String targetElementName, By locator, Optional<IFrame> iFrame) {
         super(targetElementName, iFrame);
         this.locator = locator;
     }
 
+    public ByTarget(String targetElementName, By androidLocator, By iosLocator, Optional<IFrame> iFrame) {
+        super(targetElementName, iFrame);
+        this.androidLocator = androidLocator;
+        this.iosLocator = iosLocator;
+    }
+
     public WebElementFacade resolveFor(Actor actor) {
-        return TargetResolver.create(BrowseTheWeb.as(actor).getDriver(), this).find(locator);
+        return TargetResolver.create(BrowseTheWeb.as(actor).getDriver(), this).find(getLocatorForPlatform(actor));
     }
 
     public List<WebElementFacade> resolveAllFor(Actor actor) {
-        return TargetResolver.create(BrowseTheWeb.as(actor).getDriver(), this).findAll(locator);
+        return TargetResolver.create(BrowseTheWeb.as(actor).getDriver(), this).findAll(getLocatorForPlatform(actor));
     }
 
     public XPathOrCssTarget of(String... parameters) {
         throw new UnsupportedOperationException("The of() method is not supported for By-type Targets");
+    }
+
+    private By getLocatorForPlatform(Actor actor) {
+        if (null != this.androidLocator && null != this.iosLocator) {
+            String platform;
+            try {
+                platform = ((RemoteWebDriver) BrowseTheWeb.as(actor).getDriver()).getCapabilities()
+                                                                                 .getPlatform().name().toUpperCase();
+            } catch (ClassCastException e) {
+                throw new ThucydidesConfigurationException(String.format(
+                        "The configured driver '%s' does not support Cross Platform Mobile targets",
+                        BrowseTheWeb.as(actor).getDriver()
+                ), e);
+            }
+            if (platform.equals("ANDROID")) {
+                return this.androidLocator;
+            } else if (platform.equals("IOS")) {
+                return this.iosLocator;
+            } else {
+                throw new ThucydidesConfigurationException(String.format(
+                        "'%s' is not a valid platform for Cross Platform Mobile targets", platform
+                ));
+            }
+        }
+        return this.locator;
     }
 
     @Override

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/LocatesCrossPlatform.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/LocatesCrossPlatform.java
@@ -1,0 +1,10 @@
+package net.serenitybdd.screenplay.targets;
+
+import org.openqa.selenium.By;
+
+/**
+ * For the fluent builder when giving unique locators for iOS and Android
+ */
+public interface LocatesCrossPlatform {
+    Target locatedForIOS(By iosLocator);
+}

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/TargetBuilder.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/TargetBuilder.java
@@ -28,4 +28,25 @@ public class TargetBuilder<T> {
         return new ByTarget(targetElementName, locator, iFrame);
     }
 
+    public LocatesCrossPlatform locatedForAndroid(By androidLocator) {
+        return new CrossPlatformTargetBuilder(targetElementName, androidLocator, iFrame);
+    }
+
+    static class CrossPlatformTargetBuilder implements LocatesCrossPlatform {
+
+        private String targetElementName;
+        private By androidLocator;
+        private Optional<IFrame> iFrame;
+
+        CrossPlatformTargetBuilder(String targetElementName, By androidLocator, Optional<IFrame> iFrame) {
+            this.targetElementName = targetElementName;
+            this.androidLocator = androidLocator;
+            this.iFrame = iFrame;
+        }
+
+        public Target locatedForIOS(By iosLocator) {
+            return new ByTarget(this.targetElementName, this.androidLocator, iosLocator, this.iFrame);
+        }
+
+    }
 }

--- a/serenity-screenplay-webdriver/src/test/groovy/net/serenitybdd/screenplay/targets/WhenDefiningTargets.groovy
+++ b/serenity-screenplay-webdriver/src/test/groovy/net/serenitybdd/screenplay/targets/WhenDefiningTargets.groovy
@@ -1,0 +1,99 @@
+package net.serenitybdd.screenplay.targets
+
+import io.appium.java_client.AppiumDriver
+import io.appium.java_client.MobileBy
+import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.abilities.BrowseTheWeb
+import net.thucydides.core.webdriver.ThucydidesConfigurationException
+import org.mockito.Mock
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.remote.DesiredCapabilities
+import org.openqa.selenium.remote.RemoteWebDriver
+import spock.lang.Specification
+
+import static org.mockito.Mockito.when
+import static org.mockito.MockitoAnnotations.initMocks
+
+
+class WhenDefiningTargets extends Specification {
+
+    @Mock
+    AppiumDriver appiumDriver
+
+    @Mock
+    WebDriver driver
+
+    @Mock
+    RemoteWebDriver remoteWebDriver
+
+    DesiredCapabilities dc
+
+    def BY_TARGET = Target.the("By Target").located(By.name("Simple locator"))
+    def CROSS_PLATFORM_BY_TARGET = Target.the("Cross Platform By Target")
+                                         .locatedForAndroid(MobileBy.id("android_element_id"))
+                                         .locatedForIOS(MobileBy.id("iOS_element_id"))
+
+    def setup() {
+        initMocks(this)
+        dc = new DesiredCapabilities()
+        dc.setCapability("app", "mock-app")
+    }
+
+    def "targets can be specified for iOS or Android"() {
+        given:
+        dc.setCapability("platformName", configuredPlatform)
+        when(appiumDriver.getCapabilities()).thenReturn(dc)
+        Actor dana = new Actor("Dana")
+        dana.can(BrowseTheWeb.with(appiumDriver))
+        when:
+        def description = CROSS_PLATFORM_BY_TARGET.resolveFor(dana).toString()
+        then:
+        description.contains(expectedElementString)
+        where:
+        configuredPlatform     | expectedElementString
+        "android"              | "android_element_id"
+        "IOS"                  | "iOS_element_id"
+    }
+
+    def "an exception is thrown when trying to use a Cross Platform target in a non-mobile test"() {
+        given:
+        dc.setCapability("platformName", "android")
+        Actor dana = new Actor("Dana")
+        dana.can(BrowseTheWeb.with(driver))
+        when:
+        CROSS_PLATFORM_BY_TARGET.resolveFor(dana).toString()
+        then:
+        ThucydidesConfigurationException e = thrown()
+        e.message.contains("The configured driver ")
+    }
+
+    def "an exception is thrown for invalid platforms"() {
+        given:
+        dc.setCapability("platformName", "Windows")
+        when(remoteWebDriver.getCapabilities()).thenReturn(dc)
+        Actor dana = new Actor("Dana")
+        dana.can(BrowseTheWeb.with(remoteWebDriver))
+        when:
+        CROSS_PLATFORM_BY_TARGET.resolveFor(dana).toString()
+        then:
+        ThucydidesConfigurationException e = thrown()
+        e.message.contains("is not a valid platform for Cross Platform Mobile targets")
+    }
+
+    def "targets can have a single locator"() {
+        given:
+        dc.setCapability("platformName", configuredPlatform)
+        when(appiumDriver.getCapabilities()).thenReturn(dc)
+        Actor dana = new Actor("Dana")
+        dana.can(BrowseTheWeb.with(appiumDriver))
+        when:
+        def description = BY_TARGET.resolveFor(dana).toString()
+        then:
+        description.contains(expectedElementString)
+        where:
+        configuredPlatform     | expectedElementString
+        "IOS"                  | "Simple locator"
+        "android"              | "Simple locator"
+    }
+}


### PR DESCRIPTION
Add the ability to define one locator for Android and another for iOS. If one is defined, the other also must be. The correct locator will be returned based on the `platformName` set on the driver for the `Actor` resolving the `Target`.

Usage example:
`Target.the("Cross Platform By Target").locatedForAndroid(MobileBy.id("android_element_id")).locatedForIOS(MobileBy.id("iOS_element_id"))`