### PR TITLE
Upgrade to rest-assured 4.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ subprojects {
         /* Required for Java 9 and higher */
         compile "javax.xml.bind:jaxb-api:${jaxbApiVersion}"
         compile "com.sun.xml.bind:jaxb-core:${jaxbCoreVersion}"
-        compile "com.sun.xml.bind:jaxb-impl:${jaxbCoreVersion}"
+        compile "com.sun.xml.bind:jaxb-impl:${jaxbImplVersion}"
         compile "javax.activation:activation:${activationVersion}"
 
         testCompile("ch.qos.logback:logback-classic:${logbackVersion}") {
@@ -280,10 +280,11 @@ subprojects {
 
         testCompile("org.codehaus.groovy:groovy-all:${groovyVersion}") {
             exclude group: "org.junit.jupiter"
+            exclude group: "com.google.inject"
         }
         testCompile("org.spockframework:spock-core:${spockVersion}") {
-            exclude group: "junit"
             exclude group: "org.codehaus.groovy"
+            exclude group: "org.junit.platform"
 
         }
         testCompile "org.assertj:assertj-core:${assertjVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,17 +4,16 @@ org.gradle.parallel=false
 
 seleniumVersion = 3.141.59
 
-groovyVersion = 2.5.13
+groovyVersion = 3.0.5
 gradleVersion = 5.6.2
 
-junitVersion = 4.12
+junitVersion = 4.13
 hamcrestVersion = 1.3
 springVersion = 5.1.2.RELEASE
 springBootVersion = 2.1.0.RELEASE
 guavaVersion = 25.0-jre
 okioVersion=1.14.1
-restAssuredVersion = 4.2.0
-#mockitoCoreVersion = 2.25.0
+restAssuredVersion = 4.3.1
 mockitoCoreVersion = 3.1.0
 jbehaveCoreVersion = 4.3.1
 commonsIoVersion = 2.6
@@ -60,9 +59,7 @@ slf4jVersion = 1.7.26
 vavrVersion = 0.9.0
 browsermobVersion=2.1.5
 jettyVersion = 9.4.8.v20171121
-#antVersion = 1.9.6
-antVersion = 1.9.15
-#antVersion = 1.10.7
+antVersion = 1.10.8
 bouncycastleVersion = 1.58
 nettyVersion= 4.0.33.Final
 commonsText = 1.2
@@ -81,18 +78,17 @@ webdrivermanagerVersion = 4.2.0
 shutterBugVersion=0.9.3
 
 # Scheduled for updates
-#byteBuddyVersion = 1.8.15
-#byteBuddyVersion = 1.9.12
 byteBuddyVersion = 1.10.1
-#guiceVersion = 4.2.0
 guiceVersion = 4.2.2
 
 # Test-scope dependencies
-spockVersion = 1.2-groovy-2.5
+spockVersion = 2.0-M3-groovy-3.0
 spockExtensionsVersion = 0.1.4
 assertjVersion = 3.12.2
 jsonassertVersion = 1.5.0
 jbehaveVersion = 4.0.5
+junit5Version = 5.6.2
+opentest4jVersion = 1.2.0
 
 # Bintray configuration
 
@@ -101,11 +97,10 @@ bintrayRepository = maven
 bintrayPackage = serenity-core
 projectDescription = Serenity Core
 
-junit5_version = 5.4.2
-
 kotlin.incremental=true
 thymeleafVersion=3.0.11.RELEASE
 xchartVersion=3.5.2
 jaxbApiVersion=2.2.12
 jaxbCoreVersion=2.3.0.1
+jaxbImplVersion=2.3.3
 activationVersion=1.1.1

--- a/serenity-asciidoc/build.gradle
+++ b/serenity-asciidoc/build.gradle
@@ -38,10 +38,10 @@ dependencies {
 
     // JUnit 5
     testImplementation(
-            "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     )
     testRuntimeOnly(
-            "org.junit.jupiter:junit-jupiter-engine:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     )
 }
 repositories {

--- a/serenity-browsermob-plugin/build.gradle
+++ b/serenity-browsermob-plugin/build.gradle
@@ -22,4 +22,5 @@ dependencies {
 	}
     compile("io.netty:netty-all:${nettyVersion}")
     compile("org.bouncycastle:bcprov-jdk15on:${bouncycastleVersion}")
+    testCompile("org.opentest4j:opentest4j:${opentest4jVersion}")
 }

--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -243,6 +243,7 @@ dependencies {
 
 
     testCompile "junit:junit:${junitVersion}"
+    testCompile "org.opentest4j:opentest4j:${opentest4jVersion}"
     testCompile "org.springframework:spring-test:${springVersion}"
     testCompile "org.springframework:spring-context:${springVersion}"
     testCompile "org.springframework:spring-context-support:${springVersion}"

--- a/serenity-ensure/build.gradle
+++ b/serenity-ensure/build.gradle
@@ -33,10 +33,10 @@ dependencies {
 
     // JUnit 5
     testImplementation(
-            "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     )
     testRuntimeOnly(
-            "org.junit.jupiter:junit-jupiter-engine:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     )
 }
 repositories {

--- a/serenity-json-summary-report/build.gradle
+++ b/serenity-json-summary-report/build.gradle
@@ -34,10 +34,10 @@ dependencies {
 
     // JUnit 5
     testImplementation(
-            "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     )
     testRuntimeOnly(
-            "org.junit.jupiter:junit-jupiter-engine:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     )
 }
 repositories {

--- a/serenity-junit/build.gradle
+++ b/serenity-junit/build.gradle
@@ -21,10 +21,10 @@ dependencies {
     compile project(':serenity-core')
     compile "junit:junit:${junitVersion}"
     compile "org.hamcrest:hamcrest-core:${hamcrestVersion}"
+    compile "org.opentest4j:opentest4j:${opentest4jVersion}"
 
     testCompile project(':serenity-test-utils')
     testCompile "commons-dbcp:commons-dbcp:1.3"
-//    testCompile("org.seleniumhq.selenium:htmlunit-driver:${htmlunitDriverVersion}")
     testCompile "org.springframework:spring-jdbc:${springVersion}"
     testCompile "org.springframework:spring-aop:${springVersion}"
     testCompile "org.springframework:spring-orm:${springVersion}"

--- a/serenity-model/build.gradle
+++ b/serenity-model/build.gradle
@@ -62,13 +62,14 @@ dependencies {
     compile "junit:junit:${junitVersion}"
     compile 'es.nitaur.markdown:txtmark:0.16'
 
-    compileOnly "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+    compileOnly "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
 
     testCompile project(':serenity-test-utils')
     testCompile project(':serenity-sample-alternative-resources')
     testCompile("org.spockframework:spock-core:${spockVersion}") {
         exclude group: "junit"
         exclude group: "org.codehaus.groovy"
+        exclude group: "org.junit.platform"
     }
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
 }

--- a/serenity-reports-configuration/build.gradle
+++ b/serenity-reports-configuration/build.gradle
@@ -34,10 +34,10 @@ dependencies {
 
     // JUnit 5
     testImplementation(
-            "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     )
     testRuntimeOnly(
-            "org.junit.jupiter:junit-jupiter-engine:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     )
 }
 repositories {

--- a/serenity-reports/build.gradle
+++ b/serenity-reports/build.gradle
@@ -43,5 +43,6 @@ dependencies {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
+    testCompile "org.opentest4j:opentest4j:${opentest4jVersion}"
 }
 

--- a/serenity-rest-assured/build.gradle
+++ b/serenity-rest-assured/build.gradle
@@ -24,5 +24,6 @@ dependencies {
         exclude group: 'org.apache.httpcomponents', module:'httpclient'
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
+    testCompile "org.opentest4j:opentest4j:${opentest4jVersion}"
     testCompile project(':serenity-test-utils')
 }

--- a/serenity-screenplay/build.gradle
+++ b/serenity-screenplay/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 //    compile 'uk.com.robust-it:cloning:1.9.10'
     compile project(':serenity-core')
     testCompile project(':serenity-junit')
+
 }

--- a/serenity-single-page-report/build.gradle
+++ b/serenity-single-page-report/build.gradle
@@ -45,10 +45,10 @@ dependencies {
 
     // JUnit 5
     testImplementation(
-            "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     )
     testRuntimeOnly(
-            "org.junit.jupiter:junit-jupiter-engine:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     )
 }
 repositories {

--- a/serenity-stats/build.gradle
+++ b/serenity-stats/build.gradle
@@ -29,10 +29,10 @@ dependencies {
 
     // JUnit 5
     testImplementation(
-            "org.junit.jupiter:junit-jupiter-api:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     )
     testRuntimeOnly(
-            "org.junit.jupiter:junit-jupiter-engine:${junit5_version}"
+            "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     )
 }
 repositories {


### PR DESCRIPTION
- Upgrade to rest-assured 4.3.1
- Upgrade Groovy to 3.0.5 (rest-assured since 4.3.0 use Groovy 3.x)
- Upgrade Spock to Groovy 3.x version (right now `2.0-M3-groovy-3.0` version available)