### PR TITLE
proposal for #1887

### DIFF
--- a/serenity-report-resources/src/main/resources/report-resources/css/core.css
+++ b/serenity-report-resources/src/main/resources/report-resources/css/core.css
@@ -63,8 +63,7 @@ body {
 {
 
     min-width:1024px;
-    max-width:1024px;
-    margin:0 auto;
+    margin:0 1em;
     width: auto !important; /*IE6 hack*/
     width:1024px;
 
@@ -119,8 +118,7 @@ footer {
 #topbanner
 {
     min-width:1024px;
-    max-width:1024px;
-    margin:0 auto;
+    margin:0 1em;
     width: auto !important; /*IE6 hack*/
     width:1024px; /*IE6 hack*/
     /*border: 1px solid #FF0000;*/
@@ -975,6 +973,7 @@ font-family:euphemia, verdana, sans-serif; font-size:16px; color: #88a717; font-
 .overview {
     border: 0px;
     padding-top: 10px;
+    width: 100%;
     min-height: 650px;
     min-width: 1000px;
 }
@@ -1102,7 +1101,6 @@ td.step-icon {
 
 #results-dashboard
 {
-    width:1025px;
     -webkit-border-radius: 10px;
     -moz-border-radius: 10px;
     border-radius: 10px;


### PR DESCRIPTION
#### Summary of this PR
Serenity reports are limited to ~1024px in width. This PR removes this limit.
#### Intended effect
The report fills the page, making mor space for feature/stories names in results tables, for instance
#### How should this be manually tested?
1. Use any of the demo projects to generate a report;
2. Report should be generated without width constraints.
#### Side effects
None.
#### Documentation
N/A
#### Relevant tickets
#1887 
#### Screenshots (if appropriate)
CURRENT:  
![current](https://user-images.githubusercontent.com/18273538/70066593-3e026c00-15ed-11ea-8bbf-7a05b9670814.jpg)

PROPOSAL:  
![proposal](https://user-images.githubusercontent.com/18273538/70066602-42c72000-15ed-11ea-9522-a2d156309cf6.jpg)
