### PR TITLE
Additional Browserstack session getters

### DIFF
--- a/serenity-browserstack/src/main/java/net/serenitybdd/browserstack/AfterABrowserStackScenario.java
+++ b/serenity-browserstack/src/main/java/net/serenitybdd/browserstack/AfterABrowserStackScenario.java
@@ -20,35 +20,26 @@ public class AfterABrowserStackScenario implements AfterAWebdriverScenario {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AfterABrowserStackScenario.class);
 
-    private static final String BROWSERSTACK_URL_LINK = "https://api.browserstack.com/automate/builds/%s/sessions/%s.json";
-
-    private Gson gson = new Gson();
-
     @Override
     public void apply(EnvironmentVariables environmentVariables, TestOutcome testOutcome, WebDriver driver) {
         if ((driver == null) || (!RemoteDriver.isARemoteDriver(driver))) {
             return;
         }
 
-        try {
-            String sessionId = RemoteDriver.of(driver).getSessionId().toString();
-            String userName = EnvironmentSpecificConfiguration.from(environmentVariables)
-                    .getOptionalProperty("browserstack.user")
-                    .orElse(null);
+        String sessionId = RemoteDriver.of(driver).getSessionId().toString();
+        String userName = EnvironmentSpecificConfiguration.from(environmentVariables)
+                .getOptionalProperty("browserstack.user")
+                .orElse(null);
 
-            String key = EnvironmentSpecificConfiguration.from(environmentVariables)
-                    .getOptionalProperty("browserstack.key")
-                    .orElse(null);
+        String key = EnvironmentSpecificConfiguration.from(environmentVariables)
+                .getOptionalProperty("browserstack.key")
+                .orElse(null);
 
-            BrowserStackTestSession browserStackTestSession = new BrowserStackTestSession(userName, key, sessionId);
-            browserStackTestSession.updateTestResultFor(testOutcome);
+        BrowserStackTestSession browserStackTestSession = new BrowserStackTestSession(userName, key, sessionId);
+        browserStackTestSession.updateTestResultFor(testOutcome);
 
-            String publicUrl = browserStackTestSession.getPublicUrl();
-            testOutcome.setLink(new ExternalLink(publicUrl, "BrowserStack"));
-
-        } catch (URISyntaxException | IOException e) {
-            LOGGER.error("Failed to update BrowserStack",e);
-        }
+        String publicUrl = browserStackTestSession.getPublicUrl();
+        testOutcome.setLink(new ExternalLink(publicUrl, "BrowserStack"));
     }
 
 }

--- a/serenity-browserstack/src/main/java/net/serenitybdd/browserstack/BrowserStackTestSession.java
+++ b/serenity-browserstack/src/main/java/net/serenitybdd/browserstack/BrowserStackTestSession.java
@@ -2,6 +2,8 @@ package net.serenitybdd.browserstack;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.stream.MalformedJsonException;
 import net.thucydides.core.model.TestOutcome;
 import net.thucydides.core.model.TestResult;
 import org.apache.commons.codec.Charsets;
@@ -14,6 +16,8 @@ import org.apache.http.client.methods.HttpPut;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -23,9 +27,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 
 public class BrowserStackTestSession {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrowserStackTestSession.class);
+    private static final String BROWSER_SESSION_URL = "https://%s:%s@api.browserstack.com/automate/sessions/%s.json";
+    private static final String BUILD_INFO_URL = "https://%s:%s@api.browserstack.com/automate/builds.json";
     private final String browserStackUsername;
     private final String browserStackKey;
     private final String sessionId;
+    private final Gson gson = new Gson();
 
     public BrowserStackTestSession(String browserStackUsername, String browserStackKey, String sessionId) {
         this.browserStackUsername = browserStackUsername;
@@ -33,32 +42,136 @@ public class BrowserStackTestSession {
         this.sessionId = sessionId;
     }
 
-    private static final String BROWSER_SESSION_URL = "https://%s:%s@api.browserstack.com/automate/sessions/%s.json";
-    private static final String BUILD_INFO_URL = "https://%s:%s@api.browserstack.com/automate/builds.json";
+    public void updateTestResultFor(TestOutcome testOutcome) {
 
-    private Gson gson = new Gson();
+        try {
+            HttpPut putRequest = new HttpPut(getSessionUri());
+            ArrayList<NameValuePair> nameValuePairs = new ArrayList<>();
+            nameValuePairs.add(new BasicNameValuePair("status", browserstackCompatibleResultOf(testOutcome)));
+            nameValuePairs.add(new BasicNameValuePair("reason", testOutcome.getErrorMessage()));
+            putRequest.setEntity(new UrlEncodedFormEntity(nameValuePairs));
 
-    public void updateTestResultFor(TestOutcome testOutcome) throws URISyntaxException, IOException {
-        HttpPut putRequest = new HttpPut(getSessionUri());
-        ArrayList<NameValuePair> nameValuePairs = new ArrayList<>();
-        nameValuePairs.add(new BasicNameValuePair("status", browserstackCompatibleResultOf(testOutcome)));
-        nameValuePairs.add(new BasicNameValuePair("reason", testOutcome.getErrorMessage()));
-        putRequest.setEntity(new UrlEncodedFormEntity(nameValuePairs));
+            HttpClientBuilder.create().build().execute(putRequest);
+        }
+        catch (IOException e) {
+            LOGGER.error("Failed to update Browserstack results", e);
+        }
 
-        HttpClientBuilder.create().build().execute(putRequest);
     }
 
-    public String getPublicUrl() throws URISyntaxException, IOException {
-        if ((browserStackUsername == null) || (browserStackKey == null)) {
-            return "";
-        }
-        HttpGet querySessionInfo = new HttpGet(getSessionUri());
-        HttpEntity sessionDetails = HttpClientBuilder.create().build().execute(querySessionInfo).getEntity();
-        String sessionBody = EntityUtils.toString(sessionDetails, charsetOf(sessionDetails));
+    public String getName() {
+        return getSessionProperty("name");
+    }
 
-        JsonElement sessionElement = gson.fromJson(sessionBody, JsonElement.class);
-        return sessionElement.getAsJsonObject().get("automation_session")
-                             .getAsJsonObject().get("public_url").getAsString();
+    public int getDuration() {
+        return Integer.parseInt(getSessionProperty("duration"));
+    }
+
+    public String getOS() {
+        return getSessionProperty("os");
+    }
+
+    public String getOS_Version() {
+        return getSessionProperty("os_version");
+    }
+
+    public String getBrowserVersion() {
+        return getSessionProperty("browser_version");
+    }
+
+    public String getBrowser() {
+        return getSessionProperty("browser");
+    }
+
+    public String getDevice() {
+        return getSessionProperty("device");
+    }
+
+    public String getStatus() {
+        return getSessionProperty("status");
+    }
+
+    public String getHashedId() {
+        return getSessionProperty("hashed_id");
+    }
+
+    public String getReason() {
+        return getSessionProperty("reason");
+    }
+
+    public String getBuildName() {
+        return getSessionProperty("build_name");
+    }
+
+    public String getProjectName() {
+        return getSessionProperty("project_name");
+    }
+
+    public String getTestPriority() {
+        return getSessionProperty("test_priority");
+    }
+
+    public String getLogs() {
+        return getSessionProperty("logs");
+    }
+
+    public String getBrowserstackStatus() {
+        return getSessionProperty("browserstack_status");
+    }
+
+    public String getCreatedAt() {
+        return getSessionProperty("created_at");
+    }
+
+    public String getBrowserUrl() {
+        return getSessionProperty("browser_url");
+    }
+
+    public String getPublicUrl() {
+        return getSessionProperty("public_url");
+    }
+
+    public String getAppiumLogsUrl() {
+        return getSessionProperty("appium_logs_url");
+    }
+
+    public String getVideoUrl() {
+        return getSessionProperty("video_url");
+    }
+
+    public String getBrowserConsoleLogsUrl() {
+        return getSessionProperty("browser_console_logs_url");
+    }
+
+    public String getHarLogsUrl() {
+        return getSessionProperty("har_logs_url");
+    }
+
+    public String getSeleniumLogsUrl() {
+        return getSessionProperty("selenium_logs_url");
+    }
+
+    private String getSessionProperty(String propertyName) {
+        JsonElement sessionElement = null;
+        if ((browserStackUsername == null) || (browserStackKey == null)) {
+            return null;
+        }
+
+        try {
+            HttpGet querySessionInfo = new HttpGet(getSessionUri());
+            HttpEntity sessionDetails = HttpClientBuilder.create().build().execute(querySessionInfo).getEntity();
+            String sessionBody = EntityUtils.toString(sessionDetails, charsetOf(sessionDetails));
+            sessionElement = gson.fromJson(sessionBody, JsonElement.class);
+        } catch (IOException | JsonSyntaxException e) {
+            LOGGER.error("Failed to connect to Browserstack API.", e);
+        }
+
+        if (sessionElement == null) {
+            return null;
+        }
+
+        JsonElement automationSession = sessionElement.getAsJsonObject().get("automation_session");
+        return automationSession.getAsJsonObject().get(propertyName).getAsString();
     }
 
 
@@ -81,8 +194,15 @@ public class BrowserStackTestSession {
     }
 
 
-    private URI getSessionUri() throws URISyntaxException {
-        return new URI(String.format(BROWSER_SESSION_URL, browserStackUsername, browserStackKey, sessionId));
+    private URI getSessionUri() {
+        URI uri = null;
+        try {
+            uri = new URI(String.format(BROWSER_SESSION_URL, browserStackUsername, browserStackKey, sessionId));
+        } catch (URISyntaxException e) {
+            LOGGER.error("Failed to parse Browserstack API url.", e);
+        }
+
+        return uri;
     }
 
     private TestResult latestResultOf(TestOutcome outcome) {


### PR DESCRIPTION
#### Summary of this PR
Adds some additional getters to retrieve properties from the Browserstack API


#### Intended effect
Users will have the ability to query the bstack api for all [session detail properties](https://www.browserstack.com/docs/automate/api-reference/selenium/session#get-session-details)

In my case I needed a way to reliably get os/browser version. Browserstack doesn't allow minor os versions to be assigned by device capabilities (for iOS) and by default will always get the latest stable browser

#### How should this be manually tested?
- Requires a Browserstack Automate account and at least 1 saved session
```
public class WhenGettingBrowserStackSessionInfo {
    BrowserStackTestSession session;

    @Before
    public void setup() {
        session = new BrowserStackTestSession("BSTACK USER", "BSTACK KEY", "BSTACK SESSION ID");
    }

    @Test
    public void canGetName() {
        assertThat(session.getName()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetDuration() {
        assertThat(session.getDuration()).isGreaterThan(0);
    }

    @Test
    public void canGetOS() {
        assertThat(session.getOS()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetOS_Version() {
        assertThat(session.getOS_Version()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetBrowserVersion() {
        assertThat(session.getBrowserVersion()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetBrowser() {
        assertThat(session.getBrowser()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetDevice() {
        assertThat(session.getDevice()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetStatus() {
        assertThat(session.getStatus()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetHashedId() {
        assertThat(session.getHashedId()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetReason() {
        assertThat(session.getReason()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetBuildName() {
        assertThat(session.getBuildName()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetProjectName() {
        assertThat(session.getProjectName()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetTestPriority() {
        assertThat(session.getTestPriority()).isNull()
    }

    @Test
    public void canGetLogs() {
        assertThat(session.getLogs()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetBrowserstackStatus() {
        assertThat(session.getBrowserstackStatus()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetCreatedAt() {
        assertThat(session.getCreatedAt()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetBrowserUrl() {
        assertThat(session.getBrowserUrl()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetPublicUrl() {
        assertThat(session.getPublicUrl()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetAppiumLogsUrl() {
        assertThat(session.getAppiumLogsUrl()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetVideoUrl() {
        assertThat(session.getVideoUrl()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetBrowserConsoleLogsUrl() {
        assertThat(session.getBrowserConsoleLogsUrl()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetHarLogsUrl() {
        assertThat(session.getHarLogsUrl()).isNotNull().isNotEmpty();
    }

    @Test
    public void canGetSeleniumLogsUrl() {
        assertThat(session.getSeleniumLogsUrl()).isNotNull().isNotEmpty();
    }


}

```