### PR TITLE
:sparkles: Add forget option to actors

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/WebElementFacadeImpl.java
@@ -226,10 +226,10 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
         if (driverIsDisabled()) {
             return new WebElementFacadeStub();
         }
-        return getResolvedELement();
+        return getResolvedElement();
     }
 
-    private WebElement getResolvedELement() {
+    private WebElement getResolvedElement() {
         if (resolvedELement == null) {
             resolvedELement = getElementResolver().resolveForDriver(driver);
         }
@@ -606,16 +606,16 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
 
         WebElement element = getElement();
 
-	if (element == null)
-	    return false;
+        if (element == null)
+            return false;
 
-	String text = element.getText();
-	if (text.isEmpty()) {
-	    // https://github.com/serenity-bdd/serenity-core/issues/2134
-	    // maybe it's an input element?
-	    text = element.getAttribute("value");
-	}
-	return text.equals(value);
+        String text = element.getText();
+        if (text.isEmpty()) {
+            // https://github.com/serenity-bdd/serenity-core/issues/2134
+            // maybe it's an input element?
+            text = element.getAttribute("value");
+        }
+        return text.equals(value);
     }
 
     /**
@@ -799,7 +799,7 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
                 return true;
             }
         } catch (TimeoutException timeout) {
-            throw new ElementShouldBeEnabledException("Expected enabled element was not clickable", timeout);
+            return false;
         }
         return false;
     }
@@ -1088,8 +1088,8 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
     @Override
     public Wait<WebDriver> waitForCondition() {
         return new FluentWait<>(driver, webdriverClock, sleeper)
-                .withTimeout(waitForTimeoutInMilliseconds, TimeUnit.MILLISECONDS)
-                .pollingEvery(WAIT_FOR_ELEMENT_PAUSE_LENGTH, TimeUnit.MILLISECONDS)
+                .withTimeout(Duration.ofMillis(waitForTimeoutInMilliseconds))
+                .pollingEvery(Duration.ofMillis(WAIT_FOR_ELEMENT_PAUSE_LENGTH))
                 .ignoring(NoSuchElementException.class, NoSuchFrameException.class);
     }
 
@@ -1257,6 +1257,7 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
         getElement().click();
         notifyScreenChange();
     }
+
     /**
      * Wait for an element to be visible and enabled, and then click on it.
      */
@@ -1439,6 +1440,6 @@ public class WebElementFacadeImpl implements WebElementFacade, net.thucydides.co
 
     @Override
     public WebElement getWrappedElement() {
-        return getResolvedELement();
+        return getResolvedElement();
     }
 }

--- a/serenity-core/src/test/java/net/thucydides/core/pages/integration/UsingTheWebElementFacade.java
+++ b/serenity-core/src/test/java/net/thucydides/core/pages/integration/UsingTheWebElementFacade.java
@@ -213,6 +213,11 @@ public class UsingTheWebElementFacade extends FluentElementAPITestsBaseClass {
     }
 
     @Test
+    public void should_return_false_if_element_is_not_present_when_asking_for_its_clickable_state() {
+        assertThat(page.fieldDoesNotExist.isClickable()).isFalse();
+    }
+
+    @Test
     public void should_pass_if_expected_element_is_present() {
         page.firstName.shouldBePresent();
     }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/ClickOnClickable.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/ClickOnClickable.java
@@ -1,26 +1,13 @@
 package net.serenitybdd.screenplay.actions;
 
 import net.serenitybdd.core.pages.ClickStrategy;
-import net.serenitybdd.core.pages.WebElementFacade;
-import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.ClickInteraction;
-import net.serenitybdd.screenplay.Interaction;
-import net.serenitybdd.screenplay.targets.Target;
-import net.thucydides.core.annotations.Step;
-import org.openqa.selenium.WebElement;
 
 import static net.serenitybdd.core.pages.ClickStrategy.*;
 
-abstract class ClickOnClickable implements Interaction, Resolvable, ClickInteraction {
+abstract class ClickOnClickable implements ClickInteraction {
 
     private ClickStrategy clickStrategy = WAIT_UNTIL_PRESENT;
-
-    abstract protected String getName();
-
-    @Step("{0} clicks on #name")
-    public <T extends Actor> void performAs(T theUser) {
-        resolveFor(theUser).click(clickStrategy);
-    }
 
     @Override
     public ClickInteraction afterWaitingUntilEnabled() {
@@ -38,5 +25,9 @@ abstract class ClickOnClickable implements Interaction, Resolvable, ClickInterac
     public ClickInteraction withNoDelay() {
         clickStrategy = IMMEDIATE;
         return this;
+    }
+
+    public ClickStrategy getClickStrategy() {
+        return clickStrategy;
     }
 }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/ClickOnElement.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/ClickOnElement.java
@@ -2,26 +2,14 @@ package net.serenitybdd.screenplay.actions;
 
 import net.serenitybdd.core.pages.WebElementFacade;
 import net.serenitybdd.screenplay.Actor;
-import net.serenitybdd.screenplay.ClickInteraction;
-import net.serenitybdd.screenplay.Interaction;
 import net.thucydides.core.annotations.Step;
 
 public class ClickOnElement extends ClickOnClickable {
     private final WebElementFacade element;
 
-    @Override
-    public WebElementFacade resolveFor(Actor theUser) {
-        return element;
-    }
-
-    @Override
-    protected String getName() {
-        return element.toString();
-    }
-
     @Step("{0} clicks on #element")
     public <T extends Actor> void performAs(T theUser) {
-        element.click();
+        element.click(getClickStrategy());
     }
 
     public ClickOnElement(WebElementFacade element) {

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/ClickOnTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/ClickOnTarget.java
@@ -1,24 +1,21 @@
 package net.serenitybdd.screenplay.actions;
 
-import net.serenitybdd.core.pages.WebElementFacade;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.targets.Target;
+import net.thucydides.core.annotations.Step;
 
 public class ClickOnTarget extends ClickOnClickable {
     private final Target target;
 
     @Override
-    public WebElementFacade resolveFor(Actor theUser) {
-        return target.resolveFor(theUser);
-    }
-
-    @Override
-    protected String getName() {
-        return target.getName();
+    @Step("{0} clicks on #target")
+    public <T extends Actor> void performAs(T theUser) {
+        target.resolveFor(theUser).click(getClickStrategy());
     }
 
     public ClickOnTarget(Target target) {
         this.target = target;
     }
+
 
 }

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
@@ -363,6 +363,9 @@ public class Actor implements PerformsTasks, SkipNested {
         return new HashMap<>(notepad);
     }
 
+    @SuppressWarnings("unchecked")
+    public <T> T forget(String key) { return (T) notepad.remove(key);}
+
     public <T> T sawAsThe(String key) {
         return recall(key);
     }

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Forget.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Forget.java
@@ -1,0 +1,21 @@
+package net.serenitybdd.screenplay;
+
+import net.serenitybdd.markers.IsSilent;
+
+public class Forget implements Interaction, IsSilent {
+    private final String memoryKey;
+
+    public Forget(String memoryKey) {
+        this.memoryKey = memoryKey;
+    }
+
+    @Override
+    public <T extends Actor> void performAs(T actor) {
+        actor.forget(memoryKey);
+    }
+
+    public static Forget theValueOf(String memoryKey) {
+        return new Forget(memoryKey);
+    }
+
+}

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/questions/TheMemory.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/questions/TheMemory.java
@@ -1,0 +1,34 @@
+package net.serenitybdd.screenplay.questions;
+
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.Question;
+
+public class TheMemory implements Question<Boolean> {
+    private final String memoryKey;
+
+    public TheMemory(String memoryKey) {
+        this.memoryKey = memoryKey;
+    }
+
+    @Override
+    public Boolean answeredBy(Actor actor) {
+        return actor.recall(memoryKey) != null;
+    }
+
+    public static class TheMemoryQuestionBuilder {
+
+        private final String memoryKey;
+
+        public TheMemoryQuestionBuilder(String memoryKey) {
+            this.memoryKey = memoryKey;
+        }
+
+        public TheMemory isPresent() {
+            return new TheMemory(memoryKey);
+        }
+    }
+
+    public static TheMemoryQuestionBuilder withKey(String memoryKey) {
+        return new TheMemoryQuestionBuilder(memoryKey);
+    }
+}

--- a/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/WhenActorsForgetStuff.groovy
+++ b/serenity-screenplay/src/test/groovy/net/serenitybdd/screenplay/WhenActorsForgetStuff.groovy
@@ -1,0 +1,43 @@
+package net.serenitybdd.screenplay
+
+import net.serenitybdd.screenplay.conditions.Check
+import net.serenitybdd.screenplay.questions.TheMemory
+import spock.lang.Specification
+
+class WhenActorsForgetStuff extends Specification {
+
+    def "actor can forget stuff"() {
+        given:
+        def actor = new Actor("Jill")
+        actor.remember("favorite color", "blue")
+        when:
+        def forgottenColor = actor.forget("favorite color")
+        then:
+        actor.recall("favorite color") == null
+        forgottenColor == "blue"
+    }
+
+    def "actor can forget stuff when performing actions"() {
+        given:
+        def actor = new Actor("Jill")
+        actor.remember("favorite color", "blue")
+        when:
+        actor.attemptsTo(Forget.theValueOf("favorite color"))
+        then:
+        actor.recall("favorite color") == null
+    }
+
+    def "actor can check if he has something in memory"() {
+        given:
+        def actor = new Actor("Jill")
+        when:
+        actor.attemptsTo(
+                Check.whether(TheMemory.withKey("favorite color").isPresent())
+                        .otherwise(
+                                RememberThat.theValueOf("favorite color").is("blue")
+                        )
+        )
+        then:
+        actor.recall("favorite color") == "blue"
+    }
+}


### PR DESCRIPTION
Actors are now able to forget things, this is something really easy to made in Kotlin but in Java is more verbose, so I added the method to forget in the Actor class.

:bug: FIX #2243  this fixes the report things for ClickInteraction, also the ClickOnElement class now uses the CLICK_STRATEGY provided.

:bug: FIX #2168