### PR TITLE
Add test details to driver capabilities only if base step listener registered

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/DriverCapabilities.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/DriverCapabilities.java
@@ -120,9 +120,12 @@ public class DriverCapabilities {
             capabilities.setCapability("version", WEBDRIVER_REMOTE_BROWSER_VERSION.from(environmentVariables));
         }
 
-        AddCustomDriverCapabilities.from(environmentVariables)
-                .withTestDetails(SupportedWebDriver.REMOTE, StepEventBus.getEventBus().getBaseStepListener().getCurrentTestOutcome())
-                .to(capabilities);
+        AddCustomDriverCapabilities addCustomDriverCapabilities = AddCustomDriverCapabilities.from(environmentVariables);
+        if (StepEventBus.getEventBus().isBaseStepListenerRegistered()) {
+    		addCustomDriverCapabilities = addCustomDriverCapabilities
+    				.withTestDetails(SupportedWebDriver.REMOTE, StepEventBus.getEventBus().getBaseStepListener().getCurrentTestOutcome());
+        }
+        addCustomDriverCapabilities.to(capabilities);
 
         return capabilities;
     }


### PR DESCRIPTION
I encountered a NPE in the following situation:
- junit-platform-runner 1.6.0
- cucumber-junit-platform-engine 5.5.0
- serenity-cucumber5 2.2.0
- remote webdriver for firefox
- eclipse IDE junit5 launcher
=> Could not instantiate class org.openqa.selenium.remote.RemoteWebDriver
=> No BaseStepListener has been registered
at net.serenitybdd.core.webdriver.driverproviders.DriverCapabilities.remoteCapabilities(DriverCapabilities.java:124)
