### PR TITLE
Prevent StackOverflowError during checkOutcomes task with older gradle versions. fixes #1797

### DIFF
--- a/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
+++ b/serenity-gradle-plugin/src/main/groovy/net/serenitybdd/plugins/gradle/SerenityPlugin.groovy
@@ -90,7 +90,7 @@ class SerenityPlugin implements Plugin<Project> {
 
             log.info("SerenityPlugin:checkOutcomes: reportDirectory = ${reportDirectory}")
 
-            inputs.files reportDirectory
+            inputs.files(project.fileTree(reportDirectory))
 
             doLast {
                 updateProperties(project)


### PR DESCRIPTION
#### Summary of this PR
Refactor some code to prevent a StackOverflowError for older gradle versions

I tried writing tests for this in the repository but ran into a lot of issues.
Will add a link to the commit where I tried to test this so maybe someone will be able to help me.

#### Intended effect
the `checkOutcomes` task should now succeed on older gradle versions
#### How should this be manually tested?
Apply the new version of the serenity-gradle-plugin on a trial project
#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
#1797
#### Screenshots (if appropriate)
N/A