### PR TITLE
'task' is already null by the time code gets here.

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/InstrumentedTask.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/InstrumentedTask.java
@@ -70,9 +70,7 @@ public class InstrumentedTask {
         try {
             return task.getClass().getSimpleName().contains("ByteBuddy");
         } catch(NullPointerException ignore) {
-            throw new TaskInstantiationException("Could not instantiate "
-                                                 + task.getClass()
-                                                 + ". Your Task class must have a public constructor.");
+            throw new TaskInstantiationException("Your Task class must have a public constructor.");
         }
     }
 }


### PR DESCRIPTION
I used `./gradlew install` to install the snapshot. So I was able to prove that my fix does **not** work. :(
Once the code gets into `isInstrumented(Performable task)`, at that point `task` is already null. So in my "fix" `task.getClass()` throws another NPE.

I am not able to find a better solution.