### PR TITLE
Smartbear crossbrowsertesting support

### DIFF
--- a/serenity-crossbrowsertesting/build.gradle
+++ b/serenity-crossbrowsertesting/build.gradle
@@ -1,0 +1,8 @@
+ext {
+    projectDescription = 'Serenity CrossBrowserTesting Integration'
+}
+
+dependencies {
+    compile project(':serenity-core')
+    compile group: 'com.konghq', name: 'unirest-java', version: '3.11.05'
+}

--- a/serenity-crossbrowsertesting/src/main/java/net/serenitybdd/crossbrowsertesting/AfterACrossBrowserTestingScenario.java
+++ b/serenity-crossbrowsertesting/src/main/java/net/serenitybdd/crossbrowsertesting/AfterACrossBrowserTestingScenario.java
@@ -1,0 +1,35 @@
+package net.serenitybdd.crossbrowsertesting;
+
+import net.serenitybdd.core.environment.EnvironmentSpecificConfiguration;
+import net.serenitybdd.core.webdriver.RemoteDriver;
+import net.serenitybdd.core.webdriver.enhancers.AfterAWebdriverScenario;
+import net.thucydides.core.model.ExternalLink;
+import net.thucydides.core.model.TestOutcome;
+import net.thucydides.core.util.EnvironmentVariables;
+import org.openqa.selenium.WebDriver;
+
+public class AfterACrossBrowserTestingScenario implements AfterAWebdriverScenario {
+
+    @Override
+    public void apply(EnvironmentVariables environmentVariables, TestOutcome testOutcome, WebDriver driver) {
+        if ((driver == null) || (!RemoteDriver.isARemoteDriver(driver))) {
+            return;
+        }
+
+        String sessionId = RemoteDriver.of(driver).getSessionId().toString();
+        String userName = EnvironmentSpecificConfiguration.from(environmentVariables)
+                .getOptionalProperty("crossbrowsertesting.user")
+                .orElse(null);
+
+        String key = EnvironmentSpecificConfiguration.from(environmentVariables)
+                .getOptionalProperty("crossbrowsertesting.key")
+                .orElse(null);
+
+        CrossBrowserTestingTestSession crossBrowserTestingTestSession = new CrossBrowserTestingTestSession(userName, key, sessionId);
+        String publicUrl = crossBrowserTestingTestSession.getPublicUrl();
+
+        testOutcome.setLink(new ExternalLink(publicUrl, "CrossBrowserTesting"));
+        crossBrowserTestingTestSession.takeSnapshot("Final State");
+        crossBrowserTestingTestSession.updateTestResultsFor(testOutcome);
+    }
+}

--- a/serenity-crossbrowsertesting/src/main/java/net/serenitybdd/crossbrowsertesting/BeforeACrossBrowserTestingScenario.java
+++ b/serenity-crossbrowsertesting/src/main/java/net/serenitybdd/crossbrowsertesting/BeforeACrossBrowserTestingScenario.java
@@ -1,0 +1,94 @@
+package net.serenitybdd.crossbrowsertesting;
+
+import net.serenitybdd.core.environment.EnvironmentSpecificConfiguration;
+import net.serenitybdd.core.webdriver.OverrideDriverCapabilities;
+import net.serenitybdd.core.webdriver.enhancers.BeforeAWebdriverScenario;
+import net.thucydides.core.model.TestOutcome;
+import net.thucydides.core.util.EnvironmentVariables;
+import net.thucydides.core.webdriver.SupportedWebDriver;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.*;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+public class BeforeACrossBrowserTestingScenario implements BeforeAWebdriverScenario {
+    private static final String CROSS_BROWSER_TESTING = "crossbrowsertesting.";
+    private static final List<String> NON_CBT_PROPERTIES =
+            Arrays.asList(
+                    "user",
+                    "key",
+                    "browserName",
+                    "browserVersion",
+                    "platformName"
+            );
+
+    @Override
+    public DesiredCapabilities apply(EnvironmentVariables environmentVariables, SupportedWebDriver driver, TestOutcome testOutcome, DesiredCapabilities capabilities) {
+        if (driver != SupportedWebDriver.REMOTE) {
+            return capabilities;
+        }
+
+        String remotePlatform = EnvironmentSpecificConfiguration.from(environmentVariables)
+                .getOptionalProperty("remote.platform")
+                .orElse(null);
+
+        if (isNotEmpty(remotePlatform)) {
+            capabilities.setPlatform(Platform.valueOf(remotePlatform.toUpperCase()));
+        }
+
+        Properties cbtProperties = EnvironmentSpecificConfiguration.from(environmentVariables).getPropertiesWithPrefix(CROSS_BROWSER_TESTING);
+
+        OverrideDriverCapabilities.getProperties().forEach((key, value) -> cbtProperties.setProperty(key, value.toString()));
+
+        setNonW3CCapabilities(capabilities, cbtProperties);
+
+        Map<String, Object> cbtOptions = w3CPropertyMapFrom(cbtProperties);
+        String testName = testOutcome.getStoryTitle() + " - " + testOutcome.getTitle();
+        cbtOptions.put("name", testName);
+
+        capabilities.setCapability("cbt:options", cbtOptions);
+        return capabilities;
+    }
+
+    private void setNonW3CCapabilities(DesiredCapabilities capabilities, Properties cbtProperties) {
+        cbtProperties.stringPropertyNames()
+                .stream()
+                .filter(this::isNonW3CProperty)
+                .forEach(
+                        key -> capabilities.setCapability(unprefixed(key), cbtProperties.getProperty(key))
+                );
+    }
+
+    private Map<String, Object> w3CPropertyMapFrom(Properties properties) {
+        Map<String, Object> w3cOptions = new HashMap<>();
+        Map<String, Map<String, Object>> nestedOptions = new HashMap<>();
+
+        properties.stringPropertyNames()
+                .stream()
+                .filter(this::isW3CProperty)
+                .forEach(
+                        key -> {
+                            String unprefixedKey = unprefixed(key);
+                            w3cOptions.put(unprefixedKey, properties.getProperty(key));
+                        }
+                );
+        w3cOptions.putAll(nestedOptions);
+        return w3cOptions;
+    }
+
+    private boolean isNonW3CProperty(String key) {
+        return NON_CBT_PROPERTIES.contains(unprefixed(key));
+    }
+
+    private boolean isW3CProperty(String key) {
+        return !isNonW3CProperty(key);
+    }
+
+    private String unprefixed(String propertyName) {
+        return propertyName.replace(CROSS_BROWSER_TESTING, "");
+    }
+
+
+}

--- a/serenity-crossbrowsertesting/src/main/java/net/serenitybdd/crossbrowsertesting/CrossBrowserTestingTestSession.java
+++ b/serenity-crossbrowsertesting/src/main/java/net/serenitybdd/crossbrowsertesting/CrossBrowserTestingTestSession.java
@@ -1,0 +1,82 @@
+package net.serenitybdd.crossbrowsertesting;
+
+import kong.unirest.HttpResponse;
+import kong.unirest.JsonNode;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
+import net.thucydides.core.model.TestOutcome;
+import net.thucydides.core.model.TestResult;
+
+public class CrossBrowserTestingTestSession {
+
+    private final String user;
+    private final String key;
+    private final String sessionId;
+    public final String API = "https://crossbrowsertesting.com/api/v3/selenium/";
+
+    public CrossBrowserTestingTestSession(String user, String key, String sessionId) {
+        this.user = user;
+        this.key = key;
+        this.sessionId = sessionId;
+    }
+
+    public void updateTestResultsFor(TestOutcome testOutcome) {
+        String score = cbtCompatibleResultOf(testOutcome);
+
+        Unirest.put(API + this.sessionId)
+                .basicAuth(user, key)
+                .field("action", "set_score")
+                .field("score", score)
+                .asJson();
+    }
+
+    public String takeSnapshot() throws UnirestException {
+        HttpResponse<JsonNode> response = Unirest
+                .post(API + this.sessionId + "/snapshots")
+                .basicAuth(user, key)
+                .asJson();
+
+        return (String) response.getBody().getObject().get("hash");
+    }
+
+    public void takeSnapshot(String description) throws UnirestException {
+        String hash = takeSnapshot();
+
+        Unirest.put(API + "{seleniumTestId}/snapshots/{snapshotHash}")
+                .basicAuth(user, key)
+                .routeParam("seleniumTestId", this.sessionId)
+                .routeParam("snapshotHash", hash)
+                .field("description", description)
+                .asJson();
+    }
+
+    public String getPublicUrl() {
+        HttpResponse<JsonNode> response = Unirest
+                .get(API + this.sessionId)
+                .basicAuth(user, key)
+                .asJson();
+
+        return (String) response.getBody().getObject().get("show_result_public_url");
+    }
+
+    private String cbtCompatibleResultOf(TestOutcome outcome) {
+        switch (latestResultOf(outcome)) {
+            case SUCCESS:
+                return "pass";
+            case FAILURE:
+            case ERROR:
+            case COMPROMISED:
+                return "fail";
+            default:
+                return "unset";
+        }
+    }
+
+    private TestResult latestResultOf(TestOutcome outcome) {
+        if (outcome.isDataDriven()) {
+            return outcome.getLatestTopLevelTestStep().get().getResult();
+        } else {
+            return outcome.getResult();
+        }
+    }
+}

--- a/serenity-crossbrowsertesting/src/test/java/net/serenitybdd/crossbrowsertesting/WhenAddingCrossBrowserTestingCapabilities.java
+++ b/serenity-crossbrowsertesting/src/test/java/net/serenitybdd/crossbrowsertesting/WhenAddingCrossBrowserTestingCapabilities.java
@@ -1,0 +1,96 @@
+package net.serenitybdd.crossbrowsertesting;
+
+import net.serenitybdd.core.webdriver.OverrideDriverCapabilities;
+import net.serenitybdd.core.webdriver.driverproviders.AddCustomDriverCapabilities;
+import net.thucydides.core.model.Story;
+import net.thucydides.core.model.TestOutcome;
+import net.thucydides.core.util.EnvironmentVariables;
+import net.thucydides.core.util.MockEnvironmentVariables;
+import net.thucydides.core.webdriver.SupportedWebDriver;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WhenAddingCrossBrowserTestingCapabilities {
+    EnvironmentVariables environmentVariables = new MockEnvironmentVariables();
+
+    private static final TestOutcome SAMPLE_TEST_OUTCOME = TestOutcome.forTestInStory("sample_test", Story.called("Sample story"));
+
+    @Before
+    public void prepareSession() {
+        OverrideDriverCapabilities.clear();
+    }
+
+    @Test
+    public void thePlatformShouldBeAddedToTheCapability() {
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+
+        environmentVariables.setProperty("remote.platform","android");
+
+        AddCustomDriverCapabilities.from(environmentVariables)
+                .withTestDetails(SupportedWebDriver.REMOTE, SAMPLE_TEST_OUTCOME)
+                .to(capabilities);
+
+        assertThat(capabilities.getPlatform()).isEqualTo(Platform.ANDROID);
+    }
+
+    @Test
+    public void theBrowserNameShouldBeAddedDirectlyToTheCapability() {
+
+        DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+
+        AddCustomDriverCapabilities.from(environmentVariables)
+                .withTestDetails(SupportedWebDriver.REMOTE, SAMPLE_TEST_OUTCOME)
+                .to(capabilities);
+
+        assertThat(capabilities.getBrowserName()).isEqualTo("chrome");
+    }
+
+    @Test
+    public void theBuildNameCanBeSpecifiedInTheCrossBrowserTestingConfiguration() {
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+
+        environmentVariables.setProperty("crossbrowsertesting.build","sample build");
+        AddCustomDriverCapabilities.from(environmentVariables)
+                .withTestDetails(SupportedWebDriver.REMOTE, SAMPLE_TEST_OUTCOME)
+                .to(capabilities);
+
+        assertThat(cbtOptionsFrom(capabilities).get("build")).isEqualTo("sample build");
+    }
+
+    @Test
+    public void theSessionNameShouldBeTakenFromTheNameOfTheTest() {
+
+        // Given
+        DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+
+        AddCustomDriverCapabilities.from(environmentVariables)
+                .withTestDetails(SupportedWebDriver.REMOTE, SAMPLE_TEST_OUTCOME)
+                .to(capabilities);
+
+        assertThat(cbtOptionsFrom(capabilities).get("name")).isEqualTo("Sample story - Sample test");
+    }
+
+    @Test
+    public void theBuildCanBeOverridenAtRunTime() {
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+
+        environmentVariables.setProperty("crossbrowsertesting.build","sample build");
+        OverrideDriverCapabilities.withProperty("crossbrowsertesting.build").setTo("overridden build");
+
+        AddCustomDriverCapabilities.from(environmentVariables)
+                .withTestDetails(SupportedWebDriver.REMOTE, SAMPLE_TEST_OUTCOME)
+                .to(capabilities);
+
+        assertThat(cbtOptionsFrom(capabilities).get("build")).isEqualTo("overridden build");
+    }
+
+    private Map<String,String> cbtOptionsFrom(DesiredCapabilities capabilities) {
+        return (Map<String, String>) capabilities.getCapability("cbt:options");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,4 +22,6 @@ include 'serenity-test-utils',
         'serenity-assertions',
         'serenity-ensure',
         'serenity-assertions',
-        'serenity-reports-configuration'
+        'serenity-reports-configuration',
+        'serenity-crossbrowsertesting'
+


### PR DESCRIPTION
#### Summary of this PR
Integrates SerenityBDD with [CrossBrowserTesting](https://crossbrowsertesting.com/) (A service similar to BrowserStack/Saucelabs)
#### Intended effect
- adds the ability to configure drivers for cbt.
- marks the test outcome in cbt
- attaches the cbt test session link to the serenity report
#### How should this be manually tested?
- Sign up for a free trial of CBT
- in your serenity.conf place the following:

```
webdriver.remote.driver = chrome
webdriver.remote.url = "http://<user>:<key>@hub.crossbrowsertesting.com:80/wd/hub"
           
crossbrowsertesting {
    browserName = chrome
    browserVersion = Latest
    platformName = "Windows 10"
    record_video = true
}

```

- run your test
- after the test is completed, the session is marked as pass/fail in cbt
- open the serenity report, view the test results. A link to the test session is attached to the results (camera icon)
#### Documentation
available capabilities are listed [here](https://help.crossbrowsertesting.com/selenium-testing/getting-started/crossbrowsertesting-automation-capabilities/)