### PR TITLE
Fix : iOS locator strategies need to be added in WebElementFacade FindBy strategies #1846

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/annotations/locators/SmartAnnotations.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/annotations/locators/SmartAnnotations.java
@@ -112,6 +112,18 @@ public class SmartAnnotations extends Annotations {
             org.openqa.selenium.By getBy(Annotation annotation) {
                 return By.sclocator(getValue(annotation, this));
             }
+        },
+        BYIOSCLASSCHAIN("iOSClassChain") {
+            @Override
+            org.openqa.selenium.By getBy(Annotation annotation) {
+                return MobileBy.iOSClassChain(getValue(annotation, this));
+            }
+        },
+        BYIOSNSPREDICATE("iOSNsPredicate") {
+            @Override
+            org.openqa.selenium.By getBy(Annotation annotation) {
+                return MobileBy.iOSNsPredicateString(getValue(annotation, this));
+            }
         };
 
         private final String valueName;

--- a/serenity-core/src/main/java/net/thucydides/core/annotations/locators/SmartFieldDecorator.java
+++ b/serenity-core/src/main/java/net/thucydides/core/annotations/locators/SmartFieldDecorator.java
@@ -90,10 +90,10 @@ public class SmartFieldDecorator implements FieldDecorator {
             = Arrays.asList(FindBy.class,
                             net.thucydides.core.annotations.findby.FindBy.class,
                             org.openqa.selenium.support.FindBy.class,
-                            FindBys.class,
-                            FindAll.class,
-                            AndroidFindBy.class,
-                            AndroidFindBys.class);
+                            FindBys.class, FindAll.class, AndroidFindBy.class,
+                            AndroidFindBys.class, AndroidFindAll.class,
+                            iOSXCUITFindBy.class, iOSXCUITFindBys.class,
+                            iOSXCUITFindAll.class);
 //                            iOSFindBy.class,
 //                            iOSFindBys.class);
 


### PR DESCRIPTION
#### Summary of this PR
Added iOSClassChain and iOSNSPredicate in valid locator strategies.
Added iOSXCUITFindBy and some other valid annotations in Legal annotations to find list of elements. 

#### Intended effect
iOS Appium test should be fixed if they are using Class chain and ios predicate as locators. 

#### How should this be manually tested?
An automated appium test for iOS using class chain and ios predicate string locator strategies to find list of elements or just an element can test this. 

#### Side effects
None - regression tests passed.

#### Documentation
Check the corresponding issue created. 

#### Relevant tickets
#1846