### PR TITLE
feat: allow keep tags unformatted via 'report.raw.tag.list' property

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -1091,6 +1091,12 @@ public enum ThucydidesSystemProperty {
     DASHBOARD_EXCLUDED_TAG_LIST,
 
     /**
+     * If set, this will define the list of tag types which will be not formatted with title case in HTML report.
+     * This option allows to preserve underscores or camel case in tag name.
+     */
+    REPORT_RAW_TAG_LIST,
+
+    /**
      * Format the JSON test outcomes nicely.
      * "true" or "false", turned off by default.
      */

--- a/serenity-model/src/main/java/net/thucydides/core/reports/html/TagFilter.java
+++ b/serenity-model/src/main/java/net/thucydides/core/reports/html/TagFilter.java
@@ -112,4 +112,8 @@ public class TagFilter {
                         tag -> !hiddenTypes.contains(tag.getType())
                 ).collect(Collectors.toSet());
     }
+
+    public Set<String> rawTagTypes() {
+        return new HashSet<>(asLowercaseList(ThucydidesSystemProperty.REPORT_RAW_TAG_LIST.from(environmentVariables)));
+    }
 }

--- a/serenity-model/src/main/java/net/thucydides/core/util/TagInflector.java
+++ b/serenity-model/src/main/java/net/thucydides/core/util/TagInflector.java
@@ -1,0 +1,51 @@
+package net.thucydides.core.util;
+
+import static org.apache.commons.lang3.StringUtils.lowerCase;
+
+import org.apache.commons.lang3.StringUtils;
+
+import net.thucydides.core.reports.html.TagFilter;
+
+public class TagInflector {
+
+    private static TagFilter tagFilter;
+
+    public TagInflector(EnvironmentVariables environmentVariables) {
+        tagFilter = new TagFilter(environmentVariables);
+    }
+
+    public InflectableTag ofTag(String tagType, String tagName) {
+        return new InflectableTag(tagType, tagName);
+    }
+
+    public static final class InflectableTag {
+
+        private String tagType;
+        private String tagName;
+
+        InflectableTag(String tagType, String tagName) {
+            this.tagType = tagType;
+            this.tagName = tagName;
+        }
+
+        public String toFinalView() {
+            if (shouldFormatAsTitle()) {
+                return asTitle();
+            } else {
+                return rawName();
+            }
+        }
+
+        private boolean shouldFormatAsTitle() {
+            return !tagFilter.rawTagTypes().contains(lowerCase(tagType));
+        }
+
+        private String asTitle() {
+            return Inflector.getInstance().of(tagName).asATitle().toString();
+        }
+
+        private String rawName() {
+            return tagName;
+        }
+    }
+}

--- a/serenity-model/src/test/java/net/thucydides/core/util/TagInflectorTest.java
+++ b/serenity-model/src/test/java/net/thucydides/core/util/TagInflectorTest.java
@@ -1,0 +1,47 @@
+package net.thucydides.core.util;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import net.thucydides.core.ThucydidesSystemProperty;
+
+public class TagInflectorTest {
+
+    private static final String PROPERTY_UNDER_TEST = ThucydidesSystemProperty.REPORT_RAW_TAG_LIST.getPropertyName();
+    private EnvironmentVariables environmentVariables;
+
+    @Before
+    public void setUp() {
+        environmentVariables = new MockEnvironmentVariables();
+    }
+
+    @Test
+    public void shouldKeepTagRaw() {
+        environmentVariables.setProperty(PROPERTY_UNDER_TEST, "another,one,bites,the,dust");
+        TagInflector tagInflector = new TagInflector(environmentVariables);
+        String outputValue = tagInflector.ofTag("another", "tag_with_underscores").toFinalView();
+        assertEquals(format("tag should not be formatted as it was defined in '%s' property", PROPERTY_UNDER_TEST),
+            "tag_with_underscores", outputValue);
+    }
+
+    @Test
+    public void shouldFormatNotDefinedTag() {
+        environmentVariables.setProperty(PROPERTY_UNDER_TEST, "anothertag1,anothertag2");
+        TagInflector tagInflector = new TagInflector(environmentVariables);
+        String outputValue = tagInflector.ofTag("rawtype", "tag_with_underscores").toFinalView();
+        assertNotEquals(format("tag should be formatted as it was not defined in '%s' property", PROPERTY_UNDER_TEST),
+            "tag_with_underscores", outputValue);
+    }
+
+    @Test
+    public void shouldFormatTagByDefault() {
+        TagInflector tagInflector = new TagInflector(new MockEnvironmentVariables());
+        String outputValue = tagInflector.ofTag("camel", "tagCamelCase").toFinalView();
+        assertNotEquals(format("tag should be formatted as property '%s' not defined", PROPERTY_UNDER_TEST),
+            "tagCamelCase", outputValue);
+    }
+}

--- a/serenity-report-resources/src/main/resources/freemarker/components/tag-list.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/components/tag-list.ftl
@@ -19,7 +19,7 @@
                 </td>
             </tr>
             <#foreach tag in tags>
-                <#assign tagTitle = formatter.htmlCompatible(inflection.of(tag.shortName).asATitle()) >
+                <#assign tagTitle = formatter.htmlCompatible(tagInflector.ofTag(tagType, tag.shortName).toFinalView()) >
                 <#assign tagLabel = inflection.of(tag.name).asATitle() >
                 <#assign tagReport = reportName.inContext(currentTag.completeName).forRequirementOrTag(tag) >
                 <#assign outcomesForTag = testOutcomes.withTag(tag) >

--- a/serenity-report-resources/src/main/resources/freemarker/default.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/default.ftl
@@ -114,7 +114,7 @@
                         <td valign="top">
                             <#list filteredTags as tag>
                                 <#assign tagReport = absoluteReportName.forRequirementOrTag(tag) />
-                                <#assign tagTitle = inflection.of(tag.shortName).asATitle() >
+                                <#assign tagTitle = tagInflector.ofTag(tag.type, tag.shortName).toFinalView() >
                                 <p class="tag">
                                     <#assign tagStyle = styling.tagStyleFor(tag) >
                                     <span class="badge tag-badge" style="${tagStyle}">

--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -98,7 +98,7 @@
         <#assign resultsContext = '> ' + testOutcomes.label>
 
         <#if (currentTagType! != '')>
-            <#assign pageTitle = "<i class='fa fa-tags'></i> " + inflection.of(currentTagType!"").asATitle() + ': ' +  inflection.of(testOutcomes.label).asATitle() >
+            <#assign pageTitle = "<i class='fa fa-tags'></i> " + inflection.of(currentTagType!"").asATitle() + ': ' +  tagInflector.ofTag(currentTagType!"", testOutcomes.label).toFinalView() >
         <#else>
             <#assign pageTitle = inflection.of(testOutcomes.label).asATitle() >
         </#if>
@@ -629,7 +629,7 @@
                                                                                 <a href="${tagResult.report}">
                                                                         <span class="badge"
                                                                               style="background-color:${tagResult.color}; margin:1em;padding:4px;"><i
-                                                                                    class="fa fa-tag"></i> ${inflection.of(tagResult.tag.name).asATitle()}&nbsp;&nbsp;&nbsp;${tagResult.count}</span>
+                                                                                    class="fa fa-tag"></i> ${tagInflector.ofTag(tagResult.tag.type, tagResult.tag.name).toFinalView()}&nbsp;&nbsp;&nbsp;${tagResult.count}</span>
                                                                                 </a>
                                                                             </#list>
                                                                         </div>

--- a/serenity-report-resources/src/main/resources/freemarker/outcomes-with-result.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/outcomes-with-result.ftl
@@ -513,7 +513,7 @@
                                                                     <a href="${tagResult.report}">
                                                                         <span class="badge"
                                                                               style="background-color:${tagResult.color}; margin:1em;padding:4px;"><i
-                                                                                class="fa fa-tag"></i> ${inflection.of(tagResult.tag.name).asATitle()}&nbsp;&nbsp;&nbsp;${tagResult.count}</span>
+                                                                                class="fa fa-tag"></i> ${tagInflector.ofTag(tagResult.tag.type, tagResult.tag.name).toFinalView()}&nbsp;&nbsp;&nbsp;${tagResult.count}</span>
                                                                     </a>
                                                                 </#list>
                                                                 </div>

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/FreemarkerContext.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/FreemarkerContext.java
@@ -20,6 +20,7 @@ import net.thucydides.core.requirements.reports.ScenarioOutcome;
 import net.thucydides.core.requirements.reports.ScenarioOutcomes;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.Inflector;
+import net.thucydides.core.util.TagInflector;
 import net.thucydides.core.util.VersionProvider;
 import org.joda.time.DateTime;
 
@@ -126,6 +127,7 @@ public class FreemarkerContext {
                 .splitToList(REPORT_TAGTYPES.from(environmentVariables, "feature"));
 
         context.put("inflection", Inflector.getInstance());
+        context.put("tagInflector", new TagInflector(environmentVariables));
 
         Collection<TestTag> coveredTags = requirements.getTagsOfType(tagTypes).stream()
                 .filter(tag -> testOutcomes.containsTagMatching(tag))
@@ -180,6 +182,7 @@ public class FreemarkerContext {
         context.put("reportFormatter", reportFormatter);
         context.put("formatted", new NumericalFormatter());
         context.put("inflection", Inflector.getInstance());
+        context.put("tagInflector", new TagInflector(environmentVariables));
         context.put("styling", TagStylist.from(environmentVariables));
         context.put("relativeLink", relativeLink);
         context.put("reportOptions", new ReportOptions(environmentVariables));

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAcceptanceTestReporter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAcceptanceTestReporter.java
@@ -20,6 +20,7 @@ import net.thucydides.core.requirements.model.Requirement;
 import net.thucydides.core.tags.BreadcrumbTagFilter;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.Inflector;
+import net.thucydides.core.util.TagInflector;
 import net.thucydides.core.util.VersionProvider;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -156,7 +157,9 @@ public class HtmlAcceptanceTestReporter extends HtmlReporter implements Acceptan
         context.put("testOutcome", testOutcome);
         context.put("currentTag", TestTag.EMPTY_TAG);
         context.put("inflection", Inflector.getInstance());
-        context.put("styling", TagStylist.from(Injectors.getInjector().getInstance(EnvironmentVariables.class)));
+        EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+        context.put("tagInflector", new TagInflector(environmentVariables));
+        context.put("styling", TagStylist.from(environmentVariables));
         context.put("requirementTypes", requirementsService.getRequirementTypes());
 
         addParentRequirmentFieldToContext(testOutcome, context);


### PR DESCRIPTION
#### Summary of this PR
Proposal for #1764 
#### Intended effect
Improve tags readability in HTML report.
#### How should this be manually tested?
Using installed changes on serenity-cucumber test framework, do next:
* Add tags like `@mytag:value_under_test`, `@mytag:AnotherTag` to Cucumber scenario;
* define Serenity property `report.raw.tag.list=mytag`;
* execute tests and aggregate report;
* check report - `mytag` tags should be `value_under_test` and `AnotherTag` (not `Value Under Test` and `Another Tag` respectively)
#### Side effects
If property enabled, next will be affected:
* tags in tag dashboard on the bottom of index.html page;
* Outcome-with-results page title;
* list of tags on detailed results page;

However, next won't be affected:
* tag in `Functional Coverage Overview` table;
* tag in page breadcrumbs.
#### Documentation
Javadoc for `ThucydidesSystemProperty.REPORT_RAW_TAG_LIST` added.
#### Relevant tickets
#1764 
#### Screenshots (if appropriate)
See screenshots of intended effect in #1764 ticket.
