### PR TITLE
fix: orComplainWith did override the timeout of EventualConsequence

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/EventualConsequence.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/EventualConsequence.java
@@ -97,7 +97,8 @@ public class EventualConsequence<T> implements Consequence<T>, CanBeSilent {
 
     @Override
     public Consequence<T> orComplainWith(Class<? extends Error> complaintType) {
-        return new EventualConsequence(consequenceThatMightTakeSomeTime.orComplainWith(complaintType));
+        return new EventualConsequence(consequenceThatMightTakeSomeTime.orComplainWith(complaintType),
+            timeoutInMilliseconds, isSilent);
     }
 
     public Consequence<T> ignoringExceptions(Class<? extends Throwable>... exceptionsToIgnore) {
@@ -107,17 +108,20 @@ public class EventualConsequence<T> implements Consequence<T>, CanBeSilent {
 
     @Override
     public Consequence<T> orComplainWith(Class<? extends Error> complaintType, String complaintDetails) {
-        return new EventualConsequence(consequenceThatMightTakeSomeTime.orComplainWith(complaintType, complaintDetails));
+        return new EventualConsequence(consequenceThatMightTakeSomeTime.orComplainWith(complaintType,
+            complaintDetails), timeoutInMilliseconds, isSilent);
     }
 
     @Override
     public Consequence<T> whenAttemptingTo(Performable performable) {
-        return new EventualConsequence<T>(consequenceThatMightTakeSomeTime.whenAttemptingTo(performable));
+        return new EventualConsequence<T>(consequenceThatMightTakeSomeTime.whenAttemptingTo(performable),
+            timeoutInMilliseconds, isSilent);
     }
 
     @Override
     public Consequence<T> because(String explanation) {
-        return new EventualConsequence<T>(consequenceThatMightTakeSomeTime.because(explanation));
+        return new EventualConsequence<T>(consequenceThatMightTakeSomeTime.because(explanation),
+            timeoutInMilliseconds, isSilent);
     }
 
     @Override

--- a/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/ThisTakesTooLong.java
+++ b/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/ThisTakesTooLong.java
@@ -1,0 +1,14 @@
+package net.serenitybdd.screenplay;
+
+public class ThisTakesTooLong  extends AssertionError {
+  public ThisTakesTooLong() {
+  }
+
+  public ThisTakesTooLong(Object detailMessage) {
+    super(detailMessage);
+  }
+
+  public ThisTakesTooLong(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/questions/NextPersonToBeServed.java
+++ b/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/questions/NextPersonToBeServed.java
@@ -1,0 +1,27 @@
+package net.serenitybdd.screenplay.shopping.questions;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+import net.serenitybdd.screenplay.shopping.tasks.Checkout;
+
+public class NextPersonToBeServed implements Question<String> {
+
+  private Checkout checkout;
+
+  public NextPersonToBeServed(Checkout checkout) {
+    this.checkout = checkout;
+  }
+
+  public static NextPersonToBeServed nextPersonToBeServed() {
+    return new NextPersonToBeServed(null);
+  }
+
+  @Override
+  public String answeredBy(Actor actor) {
+    return checkout.nextCustomer();
+  }
+
+  public NextPersonToBeServed by(Checkout fastCheckout) {
+    return new NextPersonToBeServed(fastCheckout);
+  }
+}

--- a/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/tasks/Checkout.java
+++ b/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/tasks/Checkout.java
@@ -1,0 +1,44 @@
+package net.serenitybdd.screenplay.shopping.tasks;
+
+public class Checkout  implements Runnable{
+
+  private final int waitTimeInSeconds;
+  private volatile String nextCustomer = "Bob";
+
+  public Checkout(int waitTimeInSeconds) {
+    this.waitTimeInSeconds = waitTimeInSeconds;
+  }
+
+  public static Checkout fastCheckout() {
+    Checkout checkout = new Checkout(2);
+    checkout.startTimer();
+    return checkout;
+  }
+
+  public static Checkout slowCheckout() {
+    Checkout checkout = new Checkout(7);
+    checkout.startTimer();
+    return checkout;
+  }
+
+  public String nextCustomer() {
+    return nextCustomer;
+  }
+
+
+  private void startTimer(){
+    new Thread(() -> {
+      try {
+        Thread.sleep(waitTimeInSeconds * 1000);
+        run();
+      } catch (InterruptedException ignored) {}
+    }).start();
+  }
+
+  @Override
+  public void run() {
+    nextCustomer = "Dana";
+  }
+}
+
+

--- a/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/tasks/JoinTheCheckoutQueue.java
+++ b/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/tasks/JoinTheCheckoutQueue.java
@@ -1,0 +1,22 @@
+package net.serenitybdd.screenplay.shopping.tasks;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Performable;
+
+import static net.serenitybdd.screenplay.Tasks.instrumented;
+
+public class JoinTheCheckoutQueue implements Performable {
+
+  public static JoinTheCheckoutQueue joinTheCheckoutQueue() {
+    return instrumented(JoinTheCheckoutQueue.class);
+  }
+
+  public JoinTheCheckoutQueue of(Checkout c) {
+    return instrumented(JoinTheCheckoutQueue.class);
+  }
+
+  @Override
+  public <T extends Actor> void performAs(T actor) {
+
+  }
+}


### PR DESCRIPTION
changed orComplainWith and other chained methods to use a different constructor, timeout and isSilent should now persist
fixes #1677 

I am not sure how to test the isSilent though..