### PR TITLE
Make WebElementFacade withTimeoutOf method signature consistent with PageObject

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacade.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacade.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.interactions.internal.Locatable;
 import org.openqa.selenium.internal.WrapsElement;
 import org.openqa.selenium.support.ui.Wait;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -40,7 +41,10 @@ public interface WebElementFacade extends WebElement, WrapsElement, Locatable, W
 
     long getImplicitTimeoutInMilliseconds();
 
+    @Deprecated
     <T extends WebElementFacade> T withTimeoutOf(int timeout, TimeUnit unit);
+
+    <T extends WebElementFacade> T withTimeoutOf(Duration duration);
 
     /**
      * Convenience method to chain method calls more fluently.

--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
@@ -387,6 +387,17 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
                 foundBy);
     }
 
+    public WebElementFacade withTimeoutOf(Duration duration) {
+        return wrapWebElement(driver,
+                resolvedELement,
+                webElement,
+                bySelector,
+                locator,
+                duration.toMillis(),
+                duration.toMillis(),
+                foundBy);
+    }
+
     /**
      * Is this web element present and visible on the screen
      * This method will not throw an exception if the element is not on the screen at all.


### PR DESCRIPTION
Deprecated old withTimeoutOf(int, TimeUnit) method and replaced with withTimeoutOf(Duration) for WebElementFacade to bring it in line with the PageObject implementation.

fixes #1564 