### PR TITLE
Skipped Scenario Fix

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/model/failures/FailureAnalysisConfiguration.java
+++ b/serenity-model/src/main/java/net/thucydides/core/model/failures/FailureAnalysisConfiguration.java
@@ -90,15 +90,15 @@ public class FailureAnalysisConfiguration {
     }
 
     public List<Class<?>> skippedTypes() {
-        List<Class<?>> pendingTypes = new ArrayList<>(DEFAULT_SKIPPED_TYPES);
-        pendingTypes.addAll(skippedTypesDefinedIn(environmentVariables));
+        List<Class<?>> skippedTypes = new ArrayList<>(DEFAULT_SKIPPED_TYPES);
+        skippedTypes.addAll(skippedTypesDefinedIn(environmentVariables));
 
-        pendingTypes.removeAll(errorTypesDefinedIn(environmentVariables));
-        pendingTypes.removeAll(compromisedTypesDefinedIn(environmentVariables));
-        pendingTypes.removeAll(pendingTypesDefinedIn(environmentVariables));
-        pendingTypes.removeAll(failureTypesDefinedIn(environmentVariables));
+        skippedTypes.removeAll(errorTypesDefinedIn(environmentVariables));
+        skippedTypes.removeAll(compromisedTypesDefinedIn(environmentVariables));
+        skippedTypes.removeAll(pendingTypesDefinedIn(environmentVariables));
+        skippedTypes.removeAll(failureTypesDefinedIn(environmentVariables));
 
-        return pendingTypes;
+        return skippedTypes;
     }
 
     public List<Class<?>> errorTypes() {

--- a/serenity-model/src/main/java/net/thucydides/core/model/failures/FailureAnalysisConfiguration.java
+++ b/serenity-model/src/main/java/net/thucydides/core/model/failures/FailureAnalysisConfiguration.java
@@ -38,7 +38,7 @@ public class FailureAnalysisConfiguration {
 
     private final List<Class<?>> DEFAULT_SKIPPED_TYPES = new ArrayList<>();
     {
-        DEFAULT_PENDING_TYPES.addAll(Arrays.asList(SkipStepException.class));
+        DEFAULT_SKIPPED_TYPES.addAll(Arrays.asList(SkipStepException.class));
     }
 
     private final List<Class<?>> DEFAULT_ERROR_TYPES = new ArrayList<>();


### PR DESCRIPTION
*Brief summary*
 When throwing exception: net.serenitybdd.core.SkipStepException during test then test result is PENDING instead of SKIPPED. This code fixes wrong behaviour.

*How I did it changes*
 Instead of adding SkipStepException to DEFAULT_PENDING_TYPES, I add it to DEFAULT_SKIPPED_TYPES. Moreover, I've refactored variable name in skippedTypes() function to more precise one.

*Additional changes*