### PR TITLE
#1653 Fixed inconsistency in the timeout setup for screenplay compared to the page pattern

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/configuration/SystemPropertiesConfiguration.java
+++ b/serenity-model/src/main/java/net/thucydides/core/configuration/SystemPropertiesConfiguration.java
@@ -25,7 +25,7 @@ public class SystemPropertiesConfiguration implements Configuration {
     /**
      * Default timeout when waiting for AJAX elements in pages, in milliseconds.
      */
-    public static final int DEFAULT_ELEMENT_TIMEOUT_SECONDS = 5;
+    public static final int DEFAULT_ELEMENT_TIMEOUT_SECONDS = 5000;
 
     public static final Integer DEFAULT_ESTIMATED_AVERAGE_STEP_COUNT = 5;
 

--- a/serenity-model/src/main/java/net/thucydides/core/configuration/SystemPropertiesConfiguration.java
+++ b/serenity-model/src/main/java/net/thucydides/core/configuration/SystemPropertiesConfiguration.java
@@ -25,7 +25,7 @@ public class SystemPropertiesConfiguration implements Configuration {
     /**
      * Default timeout when waiting for AJAX elements in pages, in milliseconds.
      */
-    public static final int DEFAULT_ELEMENT_TIMEOUT_SECONDS = 5000;
+    public static final int DEFAULT_ELEMENT_TIMEOUT_MILLISECONDS = 5000;
 
     public static final Integer DEFAULT_ESTIMATED_AVERAGE_STEP_COUNT = 5;
 
@@ -140,7 +140,7 @@ public class SystemPropertiesConfiguration implements Configuration {
 
     @Override
     public int getElementTimeout() {
-        int elementTimeout = DEFAULT_ELEMENT_TIMEOUT_SECONDS;
+        int elementTimeout = DEFAULT_ELEMENT_TIMEOUT_MILLISECONDS;
 
         String stepDelayValue = THUCYDIDES_TIMEOUT.from(environmentVariables);
         if ((stepDelayValue != null) && (!stepDelayValue.isEmpty())) {

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/EventualConsequence.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/EventualConsequence.java
@@ -30,7 +30,7 @@ public class EventualConsequence<T> implements Consequence<T>, CanBeSilent {
 
     public EventualConsequence(Consequence<T> consequenceThatMightTakeSomeTime) {
         this(consequenceThatMightTakeSomeTime,
-             ConfiguredEnvironment.getConfiguration().getElementTimeout() * 1000);
+             ConfiguredEnvironment.getConfiguration().getElementTimeout());
     }
 
     public static <T> EventualConsequence<T> eventually(Consequence<T> consequenceThatMightTakeSomeTime) {


### PR DESCRIPTION
Following are the changes

- Removed the seconds to milliseconds conversion from EventualConsequence constructor.

- Corrected the timeout default value in SystemPropertiesConfiguration to milliseconds
-Renamed the timeout variable to match the documentation.

All tests passed locally and tested the snapshot with other projects with screenplay and page object patterns.