### PR TITLE
Improve report error message readability

### DIFF
--- a/serenity-report-resources/src/main/resources/report-resources/css/core.css
+++ b/serenity-report-resources/src/main/resources/report-resources/css/core.css
@@ -527,7 +527,8 @@ i.tag {
 }
 
 .error-message-title {
-    font-size: 16px;
+    font-family:monospace; font-size: 14px; color: black;
+    white-space: pre-wrap;
 }
 .parameters {
     display: block;


### PR DESCRIPTION
* Maintain whitespace formatting of the message
* Font change to monospace, black and slightly smaller

An example of the changes:
![reports-comparison](https://user-images.githubusercontent.com/23417062/53962271-4a57a800-40f3-11e9-8832-1843c45eaddd.png)
