### PR TITLE
Stop using deprecated DesiredCapabilities in main

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/ChromeDriverCapabilities.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/ChromeDriverCapabilities.java
@@ -1,7 +1,5 @@
 package net.serenitybdd.core.webdriver.driverproviders;
 
-import com.google.common.base.Optional;
-import com.google.gson.JsonObject;
 import net.serenitybdd.core.webdriver.servicepools.DriverServiceExecutable;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.util.EnvironmentVariables;
@@ -10,7 +8,6 @@ import net.thucydides.core.webdriver.capabilities.ChromePreferences;
 import net.thucydides.core.webdriver.chrome.OptionsSplitter;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.PageLoadStrategy;
-import org.openqa.selenium.Proxy;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -42,11 +39,7 @@ public class ChromeDriverCapabilities implements DriverCapabilitiesProvider {
 
     @Override
     public DesiredCapabilities getCapabilities() {
-        DesiredCapabilities capabilities = DesiredCapabilities.chrome();
-
-        ChromeOptions chromeOptions = configuredOptions();
-
-        capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+        DesiredCapabilities capabilities = new DesiredCapabilities(configuredOptions());
 
         String chromeSwitches = ThucydidesSystemProperty.CHROME_SWITCHES.from(environmentVariables);
         capabilities.setCapability("chrome.switches", chromeSwitches);

--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/DriverCapabilities.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/DriverCapabilities.java
@@ -11,6 +11,7 @@ import net.thucydides.core.webdriver.CapabilityEnhancer;
 import net.thucydides.core.webdriver.SupportedWebDriver;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Platform;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.Map;
@@ -74,7 +75,7 @@ public class DriverCapabilities {
         selectors.put(HTMLUNIT, DesiredCapabilities::htmlUnit);
         selectors.put(OPERA, DesiredCapabilities::operaBlink);
         selectors.put(IEXPLORER, DesiredCapabilities::internetExplorer);
-        selectors.put(EDGE, DesiredCapabilities::edge);
+        selectors.put(EDGE, () -> new DesiredCapabilities(new EdgeOptions()));
         selectors.put(PHANTOMJS, DesiredCapabilities::phantomjs);
         selectors.put(IPHONE, DesiredCapabilities::iphone);
         selectors.put(ANDROID, DesiredCapabilities::android);

--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/EdgeDriverProvider.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/EdgeDriverProvider.java
@@ -12,6 +12,7 @@ import net.thucydides.core.webdriver.SupportedWebDriver;
 import net.thucydides.core.webdriver.stubs.WebDriverStub;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,10 @@ public class EdgeDriverProvider implements DriverProvider {
         }
 
         CapabilityEnhancer enhancer = new CapabilityEnhancer(environmentVariables, fixtureProviderService);
-        DesiredCapabilities desiredCapabilities = enhancer.enhanced(DesiredCapabilities.edge(), SupportedWebDriver.EDGE);
+        DesiredCapabilities desiredCapabilities = enhancer.enhanced(
+            new DesiredCapabilities(new EdgeOptions()),
+            SupportedWebDriver.EDGE);
+
         driverProperties.registerCapabilities("edge", capabilitiesToProperties(desiredCapabilities));
 
         SetProxyConfiguration.from(environmentVariables).in(desiredCapabilities);

--- a/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/FirefoxDriverCapabilities.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/webdriver/driverproviders/FirefoxDriverCapabilities.java
@@ -10,10 +10,9 @@ import net.thucydides.core.steps.FilePathParser;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.webdriver.firefox.FirefoxProfileEnhancer;
 import org.apache.commons.lang3.StringUtils;
-import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.UnexpectedAlertBehaviour;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.firefox.internal.ProfilesIni;
 import org.openqa.selenium.remote.CapabilityType;
@@ -46,8 +45,11 @@ public class FirefoxDriverCapabilities implements DriverCapabilitiesProvider {
     }
 
     public DesiredCapabilities getCapabilities() {
-        DesiredCapabilities capabilities = DesiredCapabilities.firefox();
-        capabilities.setCapability("firefox_profile",buildFirefoxProfile());
+        DesiredCapabilities capabilities = new DesiredCapabilities(new FirefoxOptions());
+
+        capabilities.setCapability("firefox_profile", buildFirefoxProfile());
+        capabilities.acceptInsecureCerts();
+
         Map<String, Object> firefoxOptions = new HashMap<>();
         String geckoOptions = (!options.isEmpty()) ? options : ThucydidesSystemProperty.GECKO_FIREFOX_OPTIONS.from(environmentVariables,"");
         if (!geckoOptions.isEmpty()) {

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/CapabilityEnhancer.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/CapabilityEnhancer.java
@@ -1,6 +1,5 @@
 package net.thucydides.core.webdriver;
 
-import net.serenitybdd.core.webdriver.OverrideDriverCapabilities;
 import net.serenitybdd.core.webdriver.driverproviders.AddCustomDriverCapabilities;
 import net.serenitybdd.core.webdriver.driverproviders.AddEnvironmentSpecifiedDriverCapabilities;
 import net.thucydides.core.fixtureservices.FixtureProviderService;
@@ -29,7 +28,7 @@ public class CapabilityEnhancer {
 
     public DesiredCapabilities enhanced(DesiredCapabilities capabilities, SupportedWebDriver driver) {
         CapabilitySet capabilitySet = new CapabilitySet(environmentVariables);
-        addExtraCapabiities(capabilities, capabilitySet);
+        addExtraCapabilities(capabilities, capabilitySet);
         if (ACCEPT_INSECURE_CERTIFICATES.booleanFrom(environmentVariables,false)) {
             capabilities.acceptInsecureCerts();
         }
@@ -41,19 +40,18 @@ public class CapabilityEnhancer {
             Optional<TestOutcome> currentTestOutcome = StepEventBus.getEventBus()
                                                          .getBaseStepListener()
                                                          .latestTestOutcome();
-            if (currentTestOutcome != null) { // Technically not required but needed for some test scenarios
-                currentTestOutcome.ifPresent(
-                        outcome -> AddCustomDriverCapabilities.from(environmentVariables)
-                                .withTestDetails(driver, outcome)
-                                .to(capabilities)
-                );
-            }
+             // Technically not required but needed for some test scenarios
+            currentTestOutcome.ifPresent(
+                    outcome -> AddCustomDriverCapabilities.from(environmentVariables)
+                            .withTestDetails(driver, outcome)
+                            .to(capabilities)
+            );
         }
 
         return capabilities;
     }
 
-    private void addExtraCapabiities(DesiredCapabilities capabilities, CapabilitySet capabilitySet) {
+    private void addExtraCapabilities(DesiredCapabilities capabilities, CapabilitySet capabilitySet) {
         Map<String, Object> extraCapabilities = capabilitySet.getCapabilities();
         for(String capabilityName : extraCapabilities.keySet()) {
             capabilities.setCapability(capabilityName, extraCapabilities.get(capabilityName));


### PR DESCRIPTION
As of Selenium 4.0 the DesiredCapabilities browser factory methods are deprecated.

This commit only removes the calls from the `main` source.
I have not yet checked the amount of work to refactor the tests.

One thing that draw my attention was the fact Edge doesn't have a `DriverCapabilitiesProvider`, but as I'm not aware of its need I left it the way it is, please let me know if it should be addressed as well!

More context: https://github.com/SeleniumHQ/selenium/commit/e615772723158a74003bc8ea57f87880b8cccb21