### PR TITLE
#1858 Decoupled serenity-model and serenity-core from JUnit (4)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,3 +42,5 @@
 *.pages binary
 *driver binary
 *.woff binary
+*.woff2 binary
+*.exe

--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,7 @@ subprojects {
         options.addStringOption('debug')
         options.addStringOption('Xdoclint:none')
         options.encoding = 'UTF-8'
-        classpath = configurations.compile
+        classpath = configurations.compileClasspath
     }
 
     dokka {
@@ -272,7 +272,9 @@ subprojects {
         testCompile "org.hamcrest:hamcrest-library:${hamcrestVersion}"
         testCompile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
 
-        testCompile("org.codehaus.groovy:groovy-all:${groovyVersion}")
+        testCompile("org.codehaus.groovy:groovy-all:${groovyVersion}") {
+            exclude group: "org.junit.jupiter"
+        }
         testCompile("org.spockframework:spock-core:${spockVersion}") {
             exclude group: "junit"
             exclude group: "org.codehaus.groovy"

--- a/serenity-core/src/main/java/net/thucydides/core/annotations/TestCaseAnnotations.java
+++ b/serenity-core/src/main/java/net/thucydides/core/annotations/TestCaseAnnotations.java
@@ -2,9 +2,9 @@ package net.thucydides.core.annotations;
 
 import net.serenitybdd.core.environment.*;
 import net.thucydides.core.configuration.*;
+import net.thucydides.core.requirements.SerenityTestCaseFinder;
 import net.thucydides.core.webdriver.*;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.runner.*;
 import org.openqa.selenium.*;
 
 import java.util.*;
@@ -14,13 +14,14 @@ import static org.apache.commons.lang3.StringUtils.*;
 
 /**
  * Utility class used to inject fields into a test case.
- * @author johnsmart
  *
+ * @author johnsmart
  */
 public final class TestCaseAnnotations {
 
     private final Object testCase;
     private final DriverConfiguration configuration;
+    private static final SerenityTestCaseFinder serenityTestCaseFinder = new SerenityTestCaseFinder();
 
     public TestCaseAnnotations(final Object testCase, WebDriverConfiguration configuration) {
         this.testCase = testCase;
@@ -46,7 +47,7 @@ public final class TestCaseAnnotations {
     }
 
     public void injectDrivers(final WebdriverManager webdriverManager) {
-        injectDrivers(ThucydidesWebDriverSupport.getDriver(),webdriverManager);
+        injectDrivers(ThucydidesWebDriverSupport.getDriver(), webdriverManager);
     }
 
     public void injectDrivers(final WebDriver defaultDriver, final WebdriverManager webdriverManager) {
@@ -54,7 +55,7 @@ public final class TestCaseAnnotations {
         int driverCount = 1;
 
         String suffix = "";
-        for(ManagedWebDriverAnnotatedField webDriverField : webDriverFields) {
+        for (ManagedWebDriverAnnotatedField webDriverField : webDriverFields) {
             String driverRootName = isNotEmpty(webDriverField.getDriver()) ?  webDriverField.getDriver() : configuredDriverType();
             String driverName = driverRootName + suffix;
             String driverOptions = webDriverField.getOptions();
@@ -74,8 +75,8 @@ public final class TestCaseAnnotations {
     private WebDriver requestedDriverFrom(WebdriverManager webdriverManager, String fieldName, String driverName, String driverOptions) {
 
         return RequestedDrivers.withEnvironmentVariables(configuration.getEnvironmentVariables())
-                               .andWebDriverManager(webdriverManager)
-                               .requestedDriverFor(fieldName, driverName, driverOptions);
+                .andWebDriverManager(webdriverManager)
+                .requestedDriverFor(fieldName, driverName, driverOptions);
     }
 
     private String configuredDriverType() {
@@ -102,7 +103,6 @@ public final class TestCaseAnnotations {
         return isUniqueSession(testCase.getClass());
     }
 
-
     public static boolean isUniqueSession(Class<?> testClass) {
         ManagedWebDriverAnnotatedField webDriverField = findFirstAnnotatedField(testClass);
         return webDriverField.isUniqueSession();
@@ -122,8 +122,7 @@ public final class TestCaseAnnotations {
     }
 
     public static boolean isASerenityTestCase(Class<?> testClass) {
-        return (testClass != null)
-                && (testClass.getAnnotation(RunWith.class) != null)
-                && (testClass.getAnnotation(RunWith.class).value().toString().contains("Serenity") || testClass.getAnnotation(RunWith.class).value().toString().contains("Thucydides"));
+        return serenityTestCaseFinder.isSerenityTestCase(testClass);
     }
+
 }

--- a/serenity-core/src/main/java/net/thucydides/core/annotations/UsePersistantStepLibraries.java
+++ b/serenity-core/src/main/java/net/thucydides/core/annotations/UsePersistantStepLibraries.java
@@ -1,7 +1,5 @@
 package net.thucydides.core.annotations;
 
-import org.junit.runner.Runner;
-
 import java.lang.annotation.*;
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/serenity-core/src/main/java/net/thucydides/core/util/ExtendedTemporaryFolder.java
+++ b/serenity-core/src/main/java/net/thucydides/core/util/ExtendedTemporaryFolder.java
@@ -10,16 +10,21 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
+// TODO junit4/junit5:
+// This seems to be a test utility that is both provided as part of the library and used in serenity (internal) tests.
+// Would be better placed in serenity-junit. And as long as the serenity internal tests are also using junit4 the tests
+// should then depend on serenity-junit as well.
+// Current decision: leave it here, but using it will require to add junit4 as dependency again.
 public class ExtendedTemporaryFolder extends ExternalResource {
-	
-	private static final Logger logger = LoggerFactory.getLogger(ExtendedTemporaryFolder.class);
 
-	private final File parentFolder;
+    private static final Logger logger = LoggerFactory.getLogger(ExtendedTemporaryFolder.class);
+
+    private final File parentFolder;
     private File folder;
 
     public ExtendedTemporaryFolder() {
-    	this(null);
-	}
+        this(null);
+    }
 
     public ExtendedTemporaryFolder(File parentFolder) {
         this.parentFolder = parentFolder;
@@ -52,15 +57,15 @@ public class ExtendedTemporaryFolder extends ExternalResource {
     }
 
     /**
-     * @param  folder name of the new temporary directory
+     * @param folder name of the new temporary directory
      * @return a new fresh folder with the given name under the temporary folder.
      */
     public File newFolder(String folder) throws IOException {
-        return newFolder(new String[]{folder});
+        return newFolder(new String[] { folder });
     }
 
     /**
-     * @param  folderNames a sequence of folder names used to create a temporary directory
+     * @param folderNames a sequence of folder names used to create a temporary directory
      * @return a new fresh folder with the given name(s) under the temporary folder.
      */
     public File newFolder(String... folderNames) throws IOException {
@@ -118,34 +123,34 @@ public class ExtendedTemporaryFolder extends ExternalResource {
         file.delete();
     }
 
-	public File newFolder() throws IOException {
-		if (CurrentOS.isWindows()) {
-			synchronized (this) {
-				try {
-					return createTemporaryFolderIn(getRoot());
-				} catch (IOException e) {
-					logger.debug("Error when invoke newFolder(): {}", e);
-					throw e;
-				}
-			}
-		} else {
-			return createTemporaryFolderIn(getRoot());
-		}
-	}
-	
-	public File newFile(String fileName) throws IOException {
-		if (CurrentOS.isWindows()) {
-			synchronized (this) {
-				File file= new File(getRoot(), fileName);
+    public File newFolder() throws IOException {
+        if (CurrentOS.isWindows()) {
+            synchronized (this) {
+                try {
+                    return createTemporaryFolderIn(getRoot());
+                } catch (IOException e) {
+                    logger.debug("Error when invoke newFolder(): {}", e);
+                    throw e;
+                }
+            }
+        } else {
+            return createTemporaryFolderIn(getRoot());
+        }
+    }
+
+    public File newFile(String fileName) throws IOException {
+        if (CurrentOS.isWindows()) {
+            synchronized (this) {
+                File file = new File(getRoot(), fileName);
                 file.setWritable(true);
                 file.setReadable(true);
                 file.createNewFile();
-				return file;
-			}
-		} else {
+                return file;
+            }
+        } else {
             File file = new File(getRoot(), fileName);
             file.createNewFile();
             return file;
-		}
-	}
+        }
+    }
 }

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/BrowserStackRemoteDriverCapabilities.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/BrowserStackRemoteDriverCapabilities.java
@@ -1,18 +1,9 @@
 package net.thucydides.core.webdriver.capabilities;
 
-import net.thucydides.core.ThucydidesSystemProperty;
-import net.thucydides.core.util.EnvironmentVariables;
-import net.thucydides.core.util.NameConverter;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import java.lang.reflect.Method;
-import java.util.Optional;
-
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import net.thucydides.core.ThucydidesSystemProperty;
+import net.thucydides.core.util.EnvironmentVariables;
 
 /**
  * Provides BrowserStack specific capabilities
@@ -24,7 +15,7 @@ public class BrowserStackRemoteDriverCapabilities implements RemoteDriverCapabil
 
     private final EnvironmentVariables environmentVariables;
 
-    public BrowserStackRemoteDriverCapabilities(EnvironmentVariables environmentVariables){
+    public BrowserStackRemoteDriverCapabilities(EnvironmentVariables environmentVariables) {
         this.environmentVariables = environmentVariables;
     }
 
@@ -46,7 +37,7 @@ public class BrowserStackRemoteDriverCapabilities implements RemoteDriverCapabil
 //                name -> capabilities.setCapability("name", name)
 //        );
 //
-//        AddCustomCapabilities.startingWith("browserstack.").from(environmentVariables).withAndWithoutPrefixes().to(capabilities);
+//        AddCustomCapabilities.startingWith("browserstack.").from(environmentVariables).withAndWithoutPrefixes().to (capabilities);
 //
 //        String remotePlatform = environmentVariables.getProperty("remote.platform");
 //        if (isNotEmpty(remotePlatform)) {

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/RemoteTestName.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/capabilities/RemoteTestName.java
@@ -1,9 +1,7 @@
 package net.thucydides.core.webdriver.capabilities;
 
+import net.thucydides.core.util.JUnitAdapter;
 import net.thucydides.core.util.NameConverter;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -26,12 +24,11 @@ class RemoteTestName {
     }
 
     private static boolean isATestMethod(Method callingMethod) {
-        return callingMethod.getAnnotation(Test.class) != null;
+        return JUnitAdapter.isTestMethod(callingMethod);
     }
 
     private static boolean isASetupMethod(Method callingMethod) {
-        return (callingMethod.getAnnotation(Before.class) != null)
-                || (callingMethod.getAnnotation(BeforeClass.class) != null);
+        return JUnitAdapter.isTestSetupMethod(callingMethod);
     }
 
 }

--- a/serenity-junit/build.gradle
+++ b/serenity-junit/build.gradle
@@ -7,6 +7,15 @@ test {
     maxParallelForks = Integer.parseInt(System.getProperty("forks","1"))
 }
 
+configurations {
+    compile {
+        exclude group: 'org.junit.jupiter'
+    }
+    testCompile {
+        exclude group: 'org.junit.jupiter'
+    }
+}
+
 dependencies {
     compile project(':serenity-model')
     compile project(':serenity-core')

--- a/serenity-junit/src/test/java/net/thucydides/core/util/WhenRunningWithoutJUnit5.java
+++ b/serenity-junit/src/test/java/net/thucydides/core/util/WhenRunningWithoutJUnit5.java
@@ -1,0 +1,29 @@
+package net.thucydides.core.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import net.serenitybdd.junit.runners.SerenityRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SerenityRunner.class)
+public class WhenRunningWithoutJUnit5 {
+
+    @Test(expected = ClassNotFoundException.class)
+    public void there_are_no_junit5_classes() throws ClassNotFoundException {
+        Class.forName("org.junit.jupiter.api.Test");
+    }
+
+    @Test
+    public void junit_adapter_has_only_junit4_strategy() {
+        assertThat(JUnitAdapter.getStrategies()).hasSize(1);
+        assertThat(((Object) JUnitAdapter.getStrategies().get(0)).getClass().getCanonicalName()).contains("JUnit4");
+    }
+
+    @Test
+    public void junit_adapter_will_still_work() {
+        assertThat(JUnitAdapter.isATaggableClass(WhenRunningWithoutJUnit5.class)).isTrue();
+    }
+
+}

--- a/serenity-model/build.gradle
+++ b/serenity-model/build.gradle
@@ -56,11 +56,13 @@ dependencies {
     }
     compile 'es.nitaur.markdown:txtmark:0.16'
 
+    compileOnly "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+
     testCompile project(':serenity-test-utils')
     testCompile project(':serenity-sample-alternative-resources')
     testCompile("org.spockframework:spock-core:${spockVersion}") {
         exclude group: "junit"
         exclude group: "org.codehaus.groovy"
-
     }
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
 }

--- a/serenity-model/src/main/java/net/thucydides/core/reflection/ClassFinder.java
+++ b/serenity-model/src/main/java/net/thucydides/core/reflection/ClassFinder.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ public class ClassFinder {
     private final ClassLoader classLoader;
     private final Class annotation;
     private Class<?> parentInterface;
+    private Predicate<Class> condition;
 
     private ClassFinder(ClassLoader classLoader, Class annotation) {
         this.classLoader = classLoader;
@@ -64,6 +66,9 @@ public class ClassFinder {
         }
         if (parentInterface != null) {
             return (parentInterface.isAssignableFrom(clazz) && !clazz.isInterface());
+        }
+        if (condition != null) {
+            return condition.test(clazz);
         }
         return true;
     }
@@ -186,5 +191,11 @@ public class ClassFinder {
         this.parentInterface = parentInterface;
         return this;
     }
+
+    public ClassFinder thatMatch(final Predicate<Class> condition) {
+        this.condition = condition;
+        return this;
+    }
+
 }
 

--- a/serenity-model/src/main/java/net/thucydides/core/requirements/PackageAnnotationBasedTagProvider.java
+++ b/serenity-model/src/main/java/net/thucydides/core/requirements/PackageAnnotationBasedTagProvider.java
@@ -11,9 +11,9 @@ import net.thucydides.core.model.TestTag;
 import net.thucydides.core.requirements.annotations.NarrativeFinder;
 import net.thucydides.core.requirements.model.Requirement;
 import net.thucydides.core.util.EnvironmentVariables;
+import net.thucydides.core.util.JUnitAdapter;
 import net.thucydides.core.webdriver.Configuration;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +33,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
  * @see ThucydidesSystemProperty#THUCYDIDES_TEST_ROOT
  */
 public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagProvider implements RequirementsTagProvider, OverridableTagProvider {
+
     private static final String DOT_REGEX = "\\.";
     private final static List<String> SUPPORTED_SUFFIXES = NewList.of("story", "feature");
 
@@ -53,7 +54,7 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
     }
 
     private File getRequirementsDirectory() {
-        return new File(configuration.getOutputDirectory(),"requirements");
+        return new File(configuration.getOutputDirectory(), "requirements");
     }
 
     @Override
@@ -112,7 +113,6 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
         return requirementMap;
     }
 
-
     private void addChildrenTo(SortedMap<String, Requirement> requirementsByPath) {
         Set<String> paths = requirementsByPath.keySet();
         for (String path : paths) {
@@ -127,8 +127,8 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
     }
 
     private void addRequirementTo(Map<String, Requirement> requirementsByPath,
-                                  Class candidateClass,
-                                  int maxDepth) {
+            Class candidateClass,
+            int maxDepth) {
 
         String fullRequirementName = getFullRequirementPath(candidateClass);
 
@@ -177,12 +177,11 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
         return maxDepth;
     }
 
-
     private Requirement newParentRequirement(String requirementPath,
-                                             Requirement parentRequirement,
-                                             String packageName,
-                                             int level,
-                                             String defaultRequirementType) {
+            Requirement parentRequirement,
+            String packageName,
+            int level,
+            String defaultRequirementType) {
         String requirementTitle = packageName;
         String requirementType = defaultRequirementType;
         String narrativeText = "";
@@ -205,18 +204,17 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
     }
 
     private Requirement newRequirement(Class candidateClass,
-                                       String currentPath,
-                                       Requirement parentRequirement,
-                                       String packageName,
-                                       int level,
-                                       String defaultRequirementType) {
+            String currentPath,
+            Requirement parentRequirement,
+            String packageName,
+            int level,
+            String defaultRequirementType) {
         String requirementTitle = packageName;
         String requirementType = defaultRequirementType;
         String narrativeText = "";
         String cardNumber = "";
 
         java.util.Optional<Narrative> narrative = NarrativeFinder.forClass(candidateClass);
-
 
         Requirement newRequirement = getRequirement(candidateClass, packageName, level, requirementTitle, requirementType, narrativeText, cardNumber, narrative);
         if (parentRequirement != null) {
@@ -294,7 +292,7 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
         Set<Class<?>> classesWithNarratives = new HashSet(loadClasses().annotatedWith(Narrative.class)
                 .fromPackage(rootPackage));
 
-        Set<Class<?>> testCases = new HashSet(loadClasses().annotatedWith(RunWith.class)
+        Set<Class<?>> testCases = new HashSet(loadClasses().thatMatch(JUnitAdapter::isTestClass)
                 .fromPackage(rootPackage));
 
         Set<Class<?>> requirementClasses = new HashSet();
@@ -318,6 +316,7 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
     }
 
     private static class RequirementChildLocator {
+
         Requirement parent;
 
         public RequirementChildLocator(Requirement parent) {
@@ -334,7 +333,6 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
             return children;
         }
     }
-
 
     private Collection<Requirement> getAllRequirements() {
         return getRequirementsByPath().values();
@@ -361,13 +359,12 @@ public class PackageAnnotationBasedTagProvider extends AbstractRequirementsTagPr
         return path;
     }
 
-
     private RequirementPathMatcher fullPathOf(Requirement requirement) {
         return new RequirementPathMatcher(requirement);
     }
 
-
     private class RequirementPathMatcher {
+
         String requirementPath;
 
         public RequirementPathMatcher(Requirement requirement) {

--- a/serenity-model/src/main/java/net/thucydides/core/requirements/PackageRequirementsTagProvider.java
+++ b/serenity-model/src/main/java/net/thucydides/core/requirements/PackageRequirementsTagProvider.java
@@ -10,10 +10,8 @@ import net.thucydides.core.model.TestTag;
 import net.thucydides.core.requirements.annotations.ClassInfoAnnotations;
 import net.thucydides.core.requirements.classpath.LeafRequirementAdder;
 import net.thucydides.core.requirements.classpath.NonLeafRequirementsAdder;
-import net.thucydides.core.requirements.model.OverviewReader;
 import net.thucydides.core.requirements.model.Requirement;
 import net.thucydides.core.util.EnvironmentVariables;
-import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,8 +46,8 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
 
 
     public PackageRequirementsTagProvider(EnvironmentVariables environmentVariables,
-                                          String rootPackage,
-                                          RequirementsStore requirementsStore) {
+            String rootPackage,
+            RequirementsStore requirementsStore) {
         super(environmentVariables);
         this.environmentVariables = environmentVariables;
         this.rootPackage = rootPackage;
@@ -59,7 +57,7 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
     public PackageRequirementsTagProvider(EnvironmentVariables environmentVariables, String rootPackage) {
         this(environmentVariables, rootPackage,
                 new FileSystemRequirementsStore(getRequirementsDirectory(ConfiguredEnvironment.getConfiguration().getOutputDirectory()),
-                                                rootPackage + "-package-requirements.json"));
+                        rootPackage + "-package-requirements.json"));
     }
 
     public PackageRequirementsTagProvider(EnvironmentVariables environmentVariables) {
@@ -125,7 +123,7 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
             allRequirements = removeChildrenFromTopLevelRequirementsIn(allRequirements);
 
             if (!allRequirements.isEmpty()) {
-                classpathRequirements =new ArrayList<>(allRequirements);
+                classpathRequirements = new ArrayList<>(allRequirements);
                 Collections.sort(classpathRequirements);
 
                 requirementsStore.write(classpathRequirements);
@@ -151,7 +149,7 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
 
     private final Lock readingPaths = new ReentrantLock();
 
-    private List<String> requirementPathsStartingFrom(String rootPackage){
+    private List<String> requirementPathsStartingFrom(String rootPackage) {
 
         if (requirementPaths == null) {
             readingPaths.lock();
@@ -182,11 +180,12 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
     }
 
     private boolean classRepresentsARequirementIn(ClassPath.ClassInfo classInfo) {
-        return (ClassInfoAnnotations.theClassDefinedIn(classInfo).hasAnAnnotation(RunWith.class, net.thucydides.core.annotations.Narrative.class))
-                || (ClassInfoAnnotations.theClassDefinedIn(classInfo).hasAPackageAnnotation(net.thucydides.core.annotations.Narrative.class))
+        return (ClassInfoAnnotations.theClassDefinedIn(classInfo)
+                .hasAnAnnotation(net.thucydides.core.annotations.Narrative.class))
+                || (ClassInfoAnnotations.theClassDefinedIn(classInfo)
+                .hasAPackageAnnotation(net.thucydides.core.annotations.Narrative.class))
                 || (ClassInfoAnnotations.theClassDefinedIn(classInfo).containsTests());
     }
-
 
     private Set<Requirement> removeChildrenFromTopLevelRequirementsIn(Set<Requirement> allRequirements) {
         Set<Requirement> prunedRequirements = new HashSet();
@@ -226,7 +225,6 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
 
     }
 
-
     @Override
     public java.util.Optional<Requirement> getParentRequirementOf(TestOutcome testOutcome) {
         return getTestCaseRequirementOf(testOutcome);
@@ -252,7 +250,9 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
                 .filter(requirement -> requirement.asTag().isAsOrMoreSpecificThan(testTag))
                 .findFirst();
 
-        if (matching.isPresent()) { return matching; }
+        if (matching.isPresent()) {
+            return matching;
+        }
 //
 //        for (Requirement requirement : AllRequirements.in(getRequirements())) {
 //            if (requirement.asTag().isAsOrMoreSpecificThan(testTag)) {
@@ -305,7 +305,6 @@ public class PackageRequirementsTagProvider extends AbstractRequirementsTagProvi
     private static File getRequirementsDirectory(File directory) {
         return new File(directory, "requirements");
     }
-
 
     public void clearCache() {
         requirementsStore.clear();

--- a/serenity-model/src/main/java/net/thucydides/core/requirements/SerenityTestCaseFinder.java
+++ b/serenity-model/src/main/java/net/thucydides/core/requirements/SerenityTestCaseFinder.java
@@ -1,23 +1,14 @@
 package net.thucydides.core.requirements;
 
-import net.serenitybdd.core.collect.NewList;
-import org.junit.runner.RunWith;
-
-import java.util.List;
+import net.thucydides.core.util.JUnitAdapter;
 
 /**
  * Created by john on 22/07/2015.
  */
 public class SerenityTestCaseFinder {
-    private final List<String> LEGAL_SERENITY_RUNNER_NAMES = NewList.of("SerenityRunner", "ThucydidesRunner");
 
     public boolean isSerenityTestCase(Class<?> testClass) {
-        RunWith runWithAnnotation = testClass.getAnnotation(RunWith.class);
-        if (runWithAnnotation != null) {
-            return LEGAL_SERENITY_RUNNER_NAMES.contains(runWithAnnotation.value().getSimpleName());
-        }
-        return false;
+        return JUnitAdapter.isSerenityTestCase(testClass);
     }
-
 
 }

--- a/serenity-model/src/main/java/net/thucydides/core/requirements/annotations/ClassInfoAnnotations.java
+++ b/serenity-model/src/main/java/net/thucydides/core/requirements/annotations/ClassInfoAnnotations.java
@@ -5,29 +5,32 @@ import com.google.common.reflect.ClassPath;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
+import net.thucydides.core.util.JUnitAdapter;
+
 public class ClassInfoAnnotations {
-        private final ClassPath.ClassInfo classInfo;
 
-        public ClassInfoAnnotations(ClassPath.ClassInfo classInfo) {
+    private final ClassPath.ClassInfo classInfo;
 
-            this.classInfo = classInfo;
-        }
+    public ClassInfoAnnotations(ClassPath.ClassInfo classInfo) {
 
-        public static ClassInfoAnnotations theClassDefinedIn(ClassPath.ClassInfo classInfo)   {
-             return new ClassInfoAnnotations(classInfo);
-         }
+        this.classInfo = classInfo;
+    }
 
-        public boolean hasAnAnnotation(Class<? extends Annotation>... annotationClasses) {
-            for(Class<? extends Annotation> annotationClass : annotationClasses) {
-                if (classInfo.load().getAnnotation(annotationClass) != null) {
-                    return true;
-                }
+    public static ClassInfoAnnotations theClassDefinedIn(ClassPath.ClassInfo classInfo) {
+        return new ClassInfoAnnotations(classInfo);
+    }
+
+    public boolean hasAnAnnotation(Class<? extends Annotation>... annotationClasses) {
+        for (Class<? extends Annotation> annotationClass : annotationClasses) {
+            if (classInfo.load().getAnnotation(annotationClass) != null) {
+                return true;
             }
-            return false;
         }
+        return false;
+    }
 
     public boolean hasAPackageAnnotation(Class<? extends Annotation>... annotationClasses) {
-        for(Class<? extends Annotation> annotationClass : annotationClasses) {
+        for (Class<? extends Annotation> annotationClass : annotationClasses) {
             if (classInfo.load().getPackage().getAnnotation(annotationClass) != null) {
                 return true;
             }
@@ -37,7 +40,7 @@ public class ClassInfoAnnotations {
 
     public boolean containsTests() {
         for (Method method : classInfo.load().getMethods()) {
-            if (method.getAnnotation(org.junit.Test.class) != null) {
+            if (JUnitAdapter.isTestMethod(method)) {
                 return true;
             }
         }

--- a/serenity-model/src/main/java/net/thucydides/core/tags/TagScanner.java
+++ b/serenity-model/src/main/java/net/thucydides/core/tags/TagScanner.java
@@ -4,7 +4,7 @@ import net.serenitybdd.core.tags.EnvironmentDefinedTags;
 import net.thucydides.core.annotations.TestAnnotations;
 import net.thucydides.core.model.TestTag;
 import net.thucydides.core.util.EnvironmentVariables;
-import org.junit.runner.RunWith;
+import net.thucydides.core.util.JUnitAdapter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,20 +19,26 @@ public class TagScanner {
     }
 
     public boolean shouldRunForTags(List<String> tags) {
-        if (providedTags.isEmpty()) { return true; }
+        if (providedTags.isEmpty()) {
+            return true;
+        }
 
         return tagsMatchAPositiveTag(tags, providedTags) && !tagsMatchANegativeTag(tags, providedTags);
     }
 
     public boolean shouldRunClass(Class<?> testClass) {
-        if (providedTags.isEmpty()) { return true; }
+        if (providedTags.isEmpty()) {
+            return true;
+        }
 
         return testClassMatchesAPositiveTag(testClass, providedTags)
-               && testClassDoesNotMatchANegativeTag(testClass, providedTags);
+                && testClassDoesNotMatchANegativeTag(testClass, providedTags);
     }
 
     public boolean shouldRunMethod(Class<?> testClass, String methodName) {
-        if (!isATaggable(testClass) || (providedTags.isEmpty()) )  { return true; }
+        if (!isATaggable(testClass) || (providedTags.isEmpty())) {
+            return true;
+        }
 
         return testMethodMatchesAPositiveTag(testClass, methodName, providedTags)
                 && testMethodDoesNotMatchANegativeTag(testClass, methodName, providedTags);
@@ -42,8 +48,7 @@ public class TagScanner {
     // If the default tag scanner is applied to these test runners, it will interfere
     // with the real filtering.
     private boolean isATaggable(Class<?> testClass) {
-        RunWith runWith = testClass.getAnnotation(RunWith.class);
-        return (runWith != null && Taggable.class.isAssignableFrom(runWith.value()));
+        return JUnitAdapter.isATaggableClass(testClass);
     }
 
     private boolean testClassMatchesAPositiveTag(Class<?> testClass, List<TestTag> expectedTags) {
@@ -101,7 +106,6 @@ public class TagScanner {
         return negativeTags;
     }
 
-
     private boolean testMethodMatchesAPositiveTag(Class<?> testClass, String methodName, List<TestTag> expectedTags) {
         List<TestTag> tags = TestAnnotations.forClass(testClass).getTagsForMethod(methodName);
         return containsAPositiveMatch(expectedTags, tags);
@@ -113,11 +117,12 @@ public class TagScanner {
     }
 
     private boolean containsANegativeMatch(List<TestTag> expectedTags, List<TestTag> tags) {
-        if (negative(expectedTags).isEmpty()) {return false;}
+        if (negative(expectedTags).isEmpty()) {
+            return false;
+        }
 
         return tagsMatch(negative(expectedTags), tags);
     }
-
 
     private boolean tagsMatch(List<TestTag> expectedTags, List<TestTag> tags) {
         for (TestTag expectedTag : expectedTags) {

--- a/serenity-model/src/main/java/net/thucydides/core/util/JUnitAdapter.java
+++ b/serenity-model/src/main/java/net/thucydides/core/util/JUnitAdapter.java
@@ -1,0 +1,231 @@
+package net.thucydides.core.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import net.serenitybdd.core.collect.NewList;
+import net.thucydides.core.tags.Taggable;
+
+/**
+ * This is an INTERNAL helper class of serenity, it should not be used directly and may be subject to refactoring.
+ * <p>
+ * It serves to decouple serenity-model (and serenity-core) from JUnit. If JUnit is on the classpath, JUnit
+ * classes will be handled specifically. But serenity will continue to function without JUnit being on the classpath.
+ * Furthermore, users can choose between JUnit 4 and JUnit 5 or even use both together.
+ * <p>
+ * Ideally this approach could be generalized to avoid any special treatment of JUnit as a test framework.
+ * Test-framework specific strategies could be registered from the framework-specific modules. That would allow
+ * to place the implementation of (and the tests for) the test-framework specific strategies into the modules that know
+ * about those frameworks and also have the necessary dependencies.
+ * <p>
+ * But this would be a more extensive change, potentially breaking backwards compatibility. So for now this class does
+ * exactly only this: It provides an adapter for JUnit 4 and JUnit 5, and makes explicit the parts of the code where
+ * there has previously been a hard dependency on JUnit 4.
+ * <p>
+ * As such it is self-contained and should be possible to be grasped rather easily. And it marks the starting point for
+ * a potential refactoring towards a more general approach.
+ */
+public class JUnitAdapter {
+
+    private static List<JUnitStrategy> strategies = new ArrayList<>();
+
+    static {
+        if (isClassPresent("org.junit.runner.RunWith")) {
+            strategies.add(new JUnit4Strategy());
+        }
+        if (isClassPresent("org.junit.jupiter.api.Test")) {
+            strategies.add(new JUnit5Strategy());
+        }
+    }
+
+    // used only for testing purposes
+    static List<JUnitStrategy> getStrategies() {
+        return Collections.unmodifiableList(strategies);
+    }
+
+    public static boolean isTestClass(final Class<?> testClass) {
+        if (testClass == null) {
+            return false;
+        }
+        return delegateToStrategies(s -> s.isTestClass(testClass));
+    }
+
+    public static boolean isTestMethod(final Method method) {
+        if (method == null) {
+            return false;
+        }
+        return delegateToStrategies(s -> s.isTestMethod(method));
+    }
+
+    public static boolean isTestSetupMethod(final Method method) {
+        if (method == null) {
+            return false;
+        }
+        return delegateToStrategies(s -> s.isTestSetupMethod(method));
+    }
+
+    public static boolean isSerenityTestCase(final Class<?> testClass) {
+        if (testClass == null) {
+            return false;
+        }
+        return delegateToStrategies(s -> s.isSerenityTestCase(testClass));
+    }
+
+    public static boolean isAssumptionViolatedException(final Throwable throwable) {
+        return delegateToStrategies(s -> s.isAssumptionViolatedException(throwable));
+    }
+
+    public static boolean isATaggableClass(final Class<?> testClass) {
+        if (testClass == null) {
+            return false;
+        }
+        return delegateToStrategies(s -> s.isATaggableClass(testClass));
+    }
+
+    private static boolean delegateToStrategies(
+            final Function<JUnitStrategy, Boolean> jUnitStrategyBooleanFunction) {
+        return strategies.stream().map(jUnitStrategyBooleanFunction).filter(Boolean::booleanValue).findFirst()
+                .orElse(false);
+    }
+
+    private static boolean isClassPresent(final String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private interface JUnitStrategy {
+
+        boolean isTestClass(final Class<?> testClass);
+
+        boolean isTestMethod(final Method method);
+
+        boolean isTestSetupMethod(final Method method);
+
+        boolean isSerenityTestCase(final Class<?> testClass);
+
+        boolean isAssumptionViolatedException(final Throwable throwable);
+
+        boolean isATaggableClass(final Class<?> testClass);
+
+    }
+
+    private static class JUnit4Strategy implements JUnitStrategy {
+
+        private final List<String> LEGAL_SERENITY_RUNNER_NAMES = NewList.of("SerenityRunner", "ThucydidesRunner");
+
+        @Override
+        public boolean isTestClass(final Class<?> testClass) {
+            return (testClass.getAnnotation(org.junit.runner.RunWith.class) != null);
+        }
+
+        @Override
+        public boolean isTestMethod(final Method method) {
+            return (method.getAnnotation(org.junit.Test.class) != null);
+        }
+
+        @Override
+        public boolean isTestSetupMethod(final Method method) {
+            return (method.getAnnotation(org.junit.Before.class) != null)
+                    || (method.getAnnotation(org.junit.BeforeClass.class) != null);
+        }
+
+        @Override
+        public boolean isSerenityTestCase(Class<?> testClass) {
+            org.junit.runner.RunWith runWithAnnotation = testClass.getAnnotation(org.junit.runner.RunWith.class);
+            if (runWithAnnotation != null) {
+                return LEGAL_SERENITY_RUNNER_NAMES.contains(runWithAnnotation.value().getSimpleName());
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isAssumptionViolatedException(final Throwable throwable) {
+            return (throwable instanceof org.junit.internal.AssumptionViolatedException);
+        }
+
+        @Override
+        public boolean isATaggableClass(Class<?> testClass) {
+            org.junit.runner.RunWith runWith = testClass.getAnnotation(org.junit.runner.RunWith.class);
+            return (runWith != null && Taggable.class.isAssignableFrom(runWith.value()));
+        }
+
+    }
+
+    private static class JUnit5Strategy implements JUnitStrategy {
+
+        @Override
+        public boolean isTestClass(final Class<?> testClass) {
+            for (final Method method : testClass.getDeclaredMethods()) {
+                if (isTestMethod(method)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isTestMethod(final Method method) {
+            return (method.getAnnotation(org.junit.jupiter.api.Test.class) != null);
+        }
+
+        @Override
+        public boolean isTestSetupMethod(final Method method) {
+            return (method.getAnnotation(org.junit.jupiter.api.BeforeEach.class) != null)
+                    || (method.getAnnotation(org.junit.jupiter.api.BeforeAll.class) != null);
+        }
+
+        @Override
+        public boolean isSerenityTestCase(Class<?> testClass) {
+            return hasSerenityAnnotation(testClass, new HashSet<>());
+        }
+
+        private boolean hasSerenityAnnotation(final Class<?> clazz, final Set<Class<?>> checked) {
+            checked.add(clazz);
+            return Arrays.stream(clazz.getAnnotations()).anyMatch(a -> carriesSerenityExtension(a, checked));
+        }
+
+        private boolean carriesSerenityExtension(final Annotation annotation, final Set<Class<?>> checked) {
+            if (annotation instanceof ExtendWith) {
+                return Arrays.stream(((ExtendWith) annotation).value())
+                        .anyMatch(c -> c.getSimpleName().matches("Serenity.*Extension"));
+            }
+            Class<? extends Annotation> annotationType = annotation.annotationType();
+
+            if (annotationType.getPackage().getName().startsWith("java.lang") // performance optimization
+                    || checked.contains(annotation.annotationType()) // avoid endless loops
+            ) {
+                return false;
+            }
+
+            // find meta annotations
+            return hasSerenityAnnotation(annotation.annotationType(), checked);
+        }
+
+        @Override
+        public boolean isAssumptionViolatedException(final Throwable throwable) {
+            return (throwable instanceof org.opentest4j.TestAbortedException);
+        }
+
+        @Override
+        public boolean isATaggableClass(final Class<?> testClass) {
+            // serenity tagging mechanism currently not supported for JUnit 5, since JUnit 5 has its own tagging
+            // feature.
+            return false;
+        }
+
+    }
+
+}

--- a/serenity-model/src/test/java/net/thucydides/core/util/JUnitAdapterUnitTest.java
+++ b/serenity-model/src/test/java/net/thucydides/core/util/JUnitAdapterUnitTest.java
@@ -1,0 +1,173 @@
+package net.thucydides.core.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.JUnit4;
+import org.junit.runners.model.InitializationError;
+
+import net.thucydides.core.tags.Taggable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JUnitAdapterUnitTest {
+
+    @Test
+    public void shouldHandleNullInput() {
+        assertThat(JUnitAdapter.isTestClass(null)).isFalse();
+        assertThat(JUnitAdapter.isTestMethod(null)).isFalse();
+        assertThat(JUnitAdapter.isTestSetupMethod(null)).isFalse();
+        assertThat(JUnitAdapter.isATaggableClass(null)).isFalse();
+        assertThat(JUnitAdapter.isSerenityTestCase(null)).isFalse();
+    }
+
+    @Test
+    public void shouldNotDetectOtherClasses() throws NoSuchMethodException {
+        assertThat(JUnitAdapter.isTestClass(NoTestAtAll.class)).isFalse();
+        assertThat(JUnitAdapter.isTestMethod(NoTestAtAll.class.getMethod("justAMethod"))).isFalse();
+        assertThat(JUnitAdapter.isTestSetupMethod(NoTestAtAll.class.getMethod("justAMethod"))).isFalse();
+        assertThat(JUnitAdapter.isATaggableClass(NoTestAtAll.class)).isFalse();
+        assertThat(JUnitAdapter.isSerenityTestCase(NoTestAtAll.class)).isFalse();
+        assertThat(JUnitAdapter.isAssumptionViolatedException(new RuntimeException("Assumption violated!"))).isFalse();
+    }
+
+    @Test
+    public void shouldDetectJunit4ClassesCorrectly() throws NoSuchMethodException {
+        assertThat(JUnitAdapter.isTestClass(Junit4Test.class)).isTrue();
+        assertThat(JUnitAdapter.isTestMethod(Junit4Test.class.getMethod("shouldSucceed"))).isTrue();
+        assertThat(JUnitAdapter.isTestSetupMethod(Junit4Test.class.getMethod("beforeClass"))).isTrue();
+        assertThat(JUnitAdapter.isTestSetupMethod(Junit4Test.class.getMethod("before"))).isTrue();
+        assertThat(JUnitAdapter.isATaggableClass(Junit4Test.class)).isFalse();
+        assertThat(JUnitAdapter.isATaggableClass(TaggableJunit4Test.class)).isTrue();
+        assertThat(JUnitAdapter.isSerenityTestCase(Junit4Test.class)).isFalse();
+        assertThat(JUnitAdapter.isSerenityTestCase(SerenityJunit4Test.class)).isTrue();
+        assertThat(JUnitAdapter
+                .isAssumptionViolatedException(new org.junit.AssumptionViolatedException("Assumption violated!")))
+                .isTrue();
+    }
+
+    @Test
+    public void shouldDetectJunit5ClassesCorrectly() throws NoSuchMethodException {
+        assertThat(JUnitAdapter.isTestClass(Junit5Test.class)).isTrue();
+        assertThat(JUnitAdapter.isTestMethod(Junit5Test.class.getDeclaredMethod("shouldSucceed"))).isTrue();
+        assertThat(JUnitAdapter.isTestSetupMethod(Junit5Test.class.getDeclaredMethod("beforeAll"))).isTrue();
+        assertThat(JUnitAdapter.isTestSetupMethod(Junit5Test.class.getDeclaredMethod("beforeEach"))).isTrue();
+        assertThat(JUnitAdapter.isATaggableClass(Junit5Test.class)).isFalse();
+        assertThat(JUnitAdapter.isSerenityTestCase(Junit5Test.class)).isFalse();
+        assertThat(JUnitAdapter.isSerenityTestCase(SerenityJunit5Test.class)).isTrue();
+        assertThat(JUnitAdapter
+                .isAssumptionViolatedException(new org.opentest4j.TestAbortedException("Assumption violated!")))
+                .isTrue();
+    }
+
+    public static class NoTestAtAll {
+
+        public void justAMethod() {
+
+        }
+
+    }
+
+    @RunWith(JUnit4.class)
+    public static class Junit4Test {
+
+        @BeforeClass
+        public void beforeClass() {
+        }
+
+        @Before
+        public void before() {
+        }
+
+        @Test
+        public void shouldSucceed() {
+        }
+
+    }
+
+    @RunWith(InternalRunner.class)
+    public static class TaggableJunit4Test {
+
+    }
+
+    @RunWith(SerenityRunner.class)
+    public static class SerenityJunit4Test {
+
+    }
+
+    public static class InternalRunner extends BlockJUnit4ClassRunner implements Taggable {
+
+        public InternalRunner(Class<?> clazz) throws InitializationError {
+            super(clazz);
+        }
+    }
+
+    public static class SerenityRunner extends BlockJUnit4ClassRunner implements Taggable {
+
+        public SerenityRunner(Class<?> clazz) throws InitializationError {
+            super(clazz);
+        }
+    }
+
+    static class Junit5Test {
+
+        @BeforeAll
+        void beforeAll() {
+
+        }
+
+        @BeforeEach
+        void beforeEach() {
+
+        }
+
+        @org.junit.jupiter.api.Test
+        void shouldSucceed() {
+
+        }
+
+    }
+
+    @HigherLevelSerenityTestAnnotation
+    static class SerenityJunit5Test {
+
+        @org.junit.jupiter.api.Test
+        void shouldSucceed() {
+
+        }
+
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @ExtendWith(SerenityDummyExtension.class)
+    public @interface SerenityTestAnnotation {
+
+    }
+
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @SerenityTestAnnotation
+    public @interface HigherLevelSerenityTestAnnotation {
+
+    }
+
+    public static class SerenityDummyExtension implements Extension {
+
+    }
+
+}


### PR DESCRIPTION
#### Summary of this PR
The runtime dependency on JUnit (4) is removed by providing an adapter that is able to use either a Junit 4 or Junit 5 strategy, or both after another, or none at all, based on which JUnit version is available at runtime.
#### Intended effect
The behavior of Serenity should not change if used as before (i.e. with a not-excluded transitive dependency on JUnit 4). But it should now be able to exclude the transitive dependency on Junit 4 at runtime without causing runtime errors. And adding a dependency to JUnit 5 would handle JUnit 5 tests similar to how JUnit 4 tests are handled.
#### How should this be manually tested?
All tests based on JUnit 4 should work as before. The regression test suites already go a long way to ensure this.
#### Side effects
There is a new compile-time-only dependency on Junit 5 that will affect only developers working on (and not just with) serenity.
#### Documentation
There is no documentation provided besides Javadoc on the JUnitAdapter in this pull request. It will later make sense to provide some documentation for the upcoming serenity-junit5 module.
#### Relevant tickets
1858 Remove runtime dependency on Junit(4)
#### Screenshots (if appropriate)
(not applicable)