### PR TITLE
:bug: Updates CucumberParser to handle features in other languages or  encodings

### DIFF
--- a/serenity-model/src/test/groovy/net/thucydides/core/requirements/model/cucumber/WhenLoadingFeaturesInOtherLanguage.groovy
+++ b/serenity-model/src/test/groovy/net/thucydides/core/requirements/model/cucumber/WhenLoadingFeaturesInOtherLanguage.groovy
@@ -1,0 +1,25 @@
+package net.thucydides.core.requirements.model.cucumber
+
+
+import spock.lang.Specification
+
+class WhenLoadingFeaturesInOtherLanguage extends Specification {
+
+    def spanishFeatureFile = "src/test/resources/features/maintain_my_todo_list/feature_en_otro_idioma.feature"
+
+    def "should load the feature no matters the encoding language"() {
+        when:
+        CucumberParser parser = new CucumberParser()
+        Optional<AnnotatedFeature> spanishFeature = parser.loadFeature(new File(spanishFeatureFile))
+
+        then: "the feature file should be loaded"
+        spanishFeature.isPresent()
+        spanishFeature.get().scenarioDefinitions.size() == 2
+
+        and: "the scenarios should be read without problems"
+        def feature = spanishFeature.get().feature
+        def firstScenario = ReferencedScenario.in(feature).withName("Escenario número 1").asGivenWhenThen()
+        firstScenario.get().contains("Dado que Ricardo está realizando una prueba sobre serenity")
+        firstScenario.get().contains("Entonces al ejecutar la prueba se debe obtener un resultado éxitoso")
+    }
+}

--- a/serenity-model/src/test/groovy/net/thucydides/core/requirements/model/cucumber/WhenLoadingIncorrectFeatureFiles.groovy
+++ b/serenity-model/src/test/groovy/net/thucydides/core/requirements/model/cucumber/WhenLoadingIncorrectFeatureFiles.groovy
@@ -9,7 +9,7 @@ class WhenLoadingIncorrectFeatureFiles extends Specification {
     def "Should display a meaningful error message if there is a Gherkin syntax error"() {
         when:
         CucumberParser parser = new CucumberParser()
-        AnnotatedFeature feature = parser.loadFeature(new File(invalidFeatureFile))
+        Optional<AnnotatedFeature> feature = parser.loadFeature(new File(invalidFeatureFile))
         then:
         InvalidFeatureFileException ex = thrown()
             ex.message.contains("Failed to parse resource")

--- a/serenity-model/src/test/resources/features/maintain_my_todo_list/feature_en_otro_idioma.feature
+++ b/serenity-model/src/test/resources/features/maintain_my_todo_list/feature_en_otro_idioma.feature
@@ -1,0 +1,11 @@
+# language: es
+# encoding: iso-8859-1
+Característica: Prueba de Feature en otro idioma
+
+  Escenario: Escenario número 1
+    Dado que Ricardo está realizando una prueba sobre serenity
+    Entonces al ejecutar la prueba se debe obtener un resultado éxitoso
+
+  Escenario: Escenario de prueba número 2
+    Dado que Ricardo está realizando otra prueba sobre serenity
+    Entonces al ejecutar la prueba se debe obtener un resultado éxitoso


### PR DESCRIPTION
FIX #2146

@wakaleo, @cliviu I change the current implementation of the cucumber parser to use the FeatureParser provided by cucumber instead of rely on Gherkin implementation, because current CucumberParser was unable to handle Features in other languages different of english that are not encoding as UTF-8.

I added a test, that verifies this, also I test this in my project and now the Features are not duplicated anymore, let me know any comment. 