### PR TITLE
:bug: FIX a bug that causes current context to be overriden

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/model/TestOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/core/model/TestOutcome.java
@@ -405,7 +405,9 @@ public class TestOutcome {
     public EnvironmentVariables getEnvironmentVariables() {
         if (environmentVariables == null) {
             environmentVariables = Injectors.getInjector().getProvider(EnvironmentVariables.class).get();
-            this.context = contextFrom(environmentVariables);
+            if(this.context==null){
+                this.context = contextFrom(environmentVariables);
+            }
         }
         return environmentVariables;
     }


### PR DESCRIPTION
:bug: FIX a bug that causes current context to be overridden when calling `getEnvironmentVariables` method in TestOutcome

FIX #2129
possible FIX #2172