### PR TITLE
#1812 Filter desired capabilities

### DIFF
--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
@@ -165,4 +165,25 @@ class WhenConfiguringAnAppiumDriver extends Specification {
         invalidConfiguration.message.contains("The browser under test or path to the app needs to be provided in the appium.app or appium.browserName property.")
     }
 
+    def "should filter Appium properties that are not supported"() {
+        given:
+        environmentVariables.setProperty("appium.unknown", "value")
+        environmentVariables.setProperty("appium.app", 'classpath:/apps/dummy-app')
+        when:
+        def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
+        then:
+        !appiumConfiguration.capabilities.getCapabilityNames().contains("unknown")
+    }
+
+    def "should add 'appium:' prefix if capability listed in 'appium.additional.caps"() {
+        given:
+        environmentVariables.setProperty("appium.unknown", "value")
+        environmentVariables.setProperty("appium.additional.caps", "unknown, ")
+        environmentVariables.setProperty("appium.app", 'classpath:/apps/dummy-app')
+        when:
+        def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
+        then:
+        appiumConfiguration.capabilities.getCapability("appium:unknown") == "value"
+    }
+
 }

--- a/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -31,7 +31,7 @@ public enum ThucydidesSystemProperty {
     /**
      * If using a provided driver, what type is it.
      * The implementation class needs to be defined in the webdriver.provided.{type} system property.
-    */
+     */
     WEBDRIVER_PROVIDED_TYPE,
 
     /**
@@ -1335,6 +1335,12 @@ public enum ThucydidesSystemProperty {
      * Should Serenity Manage your appium servers for you
      */
     MANAGE_APPIUM_SERVERS,
+
+    /**
+     * List of capabilities that should be provided in addition to supported by w3c or Appium
+     * 'appium:' prefix will be added to each of provided name
+     */
+    APPIUM_ADDITIONAL_CAPABILITIES("appium.additional.caps"),
 
     /**
      * Set to true to activate the AcceptInsecureCertificates options for Chrome and Firefox.


### PR DESCRIPTION
#### Summary of this PR

Filter desired capabilities for initiating Appium session - by default, only [supported by w3c](https://www.w3.org/TR/webdriver/#capabilities) and [Appium](http://appium.io/docs/en/writing-running-appium/caps/) are kept, so things like _appium.hub_ or _loggingPref_ won't be included in desired capabilities. 
However, it is possible that interfaces in [java-cllient](https://github.com/appium/java-client) do not contain all of the supported values - so new property `appium.additional.caps` was added to ThucydidesSystemProperty enum to handle such cases. 
For example, now **appium.unlockKey** is not present in AndroidMobileCapabilityType right now, even though it is supported by Appium. Such properties should be prefixed with **appium:** to comply w3c pattern. In order to do that `appium.additional.caps=unlockKey` should be set in properties.

#### Documentation
Documentation should be updated to reflect new property and its behavior if this approach is considered as acceptable.

#### Relevant tickets
#1812
