### PR TITLE
#1839 EnvironmentStrategy ENVIRONMENT_CONFIGURED_BUT_NOT_NAMED considered

### DIFF
--- a/serenity-model/src/main/java/net/serenitybdd/core/environment/EnvironmentSpecificConfiguration.java
+++ b/serenity-model/src/main/java/net/serenitybdd/core/environment/EnvironmentSpecificConfiguration.java
@@ -113,6 +113,7 @@ public class EnvironmentSpecificConfiguration {
 
         switch (environmentStrategy) {
             case USE_NORMAL_PROPERTIES:
+            case ENVIRONMENT_CONFIGURED_BUT_NOT_NAMED:
                 return contextlessProperty.apply(propertyName);
 
             case USE_DEFAULT_PROPERTIES:

--- a/serenity-model/src/test/groovy/net/serenitybdd/core/environment/WhenDefiningBaseUrlsForDifferentEnvironments.groovy
+++ b/serenity-model/src/test/groovy/net/serenitybdd/core/environment/WhenDefiningBaseUrlsForDifferentEnvironments.groovy
@@ -222,6 +222,24 @@ class WhenDefiningBaseUrlsForDifferentEnvironments extends Specification {
 
     }
 
+    def """If environments are configured but no environment is set, normal properties will be used
+             environments {
+                dev {
+                    webdriver.base.url = http://dev.myapp.myorg.com
+                }
+        """() {
+
+        given:
+        environmentVariables.setProperties([
+                "environments.dev.webdriver.base.url"  : "http://dev.myapp.myorg.com",
+                "webdriver.base.url"                   : "a.normal.property"
+        ])
+        when:
+        def baseUrl = EnvironmentSpecificConfiguration.from(environmentVariables).getProperty("webdriver.base.url")
+        then:
+        baseUrl == "a.normal.property"
+    }
+
     def "If no configured environment can be found but a property is present in the normal properties, this will be used"() {
 
         given:


### PR DESCRIPTION
#### Summary of this PR
Fixes the situation that no properties are found with environments specified in serenity.conf but no environment named
#### Intended effect
If environments are configured but no environment is named, null was returned for any requested property. With this fix, normal properties are used.
#### How should this be manually tested?
An automated test describing the configuration was added.
#### Side effects
None - regression tests passed.
#### Documentation
Usage outlined in the automated test as well as in the corresponding issue.
#### Relevant tickets
#1839 