### PR TITLE
feat: the teardown for an Ability will be called from Onstage.drawTheCurtain()

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
@@ -14,10 +14,7 @@ import net.thucydides.core.steps.ExecutedStepDescription;
 import net.thucydides.core.steps.StepEventBus;
 
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static net.serenitybdd.screenplay.SilentTasks.isNestedInSilentTask;
 import static net.serenitybdd.screenplay.SilentTasks.isSilent;
@@ -100,8 +97,7 @@ public class Actor implements PerformsTasks, SkipNested {
      * Return an ability that extends the given class. Can be a Superclass or an Interface. If there are multiple
      * candidate Abilities, the first one found will be returned.
      * @param extendedClass the Interface class that we expect to find
-     * @param <C> the matching Ability cast to extendedClass
-     * @throws NoMatchingAbilityException when we don't find an appropriate Ability
+     * @param <C> the matching Ability cast to extendedClass or null if none match
      */
     @SuppressWarnings("unchecked")
     public <C> C getAbilityThatExtends(Class<C> extendedClass) {
@@ -113,6 +109,19 @@ public class Actor implements PerformsTasks, SkipNested {
             }
         }
         return null;
+    }
+
+    /**
+     * Return a list of all {@link Ability}s which implement {@link HasTeardown}
+     */
+    public List<HasTeardown> getTeardowns() {
+        List<HasTeardown> teardowns = new ArrayList<>();
+        for (Ability a : abilities.values()) {
+            if (a instanceof HasTeardown) {
+                teardowns.add((HasTeardown) a);
+            }
+        }
+        return teardowns;
     }
 
     /**

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/HasTeardown.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/HasTeardown.java
@@ -1,0 +1,11 @@
+package net.serenitybdd.screenplay;
+
+import net.serenitybdd.screenplay.actors.OnStage;
+
+/**
+ * Implement this Interface when you wish an {@link Ability} to be torn down upon calling
+ * {@link OnStage#drawTheCurtain()}
+ */
+public interface HasTeardown {
+    void tearDown();
+}

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/actors/Cast.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/actors/Cast.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import net.serenitybdd.screenplay.Ability;
 import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.HasTeardown;
 
 import java.util.List;
 import java.util.Map;
@@ -74,7 +75,19 @@ public class Cast {
     }
 
     public void dismissAll() {
+        runTeardowns();
         actors.clear();
+    }
+
+    /**
+     * Run the teardown for any {@link Ability} that implements one.
+     */
+    private void runTeardowns() {
+        for (Actor a : actors.values()) {
+            for (HasTeardown ability : a.getTeardowns()) {
+                ability.tearDown();
+            }
+        }
     }
 
     protected void assignGeneralAbilitiesTo(Actor newActor) {

--- a/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/actors/WhenRecruitingACast.groovy
+++ b/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/actors/WhenRecruitingACast.groovy
@@ -2,6 +2,7 @@ package net.serenitybdd.screenplay.actors
 
 import net.serenitybdd.screenplay.Ability
 import net.serenitybdd.screenplay.Actor
+import net.serenitybdd.screenplay.HasTeardown
 import spock.lang.Specification
 
 import java.util.function.Consumer
@@ -50,6 +51,23 @@ class WhenRecruitingACast extends Specification {
             Actor kenneth = globeTheatreCast.actorNamed("Kenneth")
         then:
             kenneth.abilityTo(Fetch.class).item == "Coffee"
+    }
+
+    static class PerformHamlet implements Ability, HasTeardown {
+
+        @Override
+        void tearDown() {}
+    }
+
+    def "cast members can tidy up after themselves"() {
+        given:
+            PerformHamlet performHamlet = Mock(PerformHamlet.class)
+            OnStage.setTheStage(Cast.whereEveryoneCan(performHamlet))
+            OnStage.theActorCalled("Laurence")
+        when:
+            OnStage.drawTheCurtain()
+        then:
+            1 * performHamlet.tearDown()
     }
 
 }


### PR DESCRIPTION
Abilities represent a particular API to the SUT. In some cases there will be resources specific to that API which will need to be cleaned up upon completion of the test. This change allows that to be defined for each Ability, so that regardless of what Cast/Actors/Abilities are being used in a test, only `Onstage.drawTheCurtain()` needs to be called and all of the tear down will be performed.