### PR TITLE
fix for #1879

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/components/requirements-list.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/components/requirements-list.ftl
@@ -84,7 +84,7 @@
                 <span style="display:none">${status_rank}</span>
             </td>
 
-            <td width="165px" style="padding:0px;">
+            <td width="165px">
                 <@test_coverage requirementOutcome=requirementOutcome barWidth=125 />
             </td>
 


### PR DESCRIPTION
#### Summary of this PR
There was a random `style="padding:0px;` in `requirements-list-ftl` under the serenity-report-resources module. That made the progress bars that contained percentages to go up in the parent table cell. This PR removes it.  
#### Intended effect
Vertical alignment of the progress bars to the center of the cell.
#### How should this be manually tested?
1. Use any of the demo projects to generate a report;
2. Navigate to the Requirements tab > Test Results;
3. Check the progress bar(s). It should be aligned to the vertical center.
#### Side effects
None.
#### Documentation
N/A.
#### Relevant tickets
#1879 
#### Screenshots (if appropriate)
BEFORE:
![before](https://user-images.githubusercontent.com/18273538/70056444-c546e400-15db-11ea-8c75-96da922a2040.JPG)  
AFTER:
![after](https://user-images.githubusercontent.com/18273538/70056492-d68ff080-15db-11ea-898f-a1e34cbf6213.JPG)
