### PR TITLE
fix: complain only when timer is elapsed on an eventual consequence. …

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Complaint.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Complaint.java
@@ -6,7 +6,7 @@ public class Complaint {
 
     public static Error from(Class<? extends Error> complaintType,
                                         String complaintDetails,
-                                        Error actualError) {
+                                        Throwable actualError) {
 
         if ((complaintDetails == null) && (actualError.getMessage() == null)) {
             return from(complaintType, actualError);
@@ -21,7 +21,7 @@ public class Complaint {
         }
     }
 
-    private static String errorMessageFrom(String complaintDetails, Error actualError) {
+    private static String errorMessageFrom(String complaintDetails, Throwable actualError) {
         if (complaintDetails == null) {
             return actualError.getMessage();
         }

--- a/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/WhenWaitingForDelayedResults.groovy
+++ b/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/WhenWaitingForDelayedResults.groovy
@@ -70,7 +70,7 @@ class WhenWaitingForDelayedResults extends Specification {
                                   orComplainWith(SomethingBadHappenedException)).
                         waitingForNoLongerThan(100).milliseconds())
         then:
-            theTestResult() == ERROR
+        theFailureClass() == SomethingBadHappenedException.getCanonicalName()
     }
 
     def "should report custom error if one is declared outside of the eventually scope"() {
@@ -81,11 +81,15 @@ class WhenWaitingForDelayedResults extends Specification {
         jane.should(eventually(seeThat(TheClickerValue.of(clicker), equalTo(-1))).
                 waitingForNoLongerThan(100).milliseconds().orComplainWith(SomethingBadHappenedException))
         then:
-        theTestResult() == ERROR
+        theFailureClass() == SomethingBadHappenedException.getCanonicalName()
     }
 
     private TestResult theTestResult() {
         StepEventBus.eventBus.baseStepListener.testOutcomes[0].result
+    }
+
+    private String theFailureClass() {
+        StepEventBus.eventBus.baseStepListener.testOutcomes[0].testFailureClassname
     }
 }
 


### PR DESCRIPTION
#### Summary of this PR
Assertion and hence Logging of EventualConsequence with ComplainWith will happen only once after the time is elapsed 
#### Intended effect
Earlier we will see the repetitive assertions for every lap of the timer.
#### How should this be manually tested?
Create an EventualConsequence and CustomException class and enable logging.
You will be able to see that assertion logs happens only once. Earlier the assertion logs happen for every lap of the timer. This can be tested with any serenity-demo project
e.g as below:
```
actor.should(
           eventually(seeThat(TheDashboard.startButtonIsEnabled(), is(true)))
               .waitingForNoLongerThan(20).seconds()
               .orComplainWith(StartButtonNotEnabled.class));
```
#### Side effects
Note that if there is a custom exception raised within the main EventualConsequence step that will still be logged.
#### Documentation
If the pull request is user facing, how is it documented?
Nothing changes in the usage of the orComplainWith API
#### Relevant tickets
#1799 
#### Screenshots (if appropriate)
The screen shots are taken from our project. Hence shows a minimal stacktrace
Before:
Logging happens every lap of timer. Find attached stacktrace from 2 continuous laps
![BeforeLogs@17_35_01](https://user-images.githubusercontent.com/46148202/76826432-7b100880-6842-11ea-80bf-e2110a87ab1f.JPG)
![BeforeLogs@17_35_12](https://user-images.githubusercontent.com/46148202/76826440-7d726280-6842-11ea-92d5-08bc5e507f14.JPG)

After:
Logging happens only at the end of time. Find attached one single instance of stacktrace at the end of timer.
![AfterFixLogs](https://user-images.githubusercontent.com/46148202/76826455-86fbca80-6842-11ea-9228-0f4dabeda1c7.JPG)

Nothing changes in reporting
![Report_BeforeAndAfter](https://user-images.githubusercontent.com/46148202/76826476-8ebb6f00-6842-11ea-9c63-16184e719012.JPG)

