### PR TITLE
#1831 Disable processing desired capabilities for Appium

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
@@ -132,6 +132,10 @@ public class AppiumConfiguration {
             capabilities.setCapability(key.toString(), appiumProperties.getProperty(key.toString()));
         }
 
+        if (!ThucydidesSystemProperty.APPIUM_PROCESS_DESIRED_CAPABILITIES.booleanFrom(environmentVariables, Boolean.FALSE)) {
+            return capabilities;
+        }
+
         List<String> additionalAppiumCapabilities = getAdditionalAppiumCapabilities();
 
         DesiredCapabilities processedCapabilities = new DesiredCapabilities();

--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
@@ -165,8 +165,9 @@ class WhenConfiguringAnAppiumDriver extends Specification {
         invalidConfiguration.message.contains("The browser under test or path to the app needs to be provided in the appium.app or appium.browserName property.")
     }
 
-    def "should filter Appium properties that are not supported"() {
+    def "should filter Appium properties that are not supported if 'appium.process.desired.capabilities' is enabled"() {
         given:
+        environmentVariables.setProperty("appium.process.desired.capabilities", "true")
         environmentVariables.setProperty("appium.unknown", "value")
         environmentVariables.setProperty("appium.app", 'classpath:/apps/dummy-app')
         when:
@@ -175,15 +176,29 @@ class WhenConfiguringAnAppiumDriver extends Specification {
         !appiumConfiguration.capabilities.getCapabilityNames().contains("unknown")
     }
 
-    def "should add 'appium:' prefix if capability listed in 'appium.additional.caps"() {
+    def "should not filter Appium properties that are not supported if 'appium.process.desired.capabilities' is disabled"() {
         given:
+        environmentVariables.setProperty("appium.build", "value")
+        environmentVariables.setProperty("appium.app", 'classpath:/apps/dummy-app')
+        when:
+        def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
+        then:
+        appiumConfiguration.capabilities.getCapabilityNames().contains("build")
+    }
+
+    def "should add 'appium:' prefix if capability listed in 'appium.additional.capabilities and 'appium.process.desired.capabilities' enabled"() {
+        given:
+        environmentVariables.setProperty("appium.process.desired.capabilities", "true")
         environmentVariables.setProperty("appium.unknown", "value")
-        environmentVariables.setProperty("appium.additional.caps", "unknown, ")
+        environmentVariables.setProperty("appium.additional.capabilities", "unknown, ")
         environmentVariables.setProperty("appium.app", 'classpath:/apps/dummy-app')
         when:
         def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
         then:
         appiumConfiguration.capabilities.getCapability("appium:unknown") == "value"
     }
+
+
+
 
 }

--- a/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
+++ b/serenity-model/src/main/java/net/thucydides/core/ThucydidesSystemProperty.java
@@ -1338,10 +1338,21 @@ public enum ThucydidesSystemProperty {
     MANAGE_APPIUM_SERVERS,
 
     /**
-     * List of capabilities that should be provided in addition to supported by w3c or Appium
-     * 'appium:' prefix will be added to each of provided name
+     * List of capabilities that should be provided in addition to supported by w3c or Appium.
+     * Properties, that match w3c pattern or listed in Appium's interfaces, will be included as is and
+     * 'appium:' prefix will be added to each name provided in this property
      */
-    APPIUM_ADDITIONAL_CAPABILITIES("appium.additional.caps"),
+    APPIUM_ADDITIONAL_CAPABILITIES("appium.additional.capabilities"),
+
+
+    /**
+     * Set to true to enable processing of desired capabilities, created from the provided 'appium:' properties.
+     * If processing is enabled, only capabilities supported by w3c, Appium or mentioned in
+     * {@link ThucydidesSystemProperty#APPIUM_ADDITIONAL_CAPABILITIES} will be included into desired capabilities.
+     * If processing is disabled, all of the properties that have 'appium:' prefix will be included into desired capabilities.
+     * Disabled by default
+     */
+    APPIUM_PROCESS_DESIRED_CAPABILITIES("appium.process.desired.capabilities"),
 
     /**
      * Set to true to activate the AcceptInsecureCertificates options for Chrome and Firefox.


### PR DESCRIPTION
As result of changes introduced by [pull request](https://github.com/serenity-bdd/serenity-core/pull/1824), it is not possible anymore to put properties, that are not supported by w3c/appium, in desired capabilities (adding them to _appium.additional.capabilities_ doesn't help much, because as result in desired capabilities they are prefixed with _appium:_ and it is not expected by external services).
 
New property - _appium.process.desired.capabilities_ introduced. By default it is disabled, so everything that is prefixed with _appium:_ will be added to desired capabilities without any changes (fix for https://github.com/serenity-bdd/serenity-core/issues/1831). 

If this property enabled, then filtering + processing will be applied to provided properties while creating desired capabilities.

Also, _appium.additional.caps_ was renamed to _appium.additional.capabilities_ to avoid further confusion.
