### PR TITLE
feat: Custom fields in home page of aggregate report

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -139,6 +139,26 @@
 
     <div class="clr"></div>
     <!--/* starts second table*/-->
+    <#if (customFields?has_content) && (customFields?size > 0) >
+        <div>
+            <table class="table environment">
+                <tr>
+                    <#list customFields as customField>
+                        <th class="custom-title">
+                            ${customField}
+                        </th>
+                    </#list>
+                </tr>
+                <tr>
+                    <#list customFieldValues as customFieldValue>
+                        <td class="custom-value">
+                            ${customFieldValue}
+                        </td>
+                    </#list>
+                </tr>
+            </table>
+        </div>
+    </#if>
     <#include "menu.ftl">
     <@main_menu selected="home" />
     <div class="clr"></div>
@@ -770,11 +790,12 @@
                                                 </div>
                                             </div>
                                         </#if>
+                                    </div>
+                                </div>
+                            </div>
                         </td>
-
                     </tr>
                 </table>
-
             </div>
         </div>
     </div>

--- a/serenity-report-resources/src/main/resources/report-resources/css/core.css
+++ b/serenity-report-resources/src/main/resources/report-resources/css/core.css
@@ -2301,3 +2301,20 @@ span.evidence {
     display:block;
     margin-left: 4em;
 }
+
+.environment {
+    background-color: #fff;
+    font-size: 16px;
+    table-layout: fixed;
+}
+
+.environment th {
+    color: #000000;
+    font-weight: bold;
+    text-align: center;
+}
+
+.environment td {
+    color: #69727f;
+    text-align: center;
+}

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/FreemarkerContext.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/FreemarkerContext.java
@@ -146,6 +146,10 @@ public class FreemarkerContext {
 
         context.put("tagResults", TagResults.from(testOutcomes).groupedByType());
 
+        CustomReportFields customReportFields = new CustomReportFields(environmentVariables);
+        context.put("customFields", customReportFields.getFieldNames());
+        context.put("customFieldValues", customReportFields.getValues());
+
         return context;
     }
 

--- a/serenity-reports/src/test/java/net/thucydides/core/reports/integration/WhenGeneratingAnAggregateHtmlReportSet.java
+++ b/serenity-reports/src/test/java/net/thucydides/core/reports/integration/WhenGeneratingAnAggregateHtmlReportSet.java
@@ -48,6 +48,7 @@ public class WhenGeneratingAnAggregateHtmlReportSet {
     public static void generateReports() throws IOException {
         IssueTracking issueTracking = mock(IssueTracking.class);
         environmentVariables.setProperty("output.formats", "xml");
+        environmentVariables.setProperty("report.customfields.env", "testenv");
         HtmlAggregateStoryReporter reporter = new HtmlAggregateStoryReporter("project", "", issueTracking, environmentVariables);
         outputDirectory = newTemporaryDirectory();
         reporter.setOutputDirectory(outputDirectory);
@@ -122,6 +123,16 @@ public class WhenGeneratingAnAggregateHtmlReportSet {
         File report = new File(outputDirectory, expectedSuccessReport);
         driver.get(urlFor(report));
         assertThat(driver.findElement(By.cssSelector(".date-and-time")).isDisplayed(), is(true));
+    }
+
+    @Test
+    public void should_display_custom_field_on_the_home_page() {
+        File report = new File(outputDirectory, "index.html");
+        driver.get(urlFor(report));
+        assertThat(driver.findElement(By.cssSelector(".custom-title")).isDisplayed(), is(true));
+        assertThat(driver.findElement(By.cssSelector(".custom-title")).getText(), equalTo("Env"));
+        assertThat(driver.findElement(By.cssSelector(".custom-value")).isDisplayed(), is(true));
+        assertThat(driver.findElement(By.cssSelector(".custom-value")).getText(), equalTo("testenv"));
     }
 
     private String urlFor(File report) {


### PR DESCRIPTION
Similar to email report, users can use the same configuration as email report to make custom fields displayed in the home page of aggregate report. This can help with #1454.

![Capture](https://user-images.githubusercontent.com/13144677/69911525-9826e580-13d1-11ea-8677-77422dea014e.JPG)
