### PR TITLE
Revert changes related to entering a value into element

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/EnterValueIntoElement.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/EnterValueIntoElement.java
@@ -16,7 +16,7 @@ public class EnterValueIntoElement extends EnterValue {
     @Step("{0} enters #theTextAsAString into #element")
     public <T extends Actor> void performAs(T theUser) {
         textValue().ifPresent(
-                text -> element.sendKeys(text)
+                text -> element.type(text)
         );
         if (getFollowedByKeys().length > 0) {
             element.sendKeys(getFollowedByKeys());

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/EnterValueIntoTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/EnterValueIntoTarget.java
@@ -16,7 +16,7 @@ public class EnterValueIntoTarget extends EnterValue {
     @Step("{0} enters #theTextAsAString into #target")
     public <T extends Actor> void performAs(T theUser) {
         textValue().ifPresent(
-                text -> target.resolveFor(theUser).sendKeys(text)
+                text -> target.resolveFor(theUser).type(text)
         );
         if (getFollowedByKeys().length > 0) {
             target.resolveFor(theUser).sendKeys(getFollowedByKeys());


### PR DESCRIPTION
In https://github.com/serenity-bdd/serenity-core/commit/d92aa0cfb46886c98cc734ae8feb3b96626cadd0 Enter actions were changed from type to sendActions which caused failures of tests. Instead of setting a value, value was getting appended to an existing one.