### PR TITLE
default SERENITY_CONSOLE_COLORS to false, as per documentation

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/reports/AsciiColors.java
+++ b/serenity-model/src/main/java/net/thucydides/core/reports/AsciiColors.java
@@ -1,6 +1,5 @@
 package net.thucydides.core.reports;
 
-import net.serenitybdd.core.CurrentOS;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.util.EnvironmentVariables;
 
@@ -18,8 +17,7 @@ public class AsciiColors {
         this.isBold = isBold;
     }
     private boolean showColoredOutput() {
-        Boolean defaultValue = (!CurrentOS.isWindows());
-        return ThucydidesSystemProperty.SERENITY_CONSOLE_COLORS.booleanFrom(environmentVariables,defaultValue);
+        return ThucydidesSystemProperty.SERENITY_CONSOLE_COLORS.booleanFrom(environmentVariables, false);
     }
 
     public AsciiColors bold() {


### PR DESCRIPTION
fix for https://github.com/serenity-bdd/serenity-maven-plugin/issues/77