### PR TITLE
proposal for #1887 (2nd attempt)

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/default.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/default.ftl
@@ -13,6 +13,8 @@
 
 </head>
 
+<body class="results-page">
+
 <#include "components/stacktrace.ftl">
 
 <div id="topheader">
@@ -27,8 +29,7 @@
     </div>
 </div>
 
-<#-- HEADER
--->
+<#-- HEADER -->
 <div class="middlecontent">
     <div id="contenttop">
         <div class="middlebg">
@@ -63,7 +64,7 @@
 
     <#assign title_outcome_icon =  formatter.resultIcon().inLarge().forResult(testOutcome.result) />
 
-    <#-- TEST TITLE-->
+    <#-- TEST TITLE -->
     <div id="contentbody">
         <div class="titlebar">
             <div class="story-title">
@@ -84,9 +85,9 @@
                                         <span class="story-header-title">${parentTitle} ${issueNumber}</span>
                                     </h3>
 
-<#--                                    <div class="discreet-requirement-narrative-title">-->
-<#--                                        ${formatter.renderDescription(parentRequirement.get().narrative.renderedTextWithoutTables)}-->
-<#--                                    </div>-->
+                                    <#-- <div class="discreet-requirement-narrative-title">-->
+                                    <#-- ${formatter.renderDescription(parentRequirement.get().narrative.renderedTextWithoutTables)}-->
+                                    <#-- </div>-->
                                 </div>
                             <#elseif (featureOrStory?? && featureOrStory.isPresent())>
                                 <div>
@@ -146,7 +147,7 @@
                             <#if (testOutcome.manual)>
 
                                 <#if (testOutcome.lastTested?? && testOutcome.manualTestingUpToDate)>
-<#--                                Last tested and up to date-->
+                                <#-- Last tested and up to date-->
                                     <div class="manual-test-result">
                                         <span class="badge badge-pill badge-info">
                                             <i class="fas fa-user-check"></i> Last tested version: ${testOutcome.lastTested}
@@ -154,17 +155,17 @@
                                         <#if (testOutcome.manualTestEvidence?has_content)>
                                             <br/>
                                             <#list testOutcome.renderedManualTestEvidence as manualEvidence>
-                                            <a target="_blank" href="${manualEvidence.link}">
+                                                <a target="_blank" href="${manualEvidence.link}">
                                                 <span class="badge badge-pill badge-primary">
                                                     <i class="fas fa-external-link-alt"></i> ${manualEvidence.label}
                                                 </span>
-                                            </a>
+                                                </a>
                                             </#list>
                                         </#if>
                                     </div>
 
                                 <#elseif (testOutcome.lastTested??)>
-<#--                                Last tested out of date-->
+                                <#-- Last tested out of date-->
                                     <div class="manual-test-result">
                                         <span class="badge badge-pill badge-info">
                                             <i class="fas fa-user-clock"></i> Awaiting new manual test. Last tested version: ${testOutcome.lastTested}</span>
@@ -180,7 +181,7 @@
                                         </#if>
                                     </div>
                                 <#else>
-<#--                                No last tested version specified -->
+                                <#-- No last tested version specified -->
                                     <i class="fa fa-user manual" alt="Manual test" title="Manual test"></i>
                                 </#if>
                             </#if>
@@ -341,107 +342,102 @@
     <div id="tablecontents">
         <div>
             <table class="step-table">
+                <#-- TABLE HEADER -->
                 <tr class="step-titles">
-                    <th width="65"><#if (testOutcome.manual)>
+                    <th width="65">
+                        <#if (testOutcome.manual)>
                             <i class="fa fa-user fa-2x" title="Manual test"></i>
                         </#if>
-                        &nbsp;
+                    </th>
+                    <th class="step-description-column greentext"><#if (testOutcome.manual)>Manual </#if>
+                        Steps
                     </th>
 
-                    <#if testOutcome.hasScreenshots()>
-                        <th width="%" class="step-description-column greentext"><#if (testOutcome.manual)>Manual </#if>
-                            Steps
-                        </th>
-                    <#else>
-                        <th width="%"
-                            class="step-description-wide-column greentext"><#if (testOutcome.manual)>Manual </#if>
-                            Steps
-                        </th>
-                    </#if>
                     <#if testOutcome.hasScreenshots()>
                         <th width="150" class="greentext">Screenshots</th>
                     </#if>
                     <th width="130" class="greentext">Outcome</th>
-                    <th width="80" class="greentext"><i title="Duration" class="far fa-clock"></i></th>
+                    <th width="100" class="greentext"><i title="Duration" class="far fa-clock"></i></th>
                 </tr>
                 <tr class="step-table-separator">
                     <td colspan="5"></td>
                 </tr>
+
+                <#-- STEPS BREAKDOWN-->
                 <#assign level = 1>
                 <#assign screenshotCount = 0>
                 <#macro write_step(step, step_number)>
-                <@step_details step=step step_number=step_number level=level/>
-                <#if step.isAGroup()>
-                <tr>
-                    <td colspan="5">
-                        <table id="stepSection${step_number}" style="display:none; width:100%">
+                    <@step_details step=step step_number=step_number level=level/>
+                    <#if step.isAGroup()>
+                        <tr>
+                            <td colspan="5">
+                                <table id="stepSection${step_number}" class="step-table-nested" style="display:none;">
 
-                            <#assign level = level + 1>
-                            <#list step.children as nestedStep>
-                                <#if step.isAGroup() >
-                                    <@write_step step=nestedStep step_number=step_number + "-" + nestedStep_index/>
-                                </#if>
-                            </#list>
-                            <#assign level = level-1>
-                            <#assign screenshotCount = screenshotCount + step.screenshotCount>
+                                    <#assign level = level + 1>
+                                    <#list step.children as nestedStep>
+                                        <#if step.isAGroup() >
+                                            <@write_step step=nestedStep step_number=step_number + "-" + nestedStep_index/>
+                                        </#if>
+                                    </#list>
+                                    <#assign level = level-1>
+                                    <#assign screenshotCount = screenshotCount + step.screenshotCount>
 
-                        </table>
-                    </td>
-                <tr>
+                                </table>
+                            </td>
+                        </tr>
                     </#if>
-                    </#macro>
+                </#macro>
 
-                    <#macro restQueryData(restQuery, number) >
-                        <span>
-                    <button type="button" class="btn btn-success btn-sm" data-toggle="collapse"
-                            data-target="#restModal-${number}">
-                        REST Query
-                    </button>
-                </span>
-                        <!-- Modal -->
-                        <div class="rest-query-details">
-                            <div class="collapse multi-collapse" id="restModal-${number}">
-                                <div class="card">
-                                    <div class="card-body">
-                                        <h4>Response</h4>
-                                        <#if restQuery.statusCode?has_content>
-                                            <p>Status code: ${restQuery.statusCode}</p>
-                                        </#if>
-                                        <#if restQuery.contentType?has_content>
-                                            <p>Content Type: ${restQuery.contentType}</p>
-                                        </#if>
-                                        <#if restQuery.requestHeaders?has_content>
-                                            <h4>Request Headers</h4>
-                                            <pre>${(formatter.renderHeaders(restQuery.requestHeaders))!}</pre>
-                                        </#if>
-                                        <#if restQuery.content?has_content>
-                                            <h4>Content Body</h4>
-                                            <pre>${(formatter.renderText(restQuery.content))!}</pre>
-                                        </#if>
-                                        <#if restQuery.requestCookies?has_content>
-                                            <h4>Request Cookies</h4>
-                                            <pre>${(formatter.renderText(restQuery.requestCookies))!}</pre>
-                                        </#if>
-                                        <#if restQuery.responseHeaders?has_content>
-                                            <h4>Response Headers</h4>
-                                            <pre>${(formatter.renderHeaders(restQuery.responseHeaders))!}</pre>
-                                        </#if>
-                                        <h4>Response Body</h4>
-                                        <#if restQuery.responseHeaders?has_content>
-                                            <pre>${formatter.renderText(restQuery.responseBody)}</pre>
-                                        </#if>
-                                        <#if restQuery.responseCookies?has_content && (!(restQuery.requestCookies?has_content) || restQuery.responseCookies!=restQuery.requestCookies)>
-                                            <h4>Response Cookies</h4>
-                                            <pre>${(formatter.renderText(restQuery.responseCookies))!}</pre>
-                                        </#if>
-                                    </div>
+                <#macro restQueryData(restQuery, number) >
+                    <span>
+                        <button type="button" class="btn btn-success btn-sm" data-toggle="collapse"
+                                data-target="#restModal-${number}">
+                            REST Query
+                        </button>
+                    </span>
+                    <!-- Modal -->
+                    <div class="rest-query-details">
+                        <div class="collapse multi-collapse" id="restModal-${number}">
+                            <div class="card">
+                                <div class="card-body">
+                                    <h4>Response</h4>
+                                    <#if restQuery.statusCode?has_content>
+                                        <p>Status code: ${restQuery.statusCode}</p>
+                                    </#if>
+                                    <#if restQuery.contentType?has_content>
+                                        <p>Content Type: ${restQuery.contentType}</p>
+                                    </#if>
+                                    <#if restQuery.requestHeaders?has_content>
+                                        <h4>Request Headers</h4>
+                                        <pre>${(formatter.renderHeaders(restQuery.requestHeaders))!}</pre>
+                                    </#if>
+                                    <#if restQuery.content?has_content>
+                                        <h4>Content Body</h4>
+                                        <pre>${(formatter.renderText(restQuery.content))!}</pre>
+                                    </#if>
+                                    <#if restQuery.requestCookies?has_content>
+                                        <h4>Request Cookies</h4>
+                                        <pre>${(formatter.renderText(restQuery.requestCookies))!}</pre>
+                                    </#if>
+                                    <#if restQuery.responseHeaders?has_content>
+                                        <h4>Response Headers</h4>
+                                        <pre>${(formatter.renderHeaders(restQuery.responseHeaders))!}</pre>
+                                    </#if>
+                                    <h4>Response Body</h4>
+                                    <#if restQuery.responseHeaders?has_content>
+                                        <pre>${formatter.renderText(restQuery.responseBody)}</pre>
+                                    </#if>
+                                    <#if restQuery.responseCookies?has_content && (!(restQuery.requestCookies?has_content) || restQuery.responseCookies!=restQuery.requestCookies)>
+                                        <h4>Response Cookies</h4>
+                                        <pre>${(formatter.renderText(restQuery.responseCookies))!}</pre>
+                                    </#if>
                                 </div>
                             </div>
                         </div>
-                    </#macro>
+                    </div>
+                </#macro>
 
-
-                    <#macro step_details(step, step_number, level)>
+                <#macro step_details(step, step_number, level)>
                     <#assign step_outcome_icon = formatter.resultIcon().forResult(step.result) />
                     <#assign step_outcome_style = formatter.resultIcon().colorFor(step.result) />
                     <#assign step_icon_size = 20>
@@ -460,118 +456,127 @@
                     <#else>
                         <#assign showAccordion = false/>
                     </#if>
-                <tr class="test-${step.result}">
-                    <td width="50" class="step-icon">
-                        <#if step_number?has_content><a name="${step_number}"/></#if>
-                        <#if showAccordion>
-                            <a href="javaScript:void(0)" onClick="toggleDiv('stepSection${step_number}')"
-                               style="display:block">
-                                <#--${step_outcome_icon}-->
-                                <i class="fa fa-plus-square-o imgstepSection${step_number} ${step_outcome_style}"
-                                   style="margin-left: ${step_indent}px; float:left;  padding-right:5px"></i>
-                                <#--<img src="images/plus.png" width="24" class="imgstepSection${step_number}"-->
-                                <#--style="margin-left: 20px; float:left;  padding-right:5px"/>-->
-                            </a>
-                        <#else>
-                            <span style="margin-left: ${step_indent}px; margin-right: 5px;"
-                                  class="${step_class_root}-icon">${step_outcome_icon}</span>
-                        <#--<img style="margin-left: ${step_indent}px; margin-right: 5px;"-->
-                        <#--src="images/${step_outcome_icon}" class="${step_class_root}-icon"/>-->
-                        </#if>
-                    </td>
-                    <td>
-                        <div class="step-description">
-                            <#if showAccordion>
-                            <a href="javaScript:void(0)" onClick="toggleDiv('stepSection${step_number}')"
-                               style="display:block;">
-                                </#if>
-                                <span class="${step_class_root}-step">
-                            <#if step.hasRestQuery()>
-                                ${formatter.restQuery(step.description)}
-                            <#else>
-                                ${formatter.formatWithFields(step.description)}
-                            </#if>
-                            </span>
-                                <#if showAccordion>
-                            </a>
-                            </#if>
-                            <span class="evidence">
-                                <#if step.hasRestQuery()>
-                                    <span class="piece-of-evidence">
-                                        <#assign restDataNumber = "REST-${step.number}">
-                                        <@restQueryData restQuery=step.restQuery number=restDataNumber />
-                                    </span>
-                                </#if>
-                                <#if step.hasData()>
-                                    <#list step.reportData as recordedData>
-                                        <#assign restDataNumber = "EVIDENCE-${step.number}-${recordedData?index}">
-                                        <span class="piece-of-evidence">
-                                            <@reportData reportData=recordedData number=restDataNumber />
-                                        </span>
-                                    </#list>
-                                </#if>
-                            </span>
-                        </div>
-                    </td>
-                    <#if testOutcome.hasScreenshots()>
-                        <td width="160" class="${step.result}-text">
-                            <#if step.hasMultipleScreenshots() >
-                                <a href="${relativeLink!}${testOutcome.screenshotReportName}.html#screenshots?screenshot=${screenshotCount}">
-                                    <img src="${step.earliestScreenshot.filename}"
-                                         href="${step.earliestScreenshot.filename}"
-                                         class="screenshot"
-                                         width="48" height="48"/>
-                                </a>
-                                <i class="fas fa-arrow-right"></i>
-                            </#if>
-
-                            <#if step.latestScreenshot?has_content>
-                                <#assign actualScreenshotCount = screenshotCount + step.actualScreenshotCount />
-                                <a href="${relativeLink!}${testOutcome.screenshotReportName}.html#screenshots?screenshot=${actualScreenshotCount}">
-                                    <img src="${step.latestScreenshot.filename}"
-                                         href="${step.latestScreenshot.filename}"
-                                         class="screenshot"
-                                         width="48" height="48"/>
-                                </a>
-                                <#if step.hasChildren()>
-                                    <#assign screenshotCount = screenshotCount + 1 />
-                                <#else>
-                                    <#assign screenshotCount = screenshotCount + step.screenshotCount />
-                                </#if>
-                            </#if>
-                        </td>
-                    </#if>
-                    <td width="100"><span class="${step_class_root}-step">${step.result}</span></td>
-                    <td width="100"><span class="${step_class_root}-step">${step.durationInSeconds}s</span></td>
-                </tr>
-                <#if (step.errorMessage?has_content) && !step.hasNestedErrors()>
                     <tr class="test-${step.result}">
-                        <td width="40">&nbsp</td>
-                        <#if step.errorMessage?has_content>
-                            <#assign errorMessageTitle = step.errorMessage?html>
-                        <#else>
-                            <#assign errorMessageTitle = "">
-                        </#if>
-                        <#if testOutcome.hasScreenshots()>
-                        <td width="%" colspan="4" class="error-message-cell">
-                            <#else>
-                        <td width="%" colspan="3" class="error-message-cell">
-                            </#if>
 
-                            <#assign formattedErrorMessageTitle = formatter.htmlAttributeCompatible(errorMessageTitle, true) />
-
-                            <#if step.nestedException?has_content>
-                                <@stacktrace title=formattedErrorMessageTitle cause=step.nestedException id=step.number />
+                        <#-- ICON -->
+                        <td width="${step_indent + 30}" class="step-icon">
+                            <#if step_number?has_content><a name="${step_number}"></a></#if>
+                            <#if showAccordion>
+                                <a href="javaScript:void(0)" onClick="toggleDiv('stepSection${step_number}')"
+                                   style="display:block">
+                                    <#--${step_outcome_icon}-->
+                                    <i class="fa fa-plus-square-o imgstepSection${step_number} ${step_outcome_style}"
+                                       style="margin-left: ${step_indent}px; float:left; padding-right:5px"></i>
+                                    <#--<img src="images/plus.png" width="24" class="imgstepSection${step_number}"-->
+                                    <#--style="margin-left: 20px; float:left;  padding-right:5px"/>-->
+                                </a>
                             <#else>
-                                <div class="error-message"
-                                     title='${formatter.htmlAttributeCompatible(errorMessageTitle)}'>
-                                    <pre>${formatter.htmlAttributeCompatible(errorMessageTitle,244)!''}</pre>
-                                </div>
+                                <span style="margin-left: ${step_indent}px;"
+                                      class="${step_class_root}-icon">${step_outcome_icon}
+                                </span>
+                            <#--<img style="margin-left: ${step_indent}px; margin-right: 5px;"-->
+                            <#--src="images/${step_outcome_icon}" class="${step_class_root}-icon"/>-->
                             </#if>
                         </td>
+
+                        <#-- DESCRIPTION -->
+                        <td class="step-description-column">
+                            <div class="step-description">
+                                <#if showAccordion>
+                                    <a href="javaScript:void(0)" onClick="toggleDiv('stepSection${step_number}')"
+                                       style="display:block;">
+                                        </#if>
+                                        <span class="${step_class_root}-step">
+                                            <#if step.hasRestQuery()>
+                                                ${formatter.restQuery(step.description)}
+                                            <#else>
+                                                ${formatter.formatWithFields(step.description)}
+                                            </#if>
+                                        </span>
+                                        <#if showAccordion>
+                                    </a>
+                                </#if>
+                                <span class="evidence">
+                                    <#if step.hasRestQuery()>
+                                        <span class="piece-of-evidence">
+                                            <#assign restDataNumber = "REST-${step.number}">
+                                            <@restQueryData restQuery=step.restQuery number=restDataNumber />
+                                        </span>
+                                    </#if>
+                                    <#if step.hasData()>
+                                        <#list step.reportData as recordedData>
+                                            <#assign restDataNumber = "EVIDENCE-${step.number}-${recordedData?index}">
+                                            <span class="piece-of-evidence">
+                                                <@reportData reportData=recordedData number=restDataNumber />
+                                            </span>
+                                        </#list>
+                                    </#if>
+                                </span>
+                            </div>
+                        </td>
+
+                        <#-- SCREENSHOTS -->
+                        <#if testOutcome.hasScreenshots()>
+                            <td width="160" class="${step.result}-text">
+                                <#if step.hasMultipleScreenshots() >
+                                    <a href="${relativeLink!}${testOutcome.screenshotReportName}.html#screenshots?screenshot=${screenshotCount}">
+                                        <img src="${step.earliestScreenshot.filename}"
+                                             href="${step.earliestScreenshot.filename}"
+                                             class="screenshot"
+                                             width="48" height="48"/>
+                                    </a>
+                                    <i class="fas fa-arrow-right"></i>
+                                </#if>
+
+                                <#if step.latestScreenshot?has_content>
+                                    <#assign actualScreenshotCount = screenshotCount + step.actualScreenshotCount />
+                                    <a href="${relativeLink!}${testOutcome.screenshotReportName}.html#screenshots?screenshot=${actualScreenshotCount}">
+                                        <img src="${step.latestScreenshot.filename}"
+                                             href="${step.latestScreenshot.filename}"
+                                             class="screenshot"
+                                             width="48" height="48"/>
+                                    </a>
+                                    <#if step.hasChildren()>
+                                        <#assign screenshotCount = screenshotCount + 1 />
+                                    <#else>
+                                        <#assign screenshotCount = screenshotCount + step.screenshotCount />
+                                    </#if>
+                                </#if>
+                            </td>
+                        </#if>
+                        <#-- OUTCOME & TIME -->
+                        <td width="130"><span class="${step_class_root}-step">${step.result}</span></td>
+                        <td width="100"><span class="${step_class_root}-step">${step.durationInSeconds}s</span></td>
                     </tr>
-                </#if>
+                    <#if (step.errorMessage?has_content) && !step.hasNestedErrors()>
+                        <tr class="test-${step.result}">
+                            <td width="40">&nbsp</td>
+                                <#if step.errorMessage?has_content>
+                                    <#assign errorMessageTitle = step.errorMessage?html>
+                                <#else>
+                                    <#assign errorMessageTitle = "">
+                                </#if>
+                                <#if testOutcome.hasScreenshots()>
+                                    <td width="%" colspan="4" class="error-message-cell">
+                                <#else>
+                                    <td width="%" colspan="3" class="error-message-cell">
+                                </#if>
+
+                                <#assign formattedErrorMessageTitle = formatter.htmlAttributeCompatible(errorMessageTitle, true) />
+
+                                <#if step.nestedException?has_content>
+                                    <@stacktrace title=formattedErrorMessageTitle cause=step.nestedException id=step.number />
+                                <#else>
+                                    <div class="error-message"
+                                         title='${formatter.htmlAttributeCompatible(errorMessageTitle)}'>
+                                        <pre>${formatter.htmlAttributeCompatible(errorMessageTitle,244)!''}</pre>
+                                    </div>
+                                </#if>
+                            </td>
+                        </tr>
+                    </#if>
                 </#macro>
+
                 <#-- Test step results -->
                 <#list testOutcome.testSteps as step>
                     <@write_step step=step step_number=step_index />
@@ -579,42 +584,37 @@
                 <#if testOutcome.hasNonStepFailure()>
                     <#assign step_outcome_icon = formatter.resultIcon().forResult(testOutcome.result) />
                     <tr class="test-${testOutcome.result}">
-                        <td width="40">${step_outcome_icon}
-                        </td>
+                        <td width="40">${step_outcome_icon}</td>
                         <#if testOutcome.hasScreenshots()>
-                        <td width="%" colspan="2">
-                            <#else>
-                        <td width="%" colspan="1">
-                            </#if>
-                            <#if testOutcome.errorMessage?has_content>
-                                <span class="top-level-step">${testOutcome.errorMessage}</span>
-                            <#else>
-                                <span class="top-level-step">An error occurred outside of step execution</span>
-                            </#if>
-                        </td>
-                        <td width="100"><span
-                                    class="top-level-step">${formatter.htmlCompatibleStepDescription(testOutcome.result)}</span>
-                        </td>
+                            <td width="%" colspan="2">
+                        <#else>
+                            <td width="%" colspan="1">
+                        </#if>
+                        <#if testOutcome.errorMessage?has_content>
+                            <span class="top-level-step">${testOutcome.errorMessage}</span>
+                        <#else>
+                            <span class="top-level-step">An error occurred outside of step execution</span>
+                        </#if>
+                            </td>
+                        <td width="130"><span class="top-level-step">${formatter.htmlCompatibleStepDescription(testOutcome.result)}</span></td>
                         <td width="100"><span class="top-level-step">${testOutcome.durationInSeconds}s</span></td>
                     </tr>
                     <tr class="test-${testOutcome.result}">
                         <td width="40">&nbsp</td>
                         <#if testOutcome.hasScreenshots()>
-                        <td width="%" colspan="4">
-                            <#else>
-                        <td width="%" colspan="3">
-                            </#if>
-                            <#if (testOutcome.errorMessage)??>
-                                <#if (testOutcome.nestedTestFailureCause)??>
-                                    <#assign formattedErrorMessageTitle = formatter.htmlAttributeCompatible(testOutcome.errorMessage, true) />
+                            <td width="%" colspan="4">
+                        <#else>
+                            <td width="%" colspan="3">
+                        </#if>
+                        <#if (testOutcome.errorMessage)??>
+                            <#if (testOutcome.nestedTestFailureCause)??>
+                                <#assign formattedErrorMessageTitle = formatter.htmlAttributeCompatible(testOutcome.errorMessage, true) />
 
-                                    <@stacktrace title=formattedErrorMessageTitle cause=testOutcome.nestedTestFailureCause id="overall" />
-                                </#if>
+                                <@stacktrace title=formattedErrorMessageTitle cause=testOutcome.nestedTestFailureCause id="overall" />
                             </#if>
-
-                        </td>
+                        </#if>
+                            </td>
                     </tr>
-                <#--</#if>-->
                 </#if>
                 <tr class="test-${testOutcome.result}">
                     <#if testOutcome.hasScreenshots()>
@@ -622,13 +622,14 @@
                     <#else>
                         <td colspan="2"></td>
                     </#if>
-                    <td width="100"><span class="top-level-step"><em>${testOutcome.result}</em></span></td>
+                    <td width="130"><span class="top-level-step"><em>${testOutcome.result}</em></span></td>
                     <td width="100"><span class="top-level-step"><em>${testOutcome.durationInSeconds}s</em></span></td>
                 </tr>
 
             </table>
         </div>
     </div>
+
     <div id="beforefooter"></div>
 
 
@@ -692,5 +693,6 @@
     <div id="imgPreviewWithStyles2" style="display: none; position: absolute; "><img style="height: 200px; "></div>
     <div id="imgPreviewWithStyles3" style="display: none; position: absolute; "><img style="height: 200px; "></div>
 
-    </body>
+</div>
+</body>
 </html>

--- a/serenity-report-resources/src/main/resources/report-resources/css/core.css
+++ b/serenity-report-resources/src/main/resources/report-resources/css/core.css
@@ -63,8 +63,7 @@ body {
 {
 
     min-width:1024px;
-    max-width:1024px;
-    margin:0 auto;
+    margin:0 1em;
     width: auto !important; /*IE6 hack*/
     width:1024px;
 
@@ -119,8 +118,7 @@ footer {
 #topbanner
 {
     min-width:1024px;
-    max-width:1024px;
-    margin:0 auto;
+    margin:0 1em;
     width: auto !important; /*IE6 hack*/
     width:1024px; /*IE6 hack*/
     /*border: 1px solid #FF0000;*/
@@ -531,8 +529,8 @@ i.tag {
     margin-right: 5px;
 }
 
-.error-message-cell {
-    max-width: 755px;
+.error-message-cell .table{
+    width: 99%;
 }
 .error-message {
     font-family:euphemia, verdana, sans-serif; font-size:12px; color:#CC0033; text-align:left; width:100%;
@@ -975,6 +973,7 @@ font-family:euphemia, verdana, sans-serif; font-size:16px; color: #88a717; font-
 .overview {
     border: 0px;
     padding-top: 10px;
+    width: 100%;
     min-height: 650px;
     min-width: 1000px;
 }
@@ -996,7 +995,6 @@ a.tagLink:visited, a.tagLink:link {
 }
 .story-title
 {
-    width:1008px;
     -webkit-border-radius: 10px;
     -moz-border-radius: 10px;
     border-radius: 10px;
@@ -1021,7 +1019,7 @@ a.tagLink:visited, a.tagLink:link {
 
 .step-table
 {
-    width:95%;
+    width:100%;
     -webkit-border-radius: 10px;
     -moz-border-radius: 10px;
     border-radius: 10px;
@@ -1031,7 +1029,12 @@ a.tagLink:visited, a.tagLink:link {
     border-color: #e7e8e3;
     border-style: solid;
     table-layout: fixed;
+}
 
+.step-table-nested
+{
+    width:100%;
+    table-layout: fixed;
 }
 
 .test-case-caption {
@@ -1046,12 +1049,9 @@ a.tagLink:visited, a.tagLink:link {
 .outcome-icon {
     float: left;
 }
-.step-description-wide-column {
-    width: 730px;
-}
 
 .step-description-column {
-    width: 650px;
+    width: 100%;
 }
 
 .step-table th {
@@ -1059,7 +1059,7 @@ a.tagLink:visited, a.tagLink:link {
 }
 
 .step-table td {
-    padding: 5px;
+    padding: 5px 0px;
 }
 
 td.step-icon {
@@ -1068,7 +1068,7 @@ td.step-icon {
 
 .step-description {
     overflow: auto;
-    max-width: 700px;
+    margin-right: 1em;
 }
 
 .step-table-separator td {
@@ -1102,7 +1102,6 @@ td.step-icon {
 
 #results-dashboard
 {
-    width:1025px;
     -webkit-border-radius: 10px;
     -moz-border-radius: 10px;
     border-radius: 10px;
@@ -1504,7 +1503,6 @@ table.coverage_data td {
     color:#0d78ae;
     font-family:euphemia, verdana, sans-serif;
     font-size:14px;
-    width: 1008px;
     min-width: 1008px;
 }
 
@@ -2094,22 +2092,24 @@ div.scenario-text:empty {
 }
 
 .stacktrace-details {
-    width: 100%;
+    width: 99%;
     margin-left: 0px !important;
     background-color: bisque;
     font-family: monospace;
 }
 
 .rest-query-details {
-    width: 100%;
+    width: 99%;
     margin-left: 0px !important;
     background-color: #EEEEE0;
     font-family: monospace;
 }
 
 .details-button  {
+    float: right;
     margin-top: 4px !important;
     margin-bottom: 4px !important;
+    margin-right: 5px; !important;
     font-size: 1em;
     background-color: rgba(238,0,0,0.3);
 }
@@ -2147,7 +2147,6 @@ td.indented-error-category i {
 
 .example-table table {
     min-width: 80%;
-    max-width: 80%;
 }
 .example-table table th {
     padding: 4px;
@@ -2171,7 +2170,7 @@ td.indented-error-category i {
 
 .test-report table {
     border: 0.75px solid dimgrey;
-    min-width: 98%;
+    min-width: 80%;
 }
 .test-report th {
     font-weight: bold;
@@ -2216,6 +2215,9 @@ td.indented-error-category i {
     color: grey;
 }
 
+.example-table-in-scenario .row {
+    margin-right: 15px;
+}
 
 
 .example-table-in-summary th:last-child {
@@ -2232,6 +2234,10 @@ td.indented-error-category i {
 
 .example-table-in-summary {
     padding-bottom: 0px;
+}
+
+.example-table-in-summary .row {
+    margin-right: 15px;
 }
 
 .example-table-in-scenario th:last-child {


### PR DESCRIPTION
**Summary of this PR**
Serenity reports are limited to ~1024px in width. This PR removes this limit.
Fixed results tables pointed out in #1896 
Also tested with extra long data tables (see screens).

**Intended effect**
The report fills the page, making mor space for feature/stories names in results tables, for instance

**How should this be manually tested?**
1. Use any of the demo projects to generate a report;
2. Report should be generated without width constraints.

**Side effects**
None.

**Documentation**
N/A

**Relevant tickets**
#1887 

**Screenshots (if appropriate)**
MAIN REQUIREMENT:
![more-space-for-feature-names](https://user-images.githubusercontent.com/18273538/71190743-6d6bd680-2285-11ea-88b4-05ff662747a2.png)

HOME PAGE:
![home-page](https://user-images.githubusercontent.com/18273538/71190759-75c41180-2285-11ea-999d-2609720b053d.png)

RESULTS TABLES:
![examples-results](https://user-images.githubusercontent.com/18273538/71190891-a86e0a00-2285-11ea-9918-ee18ad185acc.png)

FEATURE SPECS:
![feature-specifications](https://user-images.githubusercontent.com/18273538/71190907-aefc8180-2285-11ea-8550-0f7bcce8d046.png)

EXAMPLE WITH SCREENSHOTS:
![example-with-screenshots](https://user-images.githubusercontent.com/18273538/71190930-b91e8000-2285-11ea-8e14-6de5b6cefc1b.png)
