### PR TITLE
rest-assured 3.3.0 -> 4.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,7 @@ org.gradle.parallel=false
 
 seleniumVersion = 3.141.59
 
-#groovyVersion = 2.4.16
-groovyVersion = 3.0.2
+groovyVersion = 2.5.13
 gradleVersion = 5.6.2
 
 junitVersion = 4.12
@@ -14,7 +13,7 @@ springVersion = 5.1.2.RELEASE
 springBootVersion = 2.1.0.RELEASE
 guavaVersion = 25.0-jre
 okioVersion=1.14.1
-restAssuredVersion = 4.3.0
+restAssuredVersion = 4.2.0
 #mockitoCoreVersion = 2.25.0
 mockitoCoreVersion = 3.1.0
 jbehaveCoreVersion = 4.3.1
@@ -62,7 +61,7 @@ vavrVersion = 0.9.0
 browsermobVersion=2.1.5
 jettyVersion = 9.4.8.v20171121
 #antVersion = 1.9.6
-antVersion = 1.9.13
+antVersion = 1.9.15
 #antVersion = 1.10.7
 bouncycastleVersion = 1.58
 nettyVersion= 4.0.33.Final
@@ -94,7 +93,6 @@ spockExtensionsVersion = 0.1.4
 assertjVersion = 3.12.2
 jsonassertVersion = 1.5.0
 jbehaveVersion = 4.0.5
-junit5.version = 5.0.0
 
 # Bintray configuration
 
@@ -103,8 +101,7 @@ bintrayRepository = maven
 bintrayPackage = serenity-core
 projectDescription = Serenity Core
 
-#junit5_version = 5.1.0
-junit5_version = 5.3.2
+junit5_version = 5.4.2
 
 kotlin.incremental=true
 thymeleafVersion=3.0.11.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.parallel=false
 seleniumVersion = 3.141.59
 
 #groovyVersion = 2.4.16
-groovyVersion = 2.5.5
+groovyVersion = 3.0.2
 gradleVersion = 5.6.2
 
 junitVersion = 4.12
@@ -14,7 +14,7 @@ springVersion = 5.1.2.RELEASE
 springBootVersion = 2.1.0.RELEASE
 guavaVersion = 25.0-jre
 okioVersion=1.14.1
-restAssuredVersion = 3.3.0
+restAssuredVersion = 4.3.0
 #mockitoCoreVersion = 2.25.0
 mockitoCoreVersion = 3.1.0
 jbehaveCoreVersion = 4.3.1

--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -230,6 +230,7 @@ dependencies {
 
     compile ("com.vladsch.flexmark:flexmark-all:0.34.30") {
         exclude group:"org.jsoup", module:"jsoup"
+        exclude group:"junit", module:"junit"
     }
 
     compile("io.github.bonigarcia:webdrivermanager:${webdrivermanagerVersion}") {

--- a/serenity-model/build.gradle
+++ b/serenity-model/build.gradle
@@ -57,7 +57,9 @@ dependencies {
 
     compile ("com.vladsch.flexmark:flexmark-all:0.34.30") {
         exclude group:"org.jsoup", module:"jsoup"
+        exclude group:"junit", module:"junit"
     }
+    compile "junit:junit:${junitVersion}"
     compile 'es.nitaur.markdown:txtmark:0.16'
 
     compileOnly "org.junit.jupiter:junit-jupiter-api:${junit5_version}"

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
@@ -2,8 +2,13 @@ package net.serenitybdd.rest;
 
 import com.google.common.base.Preconditions;
 import io.restassured.RestAssured;
-import io.restassured.authentication.*;
+import io.restassured.authentication.AuthenticationScheme;
+import io.restassured.authentication.CertificateAuthSettings;
+import io.restassured.authentication.FormAuthConfig;
+import io.restassured.authentication.OAuthSignature;
+import io.restassured.authentication.PreemptiveAuthProvider;
 import io.restassured.config.LogConfig;
+import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SSLConfig;
 import io.restassured.filter.Filter;
@@ -16,18 +21,17 @@ import io.restassured.mapper.ObjectMapper;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import io.restassured.specification.*;
+import io.restassured.specification.Argument;
+import io.restassured.specification.ProxySpecification;
+import io.restassured.specification.RequestSender;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
 import net.serenitybdd.rest.decorators.ResponseSpecificationDecorated;
 import net.serenitybdd.rest.decorators.request.RequestSpecificationDecorated;
 import net.serenitybdd.rest.utils.RestDecorationHelper;
 import net.serenitybdd.rest.utils.RestSpecificationFactory;
-import net.thucydides.core.steps.BaseStepListener;
-import net.thucydides.core.steps.ExecutedStepDescription;
-import net.thucydides.core.steps.StepEventBus;
-import net.thucydides.core.steps.StepFailure;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -35,7 +39,6 @@ import java.security.KeyStore;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import static io.restassured.specification.ProxySpecification.host;
 
@@ -179,7 +182,7 @@ public class SerenityRest {
     }
 
     public static ObjectMapper objectMapper(final ObjectMapper objectMapper) {
-        RestAssured.objectMapper(objectMapper);
+        config().objectMapperConfig(ObjectMapperConfig.objectMapperConfig().defaultObjectMapper(objectMapper));
         return config().getObjectMapperConfig().defaultObjectMapper();
     }
 
@@ -192,11 +195,11 @@ public class SerenityRest {
     }
 
     public static List<Argument> withArguments(final Object firstArgument, final Object... additionalArguments) {
-        return RestAssured.withArguments(firstArgument, additionalArguments);
+        return RestAssured.withArgs(firstArgument, additionalArguments);
     }
 
     public static List<Argument> withNoArguments() {
-        return RestAssured.withNoArguments();
+        return RestAssured.withNoArgs();
     }
 
     public static List<Argument> withArgs(final Object firstArgument, final Object... additionalArguments) {

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/SerenityRest.java
@@ -182,7 +182,8 @@ public class SerenityRest {
     }
 
     public static ObjectMapper objectMapper(final ObjectMapper objectMapper) {
-        config().objectMapperConfig(ObjectMapperConfig.objectMapperConfig().defaultObjectMapper(objectMapper));
+        RestAssured.config = config().objectMapperConfig(ObjectMapperConfig.objectMapperConfig()
+                .defaultObjectMapper(objectMapper));
         return config().getObjectMapperConfig().defaultObjectMapper();
     }
 

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/ResponseSpecificationDecorated.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/ResponseSpecificationDecorated.java
@@ -1,6 +1,7 @@
 package net.serenitybdd.rest.decorators;
 
 import io.restassured.config.RestAssuredConfig;
+import io.restassured.filter.log.LogDetail;
 import io.restassured.internal.ResponseParserRegistrar;
 import io.restassured.internal.ResponseSpecificationImpl;
 import io.restassured.response.Response;
@@ -25,7 +26,7 @@ public abstract class ResponseSpecificationDecorated implements FilterableRespon
 
     public ResponseSpecificationDecorated(final ResponseSpecificationImpl core) {
         this.core = core;
-        this.helper = new ReflectionHelper<ResponseSpecificationImpl>(core);
+        this.helper = new ReflectionHelper<>(core);
     }
 
     @Override
@@ -163,4 +164,13 @@ public abstract class ResponseSpecificationDecorated implements FilterableRespon
         return core.getConfig();
     }
 
+    @Override
+    public LogDetail getLogDetail() {
+        return core.getLogDetail();
+    }
+
+    @Override
+    public ResponseSpecification statusCode(final int expectedStatusCode) {
+        return core.statusCode(expectedStatusCode);
+    }
 }

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationBodyConfigurations.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationBodyConfigurations.java
@@ -3,8 +3,8 @@ package net.serenitybdd.rest.decorators.request;
 import com.google.common.base.Preconditions;
 import io.restassured.http.ContentType;
 import io.restassured.internal.RequestSpecificationImpl;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.mapper.ObjectMapper;
+import io.restassured.mapper.ObjectMapperType;
 import io.restassured.specification.FilterableRequestSpecification;
 import io.restassured.specification.RequestSpecification;
 import org.slf4j.Logger;
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.InputStream;
 
-import static net.serenitybdd.rest.HeaderNames.*;
+import static net.serenitybdd.rest.HeaderNames.CONTENT_TYPE;
 
 
 abstract class RequestSpecificationBodyConfigurations extends RequestSpecificationHeaderConfigurations
@@ -72,46 +72,6 @@ abstract class RequestSpecificationBodyConfigurations extends RequestSpecificati
     public RequestSpecification body(InputStream body) {
         core.body(body);
         return this;
-    }
-
-    @Override
-    public RequestSpecification content(String content) {
-        core.content(content);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(byte[] content) {
-        core.content(content);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(File content) {
-        core.content(content);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(InputStream content) {
-        core.content(content);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(Object object) {
-        core.content(object);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(Object object, ObjectMapperType mapperType) {
-        return body(object, mapperType);
-    }
-
-    @Override
-    public RequestSpecification content(Object object, ObjectMapper mapper) {
-        return body(object, mapper);
     }
 
     @Override

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationConfigurable.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationConfigurable.java
@@ -3,7 +3,8 @@ package net.serenitybdd.rest.decorators.request;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.config.SessionConfig;
 import io.restassured.internal.RequestSpecificationImpl;
-import io.restassured.specification.*;
+import io.restassured.specification.FilterableRequestSpecification;
+import io.restassured.specification.RequestSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,12 +76,6 @@ abstract class RequestSpecificationConfigurable extends RequestSpecificationInit
     @Override
     public RequestSpecification spec(final RequestSpecification requestSpecificationToMerge) {
         core.spec(requestSpecificationToMerge);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification specification(final RequestSpecification requestSpecificationToMerge) {
-        core.specification(requestSpecificationToMerge);
         return this;
     }
 }

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationDecorated.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationDecorated.java
@@ -91,7 +91,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response get(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return get(path);
     }
 
@@ -117,7 +117,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response post(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return post(path);
     }
 
@@ -148,7 +148,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response put(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return put(path);
     }
 
@@ -174,7 +174,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response delete(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return delete(path);
     }
 
@@ -200,7 +200,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response head(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return head(path);
     }
 
@@ -226,7 +226,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response patch(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return patch(path);
     }
 
@@ -242,7 +242,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public Response options(String path, Map<String, ?> pathParams) {
-        pathParameters(pathParams);
+        pathParams(pathParams);
         return options(path);
     }
 
@@ -441,7 +441,7 @@ public abstract class RequestSpecificationDecorated
 
     @Override
     public <T> T getBody() {
-        return core.getBody();
+        return (T) core.getBody();
     }
 
     @Override

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationLoggable.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationLoggable.java
@@ -9,6 +9,8 @@ import net.serenitybdd.rest.utils.ReflectionHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+
 /**
  * User: YamStranger
  * Date: 3/16/16
@@ -25,6 +27,7 @@ abstract class RequestSpecificationLoggable extends RequestSpecificationRedirect
     @Override
     public RequestLogSpecification log() {
         final RequestLogSpecificationImpl specification = new RequestLogSpecificationImpl();
+        specification.setBlacklistedHeaders(Collections.emptySet());
         final ReflectionHelper<RequestLogSpecificationImpl> logHelper = new ReflectionHelper<>(specification);
         try {
             logHelper.setValueTo("requestSpecification", this);

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationParametersConfigurations.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationParametersConfigurations.java
@@ -22,29 +22,6 @@ abstract class RequestSpecificationParametersConfigurations extends RequestSpeci
         super(core);
     }
 
-    @Override
-    public RequestSpecification parameters(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
-        core.parameters(firstParameterName, firstParameterValue, parameterNameValuePairs);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification parameters(Map<String, ?> parametersMap) {
-        core.parameters(parametersMap);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification parameter(String parameterName, Object... parameterValues) {
-        core.parameter(parameterName, parameterValues);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification parameter(String parameterName, Collection<?> parameterValues) {
-        core.parameter(parameterName, parameterValues);
-        return this;
-    }
 
     @Override
     public RequestSpecification params(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
@@ -66,32 +43,8 @@ abstract class RequestSpecificationParametersConfigurations extends RequestSpeci
 
     @Override
     public RequestSpecification param(String parameterName, Collection<?> parameterValues) {
-        return parameters(parameterName, parameterValues);
-    }
-
-    @Override
-    public RequestSpecification queryParameters(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
-        core.queryParameters(firstParameterName, firstParameterValue, parameterNameValuePairs);
+        core.param(parameterName, parameterValues);
         return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameters(Map<String, ?> parametersMap) {
-        core.queryParameters(parametersMap);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameter(String parameterName, Object... parameterValues) {
-        core.queryParameter(parameterName, parameterValues);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameter(String parameterName, Collection<?> parameterValues) {
-        core.queryParameter(parameterName, parameterValues);
-        return this;
-
     }
 
     @Override
@@ -119,30 +72,6 @@ abstract class RequestSpecificationParametersConfigurations extends RequestSpeci
     }
 
     @Override
-    public RequestSpecification formParameters(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
-        core.formParameters(firstParameterName, firstParameterValue, parameterNameValuePairs);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification formParameters(Map<String, ?> parametersMap) {
-        core.formParameters(parametersMap);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification formParameter(String parameterName, Object... parameterValues) {
-        core.formParameter(parameterName, parameterValues);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification formParameter(String parameterName, Collection<?> parameterValues) {
-        core.formParameter(parameterName, parameterValues);
-        return this;
-    }
-
-    @Override
     public RequestSpecification formParams(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
         core.formParams(firstParameterName, firstParameterValue, parameterNameValuePairs);
         return this;
@@ -162,24 +91,7 @@ abstract class RequestSpecificationParametersConfigurations extends RequestSpeci
 
     @Override
     public RequestSpecification formParam(String parameterName, Collection<?> parameterValues) {
-        return formParameter(parameterName, parameterValues);
-    }
-
-    @Override
-    public RequestSpecification pathParameter(String parameterName, Object parameterValue) {
-        core.pathParameter(parameterName, parameterValue);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification pathParameters(String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
-        core.pathParameters(firstParameterName, firstParameterValue, parameterNameValuePairs);
-        return this;
-    }
-
-    @Override
-    public RequestSpecification pathParameters(Map<String, ?> parameterNameValuePairs) {
-        core.pathParameters(parameterNameValuePairs);
+        core.formParam(parameterName, parameterValues);
         return this;
     }
 

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationSecurityConfigurations.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/decorators/request/RequestSpecificationSecurityConfigurations.java
@@ -63,7 +63,6 @@ abstract class RequestSpecificationSecurityConfigurations extends RequestSpecifi
         return this;
     }
 
-    @Override
     public AuthenticationSpecification authentication() {
         return new AuthenticationSpecificationImpl(this);
     }

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/RequestSpecificationStub.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/RequestSpecificationStub.java
@@ -2,12 +2,22 @@ package net.serenitybdd.rest.stubs;
 
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.filter.Filter;
-import io.restassured.http.*;
+import io.restassured.http.ContentType;
+import io.restassured.http.Cookie;
+import io.restassured.http.Cookies;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.http.Method;
 import io.restassured.internal.RequestLogSpecificationImpl;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.mapper.ObjectMapper;
-import io.restassured.response.*;
-import io.restassured.specification.*;
+import io.restassured.mapper.ObjectMapperType;
+import io.restassured.response.Response;
+import io.restassured.specification.AuthenticationSpecification;
+import io.restassured.specification.MultiPartSpecification;
+import io.restassured.specification.ProxySpecification;
+import io.restassured.specification.RequestLogSpecification;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
 
 import java.io.File;
 import java.io.InputStream;
@@ -55,41 +65,6 @@ public class RequestSpecificationStub implements RequestSpecification {
     }
 
     @Override
-    public RequestSpecification content(final String content) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(final byte[] content) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(final File content) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(final InputStream content) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(final Object object) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(final Object object, final ObjectMapperType mapperType) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification content(final Object object, final ObjectMapper mapper) {
-        return this;
-    }
-
-    @Override
     public RedirectSpecificationStub redirects() {
         return new RedirectSpecificationStub();
     }
@@ -127,27 +102,6 @@ public class RequestSpecificationStub implements RequestSpecification {
     }
 
     @Override
-    public RequestSpecification parameters(final String firstParameterName, final Object firstParameterValue,
-                                           final Object... parameterNameValuePairs) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification parameters(final Map<String, ?> parametersMap) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification parameter(final String parameterName, final Object... parameterValues) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification parameter(final String parameterName, final Collection<?> parameterValues) {
-        return this;
-    }
-
-    @Override
     public RequestSpecification params(final String firstParameterName, final Object firstParameterValue,
                                        final Object... parameterNameValuePairs) {
         return this;
@@ -165,27 +119,6 @@ public class RequestSpecificationStub implements RequestSpecification {
 
     @Override
     public RequestSpecification param(final String parameterName, final Collection<?> parameterValues) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameters(final String firstParameterName, final Object firstParameterValue,
-                                                final Object... parameterNameValuePairs) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameters(final Map<String, ?> parametersMap) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameter(final String parameterName, final Object... parameterValues) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification queryParameter(final String parameterName, final Collection<?> parameterValues) {
         return this;
     }
 
@@ -211,27 +144,6 @@ public class RequestSpecificationStub implements RequestSpecification {
     }
 
     @Override
-    public RequestSpecification formParameters(final String firstParameterName, final Object firstParameterValue,
-                                               final Object... parameterNameValuePairs) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification formParameters(final Map<String, ?> parametersMap) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification formParameter(final String parameterName, final Object... parameterValues) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification formParameter(final String parameterName, final Collection<?> parameterValues) {
-        return this;
-    }
-
-    @Override
     public RequestSpecification formParams(final String firstParameterName, final Object firstParameterValue,
                                            final Object... parameterNameValuePairs) {
         return this;
@@ -249,22 +161,6 @@ public class RequestSpecificationStub implements RequestSpecification {
 
     @Override
     public RequestSpecification formParam(final String parameterName, final Collection<?> parameterValues) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification pathParameter(final String parameterName, final Object parameterValue) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification pathParameters(final String firstParameterName, final Object firstParameterValue,
-                                               final Object... parameterNameValuePairs) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification pathParameters(final Map<String, ?> parameterNameValuePairs) {
         return this;
     }
 
@@ -444,11 +340,6 @@ public class RequestSpecificationStub implements RequestSpecification {
     }
 
     @Override
-    public AuthenticationSpecification authentication() {
-        return new AuthenticationSpecificationStub();
-    }
-
-    @Override
     public AuthenticationSpecification auth() {
         return new AuthenticationSpecificationStub();
     }
@@ -460,11 +351,6 @@ public class RequestSpecificationStub implements RequestSpecification {
 
     @Override
     public RequestSpecification spec(final RequestSpecification requestSpecificationToMerge) {
-        return this;
-    }
-
-    @Override
-    public RequestSpecification specification(final RequestSpecification requestSpecificationToMerge) {
         return this;
     }
 

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/ResponseSpecificationStub.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/ResponseSpecificationStub.java
@@ -1,41 +1,31 @@
 package net.serenitybdd.rest.stubs;
 
 import io.restassured.filter.log.LogDetail;
-import io.restassured.function.RestAssuredFunction;
 import io.restassured.http.ContentType;
 import io.restassured.matcher.DetailedCookieMatcher;
 import io.restassured.parsing.Parser;
 import io.restassured.response.Response;
-import io.restassured.specification.*;
+import io.restassured.specification.Argument;
+import io.restassured.specification.RequestSender;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseLogSpecification;
+import io.restassured.specification.ResponseSpecification;
 import org.apache.commons.lang3.NotImplementedException;
 import org.hamcrest.Matcher;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Created by john on 23/07/2015.
  */
 public class ResponseSpecificationStub implements ResponseSpecification {
-    @Override
-    public ResponseSpecification content(final Matcher<?> matcher, final Matcher<?>... additionalMatchers) {
-        return this;
-    }
-
-    @Override
-    public ResponseSpecification content(final List<Argument> arguments, final Matcher matcher, final Object... additionalKeyMatcherPairs) {
-        return this;
-    }
 
     @Override
     public Response validate(final Response response) {
         return new ResponseStub();
-    }
-
-    @Override
-    public ResponseSpecification content(final String key, final Matcher<?> matcher, final Object... additionalKeyMatcherPairs) {
-        return this;
     }
 
     @Override
@@ -94,7 +84,7 @@ public class ResponseSpecificationStub implements ResponseSpecification {
     }
 
     @Override
-    public <T> ResponseSpecification header(String s, RestAssuredFunction<String, T> restAssuredFunction, Matcher<? super T> matcher) {
+    public <T> ResponseSpecification header(String s, Function<String, T> restAssuredFunction, Matcher<? super T> matcher) {
         return this;
     }
 
@@ -164,12 +154,27 @@ public class ResponseSpecificationStub implements ResponseSpecification {
     }
 
     @Override
+    public ResponseSpecification appendRootPath(String pathToAppend) {
+        return this;
+    }
+
+    @Override
+    public ResponseSpecification appendRootPath(String pathToAppend, List<Argument> arguments) {
+        return this;
+    }
+
+    @Override
     public ResponseSpecification noRootPath() {
         return this;
     }
 
     @Override
     public ResponseSpecification appendRoot(final String pathToAppend) {
+        return this;
+    }
+
+    @Override
+    public ResponseSpecification detachRootPath(String pathToDetach) {
         return this;
     }
 
@@ -205,11 +210,6 @@ public class ResponseSpecificationStub implements ResponseSpecification {
 
     @Override
     public ResponseSpecification body(final String path, final Matcher<?> matcher, final Object... additionalKeyMatcherPairs) {
-        return this;
-    }
-
-    @Override
-    public ResponseSpecification content(final String path, final List<Argument> arguments, final Matcher matcher, final Object... additionalKeyMatcherPairs) {
         return this;
     }
 
@@ -260,11 +260,6 @@ public class ResponseSpecificationStub implements ResponseSpecification {
 
     @Override
     public ResponseSpecification spec(final ResponseSpecification responseSpecificationToMerge) {
-        return this;
-    }
-
-    @Override
-    public ResponseSpecification specification(final ResponseSpecification responseSpecificationToMerge) {
         return this;
     }
 

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/ResponseStub.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/ResponseStub.java
@@ -1,16 +1,18 @@
 package net.serenitybdd.rest.stubs;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.Cookie;
 import io.restassured.http.Cookies;
 import io.restassured.http.Headers;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.mapper.ObjectMapper;
-import io.restassured.mapper.TypeRef;
+import io.restassured.mapper.ObjectMapperType;
 import io.restassured.path.json.JsonPath;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.path.xml.XmlPath;
 import io.restassured.path.xml.config.XmlPathConfig;
-import io.restassured.response.*;
+import io.restassured.response.Response;
+import io.restassured.response.ResponseBody;
+import io.restassured.response.ValidatableResponse;
 import org.mockito.Mockito;
 
 import java.io.InputStream;

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/ValidatableResponseStub.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/stubs/ValidatableResponseStub.java
@@ -1,6 +1,5 @@
 package net.serenitybdd.rest.stubs;
 
-import io.restassured.function.RestAssuredFunction;
 import io.restassured.http.ContentType;
 import io.restassured.internal.RestAssuredResponseOptionsImpl;
 import io.restassured.internal.ValidatableResponseImpl;
@@ -18,30 +17,12 @@ import org.hamcrest.Matcher;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Created by john on 23/07/2015.
  */
 public class ValidatableResponseStub implements ValidatableResponse {
-    @Override
-    public ValidatableResponse content(Matcher<?> matcher, Matcher<?>... additionalMatchers) {
-        return this;
-    }
-
-    @Override
-    public ValidatableResponse content(List<Argument> arguments, Matcher matcher, Object... additionalKeyMatcherPairs) {
-        return this;
-    }
-
-    @Override
-    public ValidatableResponse content(List<Argument> arguments, ResponseAwareMatcher<Response> responseAwareMatcher) {
-        return this;
-    }
-
-    @Override
-    public ValidatableResponse content(String key, Matcher<?> matcher, Object... additionalKeyMatcherPairs) {
-        return this;
-    }
 
     @Override
     public ValidatableResponse body(String path, List<Argument> arguments, Matcher matcher, Object... additionalKeyMatcherPairs) {
@@ -99,7 +80,7 @@ public class ValidatableResponseStub implements ValidatableResponse {
     }
 
     @Override
-    public <V> ValidatableResponse header(String s, RestAssuredFunction<String, V> restAssuredFunction, Matcher<? super V> matcher) {
+    public <V> ValidatableResponse header(String s, Function<String, V> restAssuredFunction, Matcher<? super V> matcher) {
         return this;
     }
 
@@ -169,12 +150,27 @@ public class ValidatableResponseStub implements ValidatableResponse {
     }
 
     @Override
+    public ValidatableResponse appendRootPath(String pathToAppend) {
+        return this;
+    }
+
+    @Override
     public ValidatableResponse appendRoot(String pathToAppend) {
         return this;
     }
 
     @Override
+    public ValidatableResponse appendRootPath(String pathToAppend, List<Argument> arguments) {
+        return this;
+    }
+
+    @Override
     public ValidatableResponse appendRoot(String pathToAppend, List<Argument> arguments) {
+        return this;
+    }
+
+    @Override
+    public ValidatableResponse detachRootPath(String pathToDetach) {
         return this;
     }
 
@@ -219,21 +215,6 @@ public class ValidatableResponseStub implements ValidatableResponse {
     }
 
     @Override
-    public ValidatableResponse content(String path, List<Argument> arguments, Matcher matcher, Object... additionalKeyMatcherPairs) {
-        return this;
-    }
-
-    @Override
-    public ValidatableResponse content(String path, List<Argument> arguments, ResponseAwareMatcher<Response> responseAwareMatcher) {
-        return this;
-    }
-
-    @Override
-    public ValidatableResponse content(String path, ResponseAwareMatcher<Response> responseAwareMatcher) {
-        return this;
-    }
-
-    @Override
     public ValidatableResponse and() {
         return this;
     }
@@ -250,11 +231,6 @@ public class ValidatableResponseStub implements ValidatableResponse {
 
     @Override
     public ValidatableResponse spec(ResponseSpecification responseSpecificationToMerge) {
-        return this;
-    }
-
-    @Override
-    public ValidatableResponse specification(ResponseSpecification responseSpecificationToMerge) {
         return this;
     }
 

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestReportingHelper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestReportingHelper.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.ObjectUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static net.thucydides.core.steps.StepEventBus.getEventBus;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
@@ -65,7 +66,8 @@ public class RestReportingHelper {
                              final RequestSpecificationDecorated spec,
                              final String path, final Object... params) {
         RestQuery restQuery = recordRestSpecificationData(method, spec, path, params);
-        final RestResponseRecordingHelper helper = new RestResponseRecordingHelper(true,
+        Set<String> blackListedHeaders = spec.getConfig().getLogConfig().blacklistedHeaders();
+        final RestResponseRecordingHelper helper = new RestResponseRecordingHelper(true, blackListedHeaders,
                 LogDetail.HEADERS, LogDetail.COOKIES);
         final Map<LogDetail, String> values = helper.print(response);
         if (shouldRecordResponseBodyFor(response)) {

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestResponseRecordingHelper.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestResponseRecordingHelper.java
@@ -9,7 +9,12 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * User: YamStranger
@@ -19,8 +24,10 @@ import java.util.*;
 public class RestResponseRecordingHelper {
     private final List<LogDetail> logDetail;
     private final boolean shouldPrettyPrint;
+    private Set<String> blackListedHeaders;
 
-    public RestResponseRecordingHelper(final boolean shouldPrettyPrint, final LogDetail... details) {
+    public RestResponseRecordingHelper(final boolean shouldPrettyPrint, final Set<String> blackListedHeaders, final LogDetail... details) {
+        this.blackListedHeaders = blackListedHeaders;
         this.logDetail = new LinkedList<>();
         this.logDetail.addAll(Arrays.asList(details));
         this.shouldPrettyPrint = shouldPrettyPrint;
@@ -33,7 +40,7 @@ public class RestResponseRecordingHelper {
                  PrintStream recordingStream = new PrintStream(output, true, StandardCharsets.UTF_8.toString())) {
                 for (final LogDetail detail : logDetail) {
                     try {
-                        ResponsePrinter.print(response, response.getBody(), recordingStream, detail, shouldPrettyPrint);
+                        ResponsePrinter.print(response, response.getBody(), recordingStream, detail, shouldPrettyPrint, blackListedHeaders);
                     } catch (NullPointerException e) {
                         //can be thrown if some field like cookies or headers are empty
                     }

--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestSpecificationFactory.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/utils/RestSpecificationFactory.java
@@ -5,7 +5,11 @@ import io.restassured.filter.log.LogDetail;
 import io.restassured.internal.RequestSpecificationImpl;
 import io.restassured.internal.ResponseSpecificationImpl;
 import io.restassured.internal.filter.SendRequestFilter;
-import io.restassured.specification.*;
+import io.restassured.specification.FilterableRequestSpecification;
+import io.restassured.specification.FilterableResponseSpecification;
+import io.restassured.specification.RequestSenderOptions;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import net.bytebuddy.implementation.MethodCall;
@@ -23,8 +27,14 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
-import static io.restassured.filter.log.LogDetail.*;
+import static io.restassured.filter.log.LogDetail.BODY;
+import static io.restassured.filter.log.LogDetail.COOKIES;
+import static io.restassured.filter.log.LogDetail.HEADERS;
+import static io.restassured.filter.log.LogDetail.METHOD;
+import static io.restassured.filter.log.LogDetail.PARAMS;
+import static io.restassured.filter.log.LogDetail.URI;
 import static net.bytebuddy.matcher.ElementMatchers.isDeclaredBy;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 
 
 public class RestSpecificationFactory {
@@ -48,7 +58,8 @@ public class RestSpecificationFactory {
                 .getLoaded();
         Class<?> responseSpecificationDecoratedClass = byteBuddy
                 .subclass(ResponseSpecificationDecorated.class)
-                .method(isDeclaredBy(ResponseSpecification.class).or(isDeclaredBy(RequestSenderOptions.class)).or(isDeclaredBy(FilterableResponseSpecification.class)))
+                .method(named("then").and(isDeclaredBy(ResponseSpecification.class).or(isDeclaredBy(RequestSenderOptions.class))
+                        .or(isDeclaredBy(FilterableResponseSpecification.class))))
                 .intercept(MethodDelegation.toField("core"))
                 .make()
                 .load(SerenityRest.class.getClassLoader(),ClassLoadingStrategy.Default.INJECTION)

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenExecutingWrappedMethods.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenExecutingWrappedMethods.groovy
@@ -12,8 +12,12 @@ import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Specification
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.matching
+import static com.github.tomakehurst.wiremock.client.WireMock.post
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import static net.serenitybdd.rest.SerenityRest.rest
-import static com.github.tomakehurst.wiremock.client.WireMock.*
 
 /**
  * User: YamStranger
@@ -52,7 +56,7 @@ class WhenExecutingWrappedMethods extends Specification {
                 .withHeader("Content-Type", "application/json")
                 .withBody(body)));
         when:
-            def result = rest().given().contentType("application/json").content(body).log().all()
+            def result = rest().given().contentType("application/json").body(body).log().all()
                 .post(url).then()
         then: "The JSON request should be recorded in the test steps"
             1 * test.firstListener().recordRestQuery(*_) >> { RestQuery query ->
@@ -82,7 +86,7 @@ class WhenExecutingWrappedMethods extends Specification {
                 .withHeader("Content-Type", "application/json")
                 .withBody(body)));
         when:
-            def result = rest().given().contentType("application/json").content(body).auth().none()
+            def result = rest().given().contentType("application/json").body(body).auth().none()
                 .post(url).then()
         then: "The JSON request should be recorded in the test steps"
             1 * test.firstListener().recordRestQuery(*_) >> { RestQuery query ->

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenRunningRestTestsThroughSerenity.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/WhenRunningRestTestsThroughSerenity.groovy
@@ -16,8 +16,21 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*
-import static net.serenitybdd.core.rest.RestMethod.*
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.delete
+import static com.github.tomakehurst.wiremock.client.WireMock.get
+import static com.github.tomakehurst.wiremock.client.WireMock.matching
+import static com.github.tomakehurst.wiremock.client.WireMock.patch
+import static com.github.tomakehurst.wiremock.client.WireMock.post
+import static com.github.tomakehurst.wiremock.client.WireMock.put
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import static net.serenitybdd.core.rest.RestMethod.DELETE
+import static net.serenitybdd.core.rest.RestMethod.GET
+import static net.serenitybdd.core.rest.RestMethod.PATCH
+import static net.serenitybdd.core.rest.RestMethod.POST
+import static net.serenitybdd.core.rest.RestMethod.PUT
 import static net.serenitybdd.rest.SerenityRest.rest
 import static net.serenitybdd.rest.SerenityRest.then
 
@@ -142,7 +155,7 @@ class WhenRunningRestTestsThroughSerenity extends Specification {
                 .withHeader("Content-Type", "application/json")
                 .withBody(body)));
         when:
-            def result = rest().given().contentType("application/json").content(body).post(url).then()
+            def result = rest().given().contentType("application/json").body(body).post(url).then()
         then: "The JSON request should be recorded in the test steps"
             1 * test.firstListener().recordRestQuery(*_) >> { RestQuery query ->
                 assert "$query" == "POST $url"
@@ -174,7 +187,7 @@ class WhenRunningRestTestsThroughSerenity extends Specification {
                 .withHeader("Content-Type", "application/json")
                 .withBody(body)));
         when:
-            def result = rest().given().contentType("application/json").content(body).patch(url).then()
+            def result = rest().given().contentType("application/json").body(body).patch(url).then()
         then: "The JSON request should be recorded in the test steps"
             1 * test.firstListener().recordRestQuery(*_) >> { RestQuery query ->
                 assert "$query" == "PATCH $url"
@@ -206,7 +219,7 @@ class WhenRunningRestTestsThroughSerenity extends Specification {
                 .withHeader("Content-Type", "application/json")
                 .withBody(body)));
         when:
-            def result = rest().given().contentType("application/json").content(body).put(url).then()
+            def result = rest().given().contentType("application/json").body(body).put(url).then()
         then: "The JSON request should be recorded in the test steps"
             1 * test.firstListener().recordRestQuery(*_) >> { RestQuery query ->
                 assert "$query" == "PUT $url"

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/configuring/WhenConfiguringDefaultParameters.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/configuring/WhenConfiguringDefaultParameters.groovy
@@ -33,10 +33,32 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import static com.github.tomakehurst.wiremock.client.WireMock.matching
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching
-
-import static net.serenitybdd.rest.SerenityRest.*
+import static net.serenitybdd.rest.SerenityRest.filters
+import static net.serenitybdd.rest.SerenityRest.getDefaultAuthentication
+import static net.serenitybdd.rest.SerenityRest.getDefaultBasePath
+import static net.serenitybdd.rest.SerenityRest.getDefaultConfig
+import static net.serenitybdd.rest.SerenityRest.getDefaultParser
+import static net.serenitybdd.rest.SerenityRest.getDefaultPort
 import static net.serenitybdd.rest.SerenityRest.getDefaultProxy
-import static net.serenitybdd.rest.SerenityRest.setDefaultResponseSpecification;
+import static net.serenitybdd.rest.SerenityRest.getDefaultResponseSpecification
+import static net.serenitybdd.rest.SerenityRest.getDefaultRootPath
+import static net.serenitybdd.rest.SerenityRest.getDefaultSessionId
+import static net.serenitybdd.rest.SerenityRest.given
+import static net.serenitybdd.rest.SerenityRest.isUrlEncodingEnabled
+import static net.serenitybdd.rest.SerenityRest.objectMapper
+import static net.serenitybdd.rest.SerenityRest.replaceFiltersWith
+import static net.serenitybdd.rest.SerenityRest.reset
+import static net.serenitybdd.rest.SerenityRest.setDefaultAuthentication
+import static net.serenitybdd.rest.SerenityRest.setDefaultBasePath
+import static net.serenitybdd.rest.SerenityRest.setDefaultConfig
+import static net.serenitybdd.rest.SerenityRest.setDefaultParser
+import static net.serenitybdd.rest.SerenityRest.setDefaultPort
+import static net.serenitybdd.rest.SerenityRest.setDefaultProxy
+import static net.serenitybdd.rest.SerenityRest.setDefaultRequestSpecification
+import static net.serenitybdd.rest.SerenityRest.setDefaultResponseSpecification
+import static net.serenitybdd.rest.SerenityRest.setDefaultRootPath
+import static net.serenitybdd.rest.SerenityRest.setDefaultSessionId
+import static net.serenitybdd.rest.SerenityRest.setUrlEncodingEnabled
 
 /**
  * User: YamStranger
@@ -396,7 +418,7 @@ class WhenConfiguringDefaultParameters extends Specification {
     }
 
     def "should be possible set default object mapper for all rest requests"(
-        final def ObjectMapper mapper
+        final ObjectMapper mapper
     ) {
         given: "rest assured default config updated"
             objectMapper(mapper)

--- a/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/requests/WhenExecutingPostRequest.groovy
+++ b/serenity-rest-assured/src/test/groovy/net/serenitybdd/rest/requests/WhenExecutingPostRequest.groovy
@@ -7,7 +7,6 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import io.restassured.RestAssured
-import io.restassured.internal.filter.FormAuthFilter
 import io.restassured.specification.RequestSender
 import io.restassured.specification.RequestSpecification
 import io.restassured.specification.ResponseSpecification
@@ -20,13 +19,15 @@ import net.thucydides.core.steps.BaseStepListener
 import org.junit.Rule
 import spock.lang.Specification
 
-import static com.github.tomakehurst.wiremock.client.WireMock.post
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import static net.serenitybdd.rest.SerenityRest.*
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import static com.github.tomakehurst.wiremock.client.WireMock.matching
+import static com.github.tomakehurst.wiremock.client.WireMock.post
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching
+import static net.serenitybdd.rest.SerenityRest.given
+import static net.serenitybdd.rest.SerenityRest.reset
+import static net.serenitybdd.rest.SerenityRest.when
 
 /**
  * User: YamStranger
@@ -232,7 +233,7 @@ class WhenExecutingPostRequest extends Specification {
                 .withHeader("Content-Type", "application/json")
                 .withBody(body)));
         when:
-            def result = given().contentType("application/json").content(body).post(url)
+            def result = given().contentType("application/json").body(body).post(url)
         then: "created response should be decorated"
             result instanceof ResponseDecorated
         and: "returned status should be correct"

--- a/serenity-smoketests/build.gradle
+++ b/serenity-smoketests/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
     compile 'org.slf4j:slf4j-simple:1.7.7'
     compile 'org.codehaus.groovy:groovy-all:2.4.11'
-    compile 'junit:junit:4.12'
+    compile "junit:junit:${junitVersion}"
     compile 'org.assertj:assertj-core:1.7.0'
     compile 'org.hamcrest:hamcrest-all:1.3'
 }

--- a/serenity-test-utils/build.gradle
+++ b/serenity-test-utils/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     compile("org.hamcrest:hamcrest-core:1.3")
     compile("xmlunit:xmlunit:1.6")
     compile("org.slf4j:slf4j-api:${slf4jVersion}")
-    testCompile("junit:junit:4.12")
+    testCompile("junit:junit:${junitVersion}")
 }


### PR DESCRIPTION
Relates to #2145
Continuation of https://github.com/serenity-bdd/serenity-core/pull/2147

Upgrade rest-assured to 4.2.0.

I know that the newest version is 4.3.1, but it requires more work to do, so let's do it step by step.