### PR TITLE
Find methods by param types

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/reflection/MethodFinder.java
+++ b/serenity-model/src/main/java/net/thucydides/core/reflection/MethodFinder.java
@@ -4,6 +4,7 @@ package net.thucydides.core.reflection;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class MethodFinder {
 
@@ -44,18 +45,24 @@ public class MethodFinder {
         return methodFound;
     }
 
-    public Method getMethodNamed(String methodName, int argumentCount) {
-        List<Method> methods = getAllMethods();
-        Method methodFound = null;
-        for (Method method : methods) {
-            if (method.getName().equals(methodName)) {
-                methodFound = method;
-                if (method.getParameterTypes().length == argumentCount){
-                    methodFound = method;
-                    break;
-                }
-            }
+    public Method getMethodNamed(String methodName, List<Object> arguments) {
+        List<Method> methodsFilteredByName = getAllMethods().stream()
+                .filter(m -> Objects.equals(methodName, m.getName()))
+                .collect(Collectors.toList());
+        if (methodsFilteredByName.isEmpty()) {
+            return null;
         }
-        return methodFound;
+        Class[] argumentTypes = arguments.stream().map(a -> a == null ? null : a.getClass()).toArray(Class[]::new);
+        Method foundMethod = methodsFilteredByName.stream()
+                .filter(m -> Arrays.equals(m.getParameterTypes(), argumentTypes))
+                .findFirst()
+                .orElse(null);
+        if (foundMethod == null) {
+            foundMethod = methodsFilteredByName.stream()
+                    .filter(m -> m.getParameterTypes().length == argumentTypes.length)
+                    .findFirst()
+                    .orElse(methodsFilteredByName.get(0));
+        }
+        return foundMethod;
     }
 }

--- a/serenity-model/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
+++ b/serenity-model/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
@@ -246,7 +246,7 @@ public final class AnnotatedStepDescription {
         }
 
         Optional<String> annotatedStepName = getAnnotatedStepName();
-        if (getAnnotatedStepName().isPresent() && (StringUtils.isNotEmpty(annotatedStepName.get()))) {
+        if (annotatedStepName.isPresent() && (StringUtils.isNotEmpty(annotatedStepName.get()))) {
             return annotatedStepNameWithParameters(annotatedStepName.get());
         }
 

--- a/serenity-model/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
+++ b/serenity-model/src/main/java/net/thucydides/core/steps/AnnotatedStepDescription.java
@@ -115,7 +115,7 @@ public final class AnnotatedStepDescription {
     }
 
     private Method findMethodCalled(final ExecutedStepDescription method, final Class<?> testClass) {
-        return MethodFinder.inClass(testClass).getMethodNamed(withNoArguments(method.getName()), method.getArguments().size());
+        return MethodFinder.inClass(testClass).getMethodNamed(withNoArguments(method.getName()), method.getRawArguments());
     }
 
     public String getAnnotatedTitle() {


### PR DESCRIPTION
Hi,
this PR should address 2 issues which we faced recently

a) while resolving step name, sometime we got not consistent results (`NoSuchElementException` was thrown at attempt to get value from `annotatedStepName` variable). The cause of this exception is that in `stepName()` method `isPresent()` is called not for variable, but for the result of another invocation of `getAnnotatedStepName()`). So it is possible that `annotatedStepName` is empty, but check won't catch it

b) find method not only by parameters count, but try to find by types first of all. it is possible to have several overloaded methods with the same name and parameters count, but different types, so it would be nice to find the right one. previous logic was preserved, so if for some reason we can't find method with exactly same parameters, we try to find by parameters count. if this doesn't work as well, try to return first method with provided name or null otherwise