### PR TITLE
fix: requirements not displayed on aggregate report when running with cucumber filter tags

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/requirements/model/cucumber/CucumberParser.java
+++ b/serenity-model/src/main/java/net/thucydides/core/requirements/model/cucumber/CucumberParser.java
@@ -75,7 +75,7 @@ public class CucumberParser {
                 return Optional.empty();
             }
             GherkinDocument gherkinDocument = gherkinDocuments.get(0);
-            
+
             String descriptionInComments = NarrativeFromCucumberComments.in(gherkinDocument.getComments());
 
             if (featureFileCouldNotBeReadFor(gherkinDocument.getFeature())) {
@@ -177,6 +177,9 @@ public class CucumberParser {
                     }
                 }
         );
+
+        // Include Scenarios And Examples Tags To Features Tags Set
+        requirementTags.addAll(scenarioTags.values().stream().flatMap(Collection::stream).collect(Collectors.toSet()));
 
         // Scenario Names
         List<String> scenarios = feature.getChildren().stream().map(ScenarioDefinition::getName).collect(Collectors.toList());

--- a/serenity-model/src/test/groovy/net/thucydides/core/requirements/model/cucumber/WhenReferencingScenariosInAFeatureNarrative.groovy
+++ b/serenity-model/src/test/groovy/net/thucydides/core/requirements/model/cucumber/WhenReferencingScenariosInAFeatureNarrative.groovy
@@ -9,6 +9,8 @@ import io.cucumber.core.internal.gherkin.stream.GherkinEvents
 import io.cucumber.core.internal.gherkin.stream.SourceEvents
 import spock.lang.Specification
 
+import java.util.stream.Collectors
+
 class WhenReferencingScenariosInAFeatureNarrative extends Specification {
 
     def featureFile = "src/test/resources/serenity-cucumber/features/maintain_my_todo_list/filtering_todos.feature"
@@ -148,6 +150,19 @@ Then her todo list should contain Walk the dog    {result:Filtering things I nee
             def narrative = parser.loadFeatureNarrative(new File(featureFile))
         then:
             narrative.isPresent()
+    }
+
+    def "should render narratives with scenarios and examples tags"() {
+        def expectedTag = ["tag:Manual", "tag:Example1", "Type:A"]
+
+        given:
+            CucumberParser parser = new CucumberParser()
+        when:
+            def narrative = parser.loadFeatureNarrative(new File(featureFile))
+        then:
+            def actualTags = narrative.get().tags.stream()
+                    .map({ t -> t.toString() }).collect(Collectors.toList())
+            assert expectedTag.every {actualTags.contains(it)}
     }
 
 }

--- a/serenity-model/src/test/resources/serenity-cucumber/features/maintain_my_todo_list/filtering_todos.feature
+++ b/serenity-model/src/test/resources/serenity-cucumber/features/maintain_my_todo_list/filtering_todos.feature
@@ -25,12 +25,12 @@ Feature: Filtering things I need to do
     And she has completed the task called 'Walk the dog'
     When she filters her list to show only <filter> tasks
     Then her todo list should contain <expected>
-
+    @Example1
     Examples: Do some things
       | tasks                       | filter    | expected      |
       | Buy some milk, Walk the dog | Completed | Walk the dog  |
       | Buy some milk, Walk the dog | Active    | Buy some milk |
-
+    @Type:A
     Examples: Do some other things
       | tasks                       | filter    | expected      |
       | Buy some milk, Walk the dog | Completed | Walk the dog  |


### PR DESCRIPTION
# Description

In the current version, running serenity:aggregate with -Dcucumber.filter.tags only works if the tags are at the feature level. If the filtered tags are at scenario, scenario outlines, or examples, the aggregate report would have blank requirements, capabilities, and features pages because the Requirement object only contains feature TestTag.
<img width="1072" alt="before_fix" src="https://user-images.githubusercontent.com/13144677/82648907-4404fd00-9bcd-11ea-8a52-8bce499f5f59.png">

I only fixed it simply by including all the tags in the feature files. Seems like it has always been like this. Let me know if this is by design.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I added a unit test. Also built locally and did e2e test.