### PR TITLE
feat: Consider a test class taggable in Junit5 based on it's extensions (analog to JUnit4)

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/annotations/WithTag.java
+++ b/serenity-model/src/main/java/net/thucydides/core/annotations/WithTag.java
@@ -1,6 +1,7 @@
 package net.thucydides.core.annotations;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -10,6 +11,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(WithTags.class)
 @Target({ElementType.METHOD, ElementType.TYPE})
 public @interface WithTag {
     String value() default "";


### PR DESCRIPTION
* For JUnit5 a test class will be considered taggable by Serenity if one of it's `Extension` implements `net.thucydides.core.tags.Taggable`
  * This is consistent with the Junit4 behaviour: For JUnit4 a test class is considered taggable by Serenity if it's `Runner` implements `net.thucydides.core.tags.Taggable`
* Junit5 supports meta-annotations. To make Serenity aware of such meta-annotations `org.junit.platform.commons.util.AnnotationUtils` is used in the `JUnit5Adapter`
  * the following JUnit5 annotations are now detected inside meta-annotations
    * `org.junit.jupiter.api.Test`
    * `org.junit.jupiter.api.BeforeEach`
    * `org.junit.jupiter.api.BeforeAll`
    * `org.junit.jupiter.api.Disabled`
    * `org.junit.jupiter.api.extension.ExtendWith` to determine if
      * a test is a serenity test case and/or
      * a test class is taggable