### PR TITLE
fix: Configuration object was being coppied when a new PageURLS objec…

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/configuration/WebDriverConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/configuration/WebDriverConfiguration.java
@@ -58,19 +58,4 @@ public class WebDriverConfiguration<T extends DriverConfiguration> extends Syste
                 + " is not a supported browser. Supported driver values are: "
                 + SupportedWebDriver.listOfSupportedDrivers());
     }
-
-    @Override
-    public WebDriverConfiguration copy() {
-        return withEnvironmentVariables(getEnvironmentVariables());
-    }
-
-
-    @Override
-    public WebDriverConfiguration withEnvironmentVariables(EnvironmentVariables environmentVariables) {
-        WebDriverConfiguration copy = new WebDriverConfiguration(environmentVariables.copy());
-        copy.outputDirectory = null; // Reset to be reloaded from the System properties
-        copy.defaultBaseUrl = defaultBaseUrl;
-        return copy;
-    }
-
 }

--- a/serenity-core/src/test/java/net/thucydides/core/webdriver/WhenManagingGlobalConfiguration.java
+++ b/serenity-core/src/test/java/net/thucydides/core/webdriver/WhenManagingGlobalConfiguration.java
@@ -29,16 +29,6 @@ public class WhenManagingGlobalConfiguration {
     }
 
     @Test
-    public void a_configuration_can_be_safely_copied() {
-        environmentVariables.setProperty("thucydides.step.delay", "1000");
-        Configuration copy = configuration.copy();
-        ((SystemPropertiesConfiguration) copy).getEnvironmentVariables().setProperty("thucydides.step.delay", "2000");
-        assertThat(copy.getStepDelay(), is(not(configuration.getStepDelay())));
-        assertThat(configuration.getStepDelay(), is(1000));
-    }
-
-
-    @Test
     public void the_browser_restart_value_can_be_defined_in_a_system_property() {
         environmentVariables.setProperty("thucydides.restart.browser.frequency", "5");
 

--- a/serenity-model/src/main/java/net/thucydides/core/configuration/SystemPropertiesConfiguration.java
+++ b/serenity-model/src/main/java/net/thucydides/core/configuration/SystemPropertiesConfiguration.java
@@ -61,7 +61,7 @@ public class SystemPropertiesConfiguration implements Configuration {
 
     protected String defaultBaseUrl;
 
-    private final EnvironmentVariables environmentVariables;
+    protected EnvironmentVariables environmentVariables;
 
     private final FilePathParser filePathParser;
 
@@ -71,24 +71,16 @@ public class SystemPropertiesConfiguration implements Configuration {
         filePathParser = new FilePathParser(environmentVariables);
     }
 
-    public Configuration copy() {
-        return withEnvironmentVariables(environmentVariables);
-    }
-
-
-    public Configuration withEnvironmentVariables(EnvironmentVariables environmentVariables) {
-        SystemPropertiesConfiguration copy = new SystemPropertiesConfiguration(environmentVariables.copy());
-        copy.outputDirectory = null; // Reset to be reloaded from the System properties
-        copy.defaultBaseUrl = defaultBaseUrl;
-        return copy;
+    @Override
+    public SystemPropertiesConfiguration withEnvironmentVariables(final EnvironmentVariables environmentVariables) {
+        this.environmentVariables = environmentVariables;
+        return this;
     }
 
     @Override
     public EnvironmentVariables getEnvironmentVariables() {
         return environmentVariables;
     }
-
-
 
     /**
      * Where should the reports go?

--- a/serenity-model/src/main/java/net/thucydides/core/webdriver/Configuration.java
+++ b/serenity-model/src/main/java/net/thucydides/core/webdriver/Configuration.java
@@ -55,8 +55,6 @@ public interface Configuration<T extends Configuration> {
 
     void setIfUndefined(String property, String value);
 
-    T copy();
-
     T withEnvironmentVariables(EnvironmentVariables environmentVariables);
 
     EnvironmentVariables getEnvironmentVariables();


### PR DESCRIPTION
Fixes #1701

#### Summary of this PR

Instead of creating a new instance of a Configuration so that the environment variables can be re-set, the environment variables have been changed to none final, and can be set using the withEnvironmentVariables method. 

#### Intended effect

When updating the environment variables, the current configuration object will be updated instead of creating an entirely new object just to update the environment variables. 

#### How should this be manually tested?

There is a sample project in issue #1701 that can be used to debug the configuration. 

After this change has been applied the configuration returned by ConfiguredEnvironment.getConfiguration() should be the same object as the Configuration stored on any PageUrls object, and any changes made to the configuration should be visible on the Configuration when accessed via either of these places. 

#### Relevant tickets

 issue #1701

#### Screenshots (if appropriate)

Before the pull request the object reference will be different when checking the configuration:
![image](https://user-images.githubusercontent.com/17050928/60192403-b2123a00-982d-11e9-9547-28badfbbeb6c.png)

After the pull request the object reference will be the same:

![image](https://user-images.githubusercontent.com/17050928/60192603-01586a80-982e-11e9-9023-2d16e5b373e3.png)
