### PR TITLE
fix: WebElementFacade#waitUntilNotVisible returns immediately if the element is currently not visible

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
@@ -1093,7 +1093,7 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
             return this;
         }
 
-        if (!withTimeoutOf(Duration.ofMillis(0)).isVisible()) {
+        if (!isCurrentlyVisible()) {
             return this;
         }
 


### PR DESCRIPTION
`net.serenitybdd.core.pages.WebElementFacadeImpl#waitUntilNotVisible` contains a guard to return if the element is not present: `withTimeoutOf(Duration.ofMillis(0)).isVisible()`. But although the timeout is set to `0` this method will not return immediately like `WebElementFacadeImpl#isCurrentlyVisible`. 

The difference here is that `SmartAjaxElementLocator#findElement` will take a moment (depending on the configured implicit timeout) because it will use `SmartAjaxElementLocator#ajaxFindElement` (while `isCurrentlyVisible` will use `SmartAjaxElementLocator#findElementImmediately`).

```
findElement:113, SmartAjaxElementLocator (net.thucydides.core.annotations.locators)
resolveForDriver:30, WebElementResolverByElementLocator (net.serenitybdd.core.pages)
getResolvedELement:235, WebElementFacadeImpl (net.serenitybdd.core.pages)
getElement:230, WebElementFacadeImpl (net.serenitybdd.core.pages)
isVisible:450, WebElementFacadeImpl (net.serenitybdd.core.pages)
waitUntilNotVisible:1096, WebElementFacadeImpl (net.serenitybdd.core.pages)
```