### PR TITLE
[Fix] Formatter does not support empty tags

### DIFF
--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
@@ -167,7 +167,7 @@ public class Formatter {
         Matcher matchingTag = SIMPLE_HTML_TAG.matcher(text);
         while (matchingTag.find()) {
             String tag = matchingTag.group(0);
-            String htmlCompatibleTag = "&lt;" + tag.substring(1, tag.length() - 2) + "&gt;";
+            String htmlCompatibleTag = "&lt;" + tag.substring(1, tag.length() - 1) + "&gt;";
             matchingTag.appendReplacement(renderedTitle, htmlCompatibleTag);
         }
         matchingTag.appendTail(renderedTitle);


### PR DESCRIPTION
Trying to migrate from v2.0.90 to a newer version (even 2.0.91), our tests fail on an obscure exception which makes Serenity explode (unable to run everything and report corrupted). The stack leads to this `substring()` call, which indeed seems erroneous when considering its documentation and the parsed regex.

I don't know Gradle and its import goes bad in my Eclipse, and testing seems rather superficial on that class, or at least not obvious to me, so I didn't spend much time and here is a tentative fix.

Context:
- `SIMPLE_HTML_TAG` accepts `"<>"`
- `String.substring()` already substracts 1 to the end index

Problem:
- The current code seems to ignore the last point
- `"<>".substring(1, tag.length() - 2)` = `"<>".substring(1, 0)` = exception because asking an impossible substring

Solution:
- `"<>".substring(1, tag.length() - 1)` = `"<>".substring(1, 1)` = `""`