### PR TITLE
 Use platformName instead of platform when deciding the MobilePlatform

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
@@ -3,6 +3,7 @@ package net.thucydides.core.webdriver.appium;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.PathProcessor;
 import net.thucydides.core.webdriver.*;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -38,8 +39,13 @@ public class AppiumConfiguration {
      * Must be either ios or android.
      */
     public MobilePlatform getTargetPlatform(WebDriver driver) {
+        String PLATFORM_NAME = "platformName";
         try {
-            return MobilePlatform.valueOf(((RemoteWebDriver) driver).getCapabilities().getPlatform().name());
+            Capabilities caps = ((RemoteWebDriver) driver).getCapabilities();
+            if (caps.getCapabilityNames().contains(PLATFORM_NAME)) {
+                return MobilePlatform.valueOf(
+                        caps.getCapability(PLATFORM_NAME).toString().toUpperCase());
+            }
         } catch (IllegalArgumentException e) {
             LOGGER.debug("Platform was not a MobilePlatform. Falling back to other platform definitions.");
         } catch (ClassCastException e) {

--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
@@ -6,7 +6,6 @@ import net.thucydides.core.util.PathProcessor
 import net.thucydides.core.webdriver.MobilePlatform
 import net.thucydides.core.webdriver.ThucydidesConfigurationException
 import net.thucydides.core.webdriver.WebDriverFacade
-import org.openqa.selenium.Platform
 import org.openqa.selenium.remote.DesiredCapabilities
 import org.openqa.selenium.remote.RemoteWebDriver
 import spock.lang.Specification
@@ -91,7 +90,7 @@ class WhenConfiguringAnAppiumDriver extends Specification {
         given:
         def driver = Stub(RemoteWebDriver)
         def caps = new DesiredCapabilities()
-        caps.setPlatform(Platform.valueOf(value.toUpperCase()))
+        caps.setCapability("platformName", value)
         driver.getCapabilities() >> caps
         def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
         when:

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/ByTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/targets/ByTarget.java
@@ -43,8 +43,9 @@ public class ByTarget extends Target {
         if (null != this.androidLocator && null != this.iosLocator) {
             String platform;
             try {
-                platform = ((RemoteWebDriver) BrowseTheWeb.as(actor).getDriver()).getCapabilities()
-                                                                                 .getPlatform().name().toUpperCase();
+                platform = ((RemoteWebDriver) BrowseTheWeb.as(actor).getDriver())
+                                                    .getCapabilities().getCapability("platformName")
+                                                                      .toString().toUpperCase();
             } catch (ClassCastException e) {
                 throw new ThucydidesConfigurationException(String.format(
                         "The configured driver '%s' does not support Cross Platform Mobile targets",


### PR DESCRIPTION
Also checks that platformName exists in the capabilities to avoid NullPointerException