### PR TITLE
fix: Remove exclamation marks from the Page Title

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Serenity Reports!!!!!</title>
+    <title>Serenity Reports</title>
 
     <#include "libraries/favicon.ftl">
 


### PR DESCRIPTION
It looks like these exclamation marks were added erroneously in 9d7f7a77