### PR TITLE
feat: Accept multiple custom filters in request

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationDecorated.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationDecorated.java
@@ -338,6 +338,17 @@ public abstract class RequestSpecificationDecorated
         return this;
     }
 
+    /**
+     * Add list of filters that will be used in the request
+     * @param filters Filter list to add
+     * @return the decorated request specification
+     */
+    @Override
+    public RequestSpecification filters(final List<Filter> filters) {
+        core.filters(filters);
+        return this;
+    }
+
     @Override
     public List<Filter> getDefinedFilters() {
         return core.getDefinedFilters();


### PR DESCRIPTION
If there are multiple custom filters in the request, then serenity report is missing the REST query.
```
given()
  .baseUri("http://…")
  .filters(Arrays.asList(new FirstFilter(), new SecondFilter()))
```
Support for a single filter is part of #1175, and this PR adds support for multiple filters