### PR TITLE
Fix appium specific environment bug.

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
@@ -89,7 +89,7 @@ public class AppiumConfiguration {
      * Return the Appium platform defined in the system properties, or NONE if no platform is defined.
      */
     public MobilePlatform definedTargetPlatform() {
-        String targetPlatform = ThucydidesSystemProperty.APPIUM_PLATFORMNAME.from(environmentVariables,"NONE");
+        String targetPlatform = ThucydidesSystemProperty.APPIUM_PLATFORMNAME.from(environmentVariables, "NONE");
         try {
             return MobilePlatform.valueOf(targetPlatform.toUpperCase());
         } catch (IllegalArgumentException e) {
@@ -143,12 +143,10 @@ public class AppiumConfiguration {
         for (String capabilityName : capabilities.getCapabilityNames()) {
             if (ACCEPTED_W3C_PATTERNS.test(capabilityName) || APPIUM_SUPPORTED_CAPABILITIES.contains(capabilityName)) {
                 processedCapabilities.setCapability(capabilityName, capabilities.getCapability(capabilityName));
-            }
-            else if (additionalAppiumCapabilities.contains(capabilityName)) {
+            } else if (additionalAppiumCapabilities.contains(capabilityName)) {
                 LOGGER.info("appium: prefix added to capability {}", capabilityName);
                 processedCapabilities.setCapability("appium:" + capabilityName, capabilities.getCapability(capabilityName));
-            }
-            else {
+            } else {
                 LOGGER.warn("{} capability is not discovered in the list of supported by w3c or Appium. " +
                                 "If it is required then it should be listed in {@link ThucydidesSystemProperty#APPIUM_ADDITIONAL_CAPABILITIES}",
                         capabilityName);
@@ -165,10 +163,12 @@ public class AppiumConfiguration {
     private Properties appiumPropertiesFrom(EnvironmentVariables environmentVariables, String options) {
 
         Properties appiumProperties = new Properties();
+        String env = environmentVariables.getProperty("environment", "default");
+        String regex=String.format("environments\\.(all|%s)\\.appium",env);
         List<String> appiumKeys =
                 environmentVariables.getKeys()
                         .stream()
-                        .map(key->key.replaceFirst("environment.*.appium","appium"))
+                        .map(key -> key.replaceFirst(regex, "appium"))
                         .distinct()
                         .filter(key -> key.startsWith("appium."))
                         .collect(Collectors.toList());
@@ -185,7 +185,7 @@ public class AppiumConfiguration {
         }
 
         Map<String, String> optionsMap = OptionsMap.from(options);
-        for(String key : optionsMap.keySet()) {
+        for (String key : optionsMap.keySet()) {
             appiumProperties.setProperty(key, optionsMap.get(key));
         }
         ensureAppOrBrowserPathDefinedIn(appiumProperties);

--- a/serenity-model/src/main/java/net/thucydides/core/model/TestOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/core/model/TestOutcome.java
@@ -473,7 +473,8 @@ public class TestOutcome {
                 this.manualTestEvidence,
                 this.projectKey,
                 this.environmentVariables,
-                this.externalLink);
+                this.externalLink,
+                this.context);
     }
 
     protected TestOutcome(final ZonedDateTime startTime,
@@ -503,7 +504,8 @@ public class TestOutcome {
                           final List<String> testEvidence,
                           final String projectKey,
                           final EnvironmentVariables environmentVariables,
-                          final ExternalLink externalLink) {
+                          final ExternalLink externalLink,
+    final String context) {
         this.startTime = startTime;
         this.duration = duration;
         this.title = title;
@@ -536,7 +538,8 @@ public class TestOutcome {
         this.lastTested = lastTested;
         this.projectKey = projectKey;
         this.environmentVariables = environmentVariables;
-        this.externalLink = this.externalLink;
+        this.externalLink = externalLink;
+        this.context=context;
     }
 
     private List<String> removeDuplicates(List<String> issues) {
@@ -591,7 +594,8 @@ public class TestOutcome {
                     this.manualTestEvidence,
                     this.projectKey,
                     this.environmentVariables,
-                    this.externalLink);
+                    this.externalLink,
+                    this.context);
         } else {
             return this;
         }
@@ -625,7 +629,8 @@ public class TestOutcome {
                 this.manualTestEvidence,
                 this.projectKey,
                 this.environmentVariables,
-                this.externalLink);
+                this.externalLink,
+                this.context);
     }
 
     public TestOutcome withTags(Set<TestTag> tags) {
@@ -656,7 +661,8 @@ public class TestOutcome {
                 this.manualTestEvidence,
                 this.projectKey,
                 this.environmentVariables,
-                this.externalLink);
+                this.externalLink,
+                this.context);
     }
 
     public TestOutcome withMethodName(String methodName) {
@@ -688,7 +694,8 @@ public class TestOutcome {
                     this.manualTestEvidence,
                     this.projectKey,
                     this.environmentVariables,
-                    this.externalLink);
+                    this.externalLink,
+                    this.context);
         } else {
             return this;
         }
@@ -875,7 +882,8 @@ public class TestOutcome {
                 this.manualTestEvidence,
                 this.projectKey,
                 this.environmentVariables,
-                this.externalLink);
+                this.externalLink,
+                this.context);
     }
 
     public void updateTopLevelStepResultsTo(TestResult result) {
@@ -2696,7 +2704,8 @@ public class TestOutcome {
                 manualTestEvidence,
                 projectKey,
                 environmentVariables,
-                externalLink);
+                externalLink,
+                context);
     }
 
     public ExternalLink getExternalLink() {


### PR DESCRIPTION
When an specific environment is used serenity was sending all appium properties which cause for example that if an IOS environment was specified then appium also receive properties for android if they exists.

Also added a fix to include context in TestOutcome constructors and clone methods.