### PR TITLE
report bugfix: disable link to "Unsuccesful" tests when all tests are passing

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/reports/html/ResultCounts.java
+++ b/serenity-model/src/main/java/net/thucydides/core/reports/html/ResultCounts.java
@@ -44,6 +44,14 @@ public class ResultCounts {
         return totalTests.getOrDefault(TestResult.valueOf(result.toUpperCase()),0);
     }
 
+    public Integer getOverallTestsCount(String... results) {
+        int allTestsCount = 0;
+        for(String result : results) {
+            allTestsCount += getOverallTestCount(result);
+        }
+        return allTestsCount;
+    }
+
     public Integer getTotalAutomatedTestCount() {
         return totalAutomatedTests;
     }

--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -366,15 +366,27 @@
                                                             </tr>
                                                             <tr>
                                                                 <#if resultCounts.hasManualTests() >
-                                                                    <td colspan="7"><a
-                                                                            href="${relativeLink}${brokenReport}"><i
-                                                                            class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
-                                                                    </td>
+                                                                        <#if (resultCounts.getOverallTestsCount("failure","error","compromised") != 0)>
+                                                                            <td colspan="7"><a
+                                                                                    href="${relativeLink}${brokenReport}"><i
+                                                                                    class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        <#else>
+                                                                            <td colspan="7"><i
+                                                                                class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        </#if>
                                                                 <#else>
-                                                                    <td colspan="3"><a
-                                                                            href="${relativeLink}${brokenReport}"><i
-                                                                            class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
-                                                                    </td>
+                                                                        <#if (resultCounts.getOverallTestsCount("failure","error","compromised") != 0)>
+                                                                            <td colspan="3"><a
+                                                                                    href="${relativeLink}${brokenReport}"><i
+                                                                                    class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        <#else>
+                                                                            <td colspan="3"><i
+                                                                                class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        </#if>
                                                                 </#if>
                                                             </tr>
                                                             <tr>

--- a/serenity-report-resources/src/main/resources/freemarker/outcomes-with-result.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/outcomes-with-result.ftl
@@ -350,15 +350,27 @@
                                                             </tr>
                                                             <tr>
                                                                 <#if resultCounts.hasManualTests() >
-                                                                    <td colspan="7"><a
-                                                                            href="${relativeLink}${brokenReport}"><i
-                                                                            class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
-                                                                    </td>
+                                                                        <#if (resultCounts.getOverallTestsCount("failure","error","compromised") != 0)>
+                                                                            <td colspan="7"><a
+                                                                                    href="${relativeLink}${brokenReport}"><i
+                                                                                    class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        <#else>
+                                                                            <td colspan="7"><i
+                                                                                class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        </#if>
                                                                 <#else>
-                                                                    <td colspan="3"><a
-                                                                            href="${relativeLink}${brokenReport}"><i
-                                                                            class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
-                                                                    </td>
+                                                                        <#if (resultCounts.getOverallTestsCount("failure","error","compromised") != 0)>
+                                                                            <td colspan="3"><a
+                                                                                    href="${relativeLink}${brokenReport}"><i
+                                                                                    class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        <#else>
+                                                                            <td colspan="3"><i
+                                                                                class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        </#if>
                                                                 </#if>
                                                             </tr>
                                                             <tr>

--- a/serenity-report-resources/src/main/resources/freemarker/requirements.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/requirements.ftl
@@ -496,15 +496,28 @@
                                                                 </#if>
                                             </tr>
                                             <tr>
-                                                                <#if resultCounts.hasManualTests() >
-                                                                    <td colspan="7"><a href="${brokenReport}"><i
-                                                                            class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
-                                                                    </td>
+                                                                 <#if resultCounts.hasManualTests() >
+                                                                        <#if (resultCounts.getOverallTestsCount("failure","error","compromised") != 0)>
+                                                                           <td colspan="7"><a href="${brokenReport}"><i
+                                                                                   class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                           </td>
+                                                                        <#else>
+                                                                            <td colspan="7"><i
+                                                                                class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        </#if>
                                                                 <#else>
-                                                                    <td colspan="3"><a href="${brokenReport}"><i
-                                                                            class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
-                                                                    </td>
+                                                                        <#if (resultCounts.getOverallTestsCount("failure","error","compromised") != 0)>
+                                                                             <td colspan="3"><a href="${brokenReport}"><i
+                                                                                    class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        <#else>
+                                                                            <td colspan="3"><i
+                                                                                class='fa fa-times failure-icon'></i>&nbsp;<em>Unsuccessful</em></a>
+                                                                            </td>
+                                                                        </#if>
                                                                 </#if>
+
                                             </tr>
 
                                             <tr>


### PR DESCRIPTION
even when all the tests are passing, the link to “unsuccessful” test results remains active, but leads to a non-existent page