### PR TITLE
Ensure appiumConfiguration is consistent when choosing an ElementLocatorFactory (#2281)

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/ElementLocatorFactorySelector.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/ElementLocatorFactorySelector.java
@@ -24,7 +24,7 @@ public class ElementLocatorFactorySelector {
     public ElementLocatorFactorySelector(int timeoutInSeconds, EnvironmentVariables environmentVariables) {
         this.timeoutInSeconds = timeoutInSeconds;
         this.environmentVariables = environmentVariables.copy();
-        appiumConfiguration = AppiumConfiguration.from(Injectors.getInjector().getProvider(EnvironmentVariables.class).get());
+        appiumConfiguration = AppiumConfiguration.from(environmentVariables);
     }
 
     public ElementLocatorFactory getLocatorFor(WebDriver driver) {


### PR DESCRIPTION
#### Summary of this PR
Fixes an inconsistency in `ElementLocatorFactorySelector` where it's AppiumConfiguration uses a different EnvironmentVariables than other usages.
#### Intended effect
ElementLocatorFactorySelector will assign the target platform consistent with the passed configuration.
#### How should this be manually tested?
- Start with a configuration that does not contain `appium.platformName` (previously this would later be read by Injectors)
- make a copy of the configuration and update with a valid platformName
- pass updated configuration to ElementLocatorFactorySelector
- call elementLocatorFactorySelector.getLocatorFor(MobileDriver)
**Expected:**
  AppiumConfiguration.getTargetPlatform() does not throw a ThucydidesConfigurationException stating the platformName is not defined
#### Relevant tickets
#2281