### PR TITLE
refactor: added detection of ignored test methods to JUnitAdapter to …

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/annotations/TestAnnotations.java
+++ b/serenity-model/src/main/java/net/thucydides/core/annotations/TestAnnotations.java
@@ -3,9 +3,9 @@ package net.thucydides.core.annotations;
 import net.thucydides.core.model.TestTag;
 import net.thucydides.core.model.formatters.ReportFormatter;
 import net.thucydides.core.tags.TagConverters;
+import net.thucydides.core.util.JUnitAdapter;
 import org.apache.commons.lang3.StringUtils;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -45,7 +45,7 @@ public class TestAnnotations {
     }
 
     public static boolean isIgnored(final Method method) {
-        return method != null && hasAnnotationCalled(method, "Ignore");
+        return JUnitAdapter.isIgnored(method);
     }
 
     public static boolean shouldSkipNested(Method method) {
@@ -62,14 +62,6 @@ public class TestAnnotations {
             return ((stepAnnotation != null) && (stepAnnotation.exampleRow()));
         }
         return false;
-    }
-
-    private static boolean hasAnnotationCalled(Method method, String annotationName) {
-        Annotation[] annotations = method.getAnnotations();
-
-        return Arrays.stream(annotations).anyMatch(
-              annotation -> annotation.annotationType().getSimpleName().equals(annotationName)
-        );
     }
 
     public boolean isIgnored(final String methodName) {

--- a/serenity-model/src/test/java/net/thucydides/core/util/JUnitAdapterUnitTest.java
+++ b/serenity-model/src/test/java/net/thucydides/core/util/JUnitAdapterUnitTest.java
@@ -8,9 +8,11 @@ import java.lang.annotation.Target;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.runner.RunWith;
@@ -31,6 +33,7 @@ public class JUnitAdapterUnitTest {
         assertThat(JUnitAdapter.isTestSetupMethod(null)).isFalse();
         assertThat(JUnitAdapter.isATaggableClass(null)).isFalse();
         assertThat(JUnitAdapter.isSerenityTestCase(null)).isFalse();
+        assertThat(JUnitAdapter.isIgnored(null)).isFalse();
     }
 
     @Test
@@ -41,6 +44,7 @@ public class JUnitAdapterUnitTest {
         assertThat(JUnitAdapter.isATaggableClass(NoTestAtAll.class)).isFalse();
         assertThat(JUnitAdapter.isSerenityTestCase(NoTestAtAll.class)).isFalse();
         assertThat(JUnitAdapter.isAssumptionViolatedException(new RuntimeException("Assumption violated!"))).isFalse();
+        assertThat(JUnitAdapter.isIgnored(NoTestAtAll.class.getMethod("justAMethod"))).isFalse();
     }
 
     @Test
@@ -56,6 +60,7 @@ public class JUnitAdapterUnitTest {
         assertThat(JUnitAdapter
                 .isAssumptionViolatedException(new org.junit.AssumptionViolatedException("Assumption violated!")))
                 .isTrue();
+        assertThat(JUnitAdapter.isIgnored(Junit4Test.class.getMethod("shouldBeIgnored"))).isTrue();
     }
 
     @Test
@@ -70,6 +75,7 @@ public class JUnitAdapterUnitTest {
         assertThat(JUnitAdapter
                 .isAssumptionViolatedException(new org.opentest4j.TestAbortedException("Assumption violated!")))
                 .isTrue();
+        assertThat(JUnitAdapter.isIgnored(Junit5Test.class.getDeclaredMethod("shouldBeIgnored"))).isTrue();
     }
 
     public static class NoTestAtAll {
@@ -93,6 +99,11 @@ public class JUnitAdapterUnitTest {
 
         @Test
         public void shouldSucceed() {
+        }
+
+        @Test
+        @Ignore
+        public void shouldBeIgnored() {
         }
 
     }
@@ -136,6 +147,11 @@ public class JUnitAdapterUnitTest {
         @org.junit.jupiter.api.Test
         void shouldSucceed() {
 
+        }
+
+        @org.junit.jupiter.api.Test
+        @Disabled
+        void shouldBeIgnored() {
         }
 
     }


### PR DESCRIPTION
#### Summary of this PR
The detection of ignored test methods has been missed in the first effort to decouple serenity-core and serenity-model from JUnit 4. This has now been added to the JUnitAdapter introduced in pull request #1861
#### Intended effect
Additionally JUnit 5 Disabled tests should now be detected as to be ignored.
#### How should this be manually tested?
All tests based on JUnit 4 should work as before. The regression test suites already go a long way to ensure this.
#### Side effects
none
#### Documentation
none
#### Relevant tickets
#1858 Remove runtime dependency on Junit(4)
#### Screenshots (if appropriate)
(not applicable)