### PR TITLE
fix: Test tags for parameterized JUnit tests: #1378 and #1261

### DIFF
--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/DataDrivenAnnotations.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/DataDrivenAnnotations.java
@@ -65,13 +65,12 @@ public class DataDrivenAnnotations {
                 .build();
     }
 
-    public FrameworkMethod getTestMethod() {
+    public List<FrameworkMethod> getTestMethods() {
         List<FrameworkMethod> methods = testClass.getAnnotatedMethods(Test.class);
-
-        return methods.stream()
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Parameterized test should have at least one @Test method"));
-
+        if (methods.isEmpty()) {
+            throw new IllegalStateException("Parameterized test should have at least one @Test method");
+        }
+        return methods;
     }
 
     public DataTable getParametersTableFromTestDataAnnotation() {

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityParameterizedRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityParameterizedRunner.java
@@ -106,8 +106,7 @@ public class SerenityParameterizedRunner extends Suite implements Taggable {
 
     private List<Runner> buildTestRunnersForEachDataSetUsing(final WebDriverFactory webDriverFactory,
                                                      final BatchManager batchManager) throws Throwable {
-
-        if (shouldSkipTest(getTestAnnotations().getTestMethod())) {
+        if (shouldSkipAllTests()) {
             return new ArrayList<>();
         }
 
@@ -129,8 +128,7 @@ public class SerenityParameterizedRunner extends Suite implements Taggable {
 
     private List<Runner> buildTestRunnersFromADataSourceUsing(final WebDriverFactory webDriverFactory,
                                                       final BatchManager batchManager) throws Throwable {
-
-        if (shouldSkipTest(getTestAnnotations().getTestMethod())) {
+        if (shouldSkipAllTests()) {
             return new ArrayList<>();
         }
 
@@ -153,6 +151,13 @@ public class SerenityParameterizedRunner extends Suite implements Taggable {
 
     private boolean shouldSkipTest(FrameworkMethod method) {
         return !tagScanner.shouldRunMethod(getTestClass().getJavaClass(), method.getName());
+    }
+
+    private boolean shouldSkipAllTests() {
+        return getTestAnnotations()
+                .getTestMethods()
+                .stream()
+                .allMatch(this::shouldSkipTest);
     }
 
     private String getQualifierFor(final Object testCase) {


### PR DESCRIPTION
Fix using test tags for parameterized JUnit test classes containing multiple test methods.