### PR TITLE
Upgraded Guice to 5.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -75,7 +75,7 @@ shutterBugVersion=0.9.3
 
 # Scheduled for updates
 byteBuddyVersion = 1.10.10
-guiceVersion = 4.2.2
+guiceVersion = 5.0.1
 
 # Test-scope dependencies
 spockVersion = 2.0-M3-groovy-3.0

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <guava.version>30.1-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <guice.version>4.2.3</guice.version>
+        <guice.version>5.0.1</guice.version>
         <cucumber.version>6.10.2</cucumber.version>
         <gson.version>2.8.6</gson.version>
         <junit5.version>5.7.1</junit5.version>


### PR DESCRIPTION
Serenity BDD reports issues with illegal reflective access, caused by Guice (see google/guice#1133):
```
➜ npx serenity-bdd run                                                                                                                                                                                                                                                                                   20:02  [397ccd3]
Spawning: /usr/lib/jvm/java-11-openjdk-amd64/bin/java -Dserenity.compress.filenames=true -DLOG_LEVEL=warn -Dlogback.configurationFile=/home/rod/serenity-js-cucumber-protractor-template/node_modules/@serenity-js/serenity-bdd/resources/logback.config.xml -jar node_modules/@serenity-js/serenity-bdd/cache/serenity-cli-2.3.31.jar --destination target/site/serenity --features features --source target/site/serenity --project serenity-js-cucumber-protractor-template
-------------------------------
SERENITY COMMAND LINE INTERFACE
-------------------------------
Loading test outcomes from target/site/serenity
Writing aggregated report to target/site/serenity

WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/home/rod/serenity-js-cucumber-protractor-template/node_modules/@serenity-js/serenity-bdd/cache/serenity-cli-2.3.31.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Report generation done
```

The issue seems to have been fixed in Guice 5.0.1