### PR TITLE
fix: issue 1997 - report correct number of junit retries

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
@@ -218,14 +218,14 @@ public class BaseStepListener implements StepListener, StepPublisher {
         }
     }
 
-    public void lastTestPassedAfterRetries(int remainingTries, List<String> failureMessages, TestFailureCause testfailureCause) {
+    public void lastTestPassedAfterRetries(int attemptNum, List<String> failureMessages, TestFailureCause testfailureCause) {
         if (latestTestOutcome().isPresent()) {
             latestTestOutcome().get().recordStep(
                     TestStep.forStepCalled("UNSTABLE TEST:\n" + failureHistoryFor(failureMessages))
                             .withResult(UNDEFINED));
 //                            .withResult(TestResult.IGNORED));
 
-            latestTestOutcome().get().addTag(TestTag.withName("Retries: " + (remainingTries - 1)).andType("unstable test"));
+            latestTestOutcome().get().addTag(TestTag.withName("Retries: " + attemptNum).andType("unstable test"));
             latestTestOutcome().get().setFlakyTestFailureCause(testfailureCause);
         }
     }

--- a/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
+++ b/serenity-junit/src/main/java/net/serenitybdd/junit/runners/SerenityRunner.java
@@ -446,14 +446,15 @@ public class SerenityRunner extends BlockJUnit4ClassRunner implements Taggable {
                              RerunTest rerunTest) {
         if (remainingTries <= 0) { return; }
 
-        logger.info(rerunTest.toString() + ": attempt " + (maxRetries() - remainingTries));
+        int attemptNum = maxRetries() - remainingTries + 1;
+        logger.info(rerunTest.toString() + ": attempt " + attemptNum);
         StepEventBus.getEventBus().cancelPreviousTest();
         rerunTest.perform();
 
         if (failureDetectingStepListener.lastTestFailed()) {
             retryAtMost(remainingTries - 1, rerunTest);
         } else {
-            StepEventBus.getEventBus().lastTestPassedAfterRetries(remainingTries,
+            StepEventBus.getEventBus().lastTestPassedAfterRetries(attemptNum,
                                                                   failureDetectingStepListener.getFailureMessages(),failureDetectingStepListener.getTestFailureCause());
         }
     }


### PR DESCRIPTION
#### Summary of this PR
Minor fix of tag value, applied to passed junit tests after rerun.
#### Intended effect
Number of test retries should be reported correctly.
#### How should this be manually tested?
* Introduce some flaky serenity-junit test;
* run test with property `test.retry.count=10`;
* Make sure that flaky test pass not in 1st try, but in some next try;
* Open generated page and check number of retries, reported in `unstable test` tag
#### Documentation
Documentation for `TEST_RETRY_COUNT` system property already exists.
#### Relevant tickets
#1997 
#### Screenshots (if appropriate)
Please check related issue.