### PR TITLE
Handle any WebDriverException when evaluating usability of webelements collection for default strategy.

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/annotations/locators/WaitForWebElementCollection.java
+++ b/serenity-core/src/main/java/net/thucydides/core/annotations/locators/WaitForWebElementCollection.java
@@ -22,7 +22,7 @@ public class WaitForWebElementCollection {
             if (elements == null) {
                 return false;
             }
-            return elements.isEmpty() || elements.get(0).isDisplayed();
+            return elements.isEmpty() || ElementIsUsable.forElement(elements.get(0));
         });
 
         COLLECTION_STRATEGY.put(Paranoid, elements -> {


### PR DESCRIPTION
The original intent of this pull request is to work around StaleElementReferenceException that sometimes  occurs when visiting list of WebElement annotated with FindBy.

When page is updated, the WebElements in the collection appear stale. When Serenity PageObject is trying to revisit this collection, directly calling WebElement::isDisplayed() method throws StaleElementReferenceException. To handle this, for `Paranoid` strategy it is handled by using ElementIsUsable::forElement() that handles generic WebDriverException. On the contrary, the default `Pessimistic` strategy does not handle exception at all.


DISCLAIMER: I haven't had a chance to run CI on this change - please suggest documentation on it