### PR TITLE
Resolve step objects dynamically

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/construction/StepsClassResolver.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/construction/StepsClassResolver.java
@@ -1,0 +1,5 @@
+package net.thucydides.core.steps.construction;
+
+public interface StepsClassResolver {
+    Class<?> resolveStepsClass(Class<?> original);
+}

--- a/serenity-core/src/test/java/net/thucydides/core/steps/WhenResolvingStepsObjects.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/WhenResolvingStepsObjects.java
@@ -1,0 +1,118 @@
+package net.thucydides.core.steps;
+
+import net.thucydides.core.annotations.Steps;
+import net.thucydides.core.steps.construction.StepsClassResolver;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class WhenResolvingStepsObjects {
+
+    private StepFactory stepFactory = StepFactory.getFactory();
+    private StepAnnotations stepAnnotations = StepAnnotations.injector();
+
+    private static final Map<Class, Class> classesStorage = new HashMap<>();
+
+    public static class StepsClassResolverImpl implements StepsClassResolver {
+        @Override
+        public Class<?> resolveStepsClass(Class<?> original) {
+            return classesStorage.get(original);
+        }
+    }
+
+    interface InterfaceSteps {
+        String step1();
+    }
+
+    static class InterfaceStepsImpl implements InterfaceSteps {
+        @Override
+        public String step1() {
+            return "InterfaceStepsImpl: step1";
+        }
+    }
+
+    static abstract class AbstractClassSteps {
+        public abstract String step1();
+    }
+
+    static class AbstractClassStepsImpl extends AbstractClassSteps {
+        @Override
+        public String step1() {
+            return "AbstractClassStepsImpl: step1";
+        }
+    }
+
+    static class SimpleBaseSteps  {
+        public String step1() {
+            return "SimpleBaseSteps: step1";
+        }
+    }
+
+    static class SimpleInheritedSteps extends SimpleBaseSteps {
+        public String step1() {
+            return "SimpleInheritedSteps: step1";
+        }
+    }
+
+    static class TestCaseWithInterfaceSteps {
+        @Steps
+        InterfaceSteps interfaceSteps;
+    }
+
+    static class TestCaseWithAbstractSteps {
+        @Steps
+        AbstractClassSteps abstractClassSteps;
+    }
+
+    static class TestCaseWithRegularSteps {
+        @Steps
+        SimpleBaseSteps simpleBaseSteps;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        classesStorage.clear();
+    }
+
+    @Test
+    public void should_resolve_implementation_for_interface_steps() {
+        classesStorage.put(InterfaceSteps.class, InterfaceStepsImpl.class);
+
+        TestCaseWithInterfaceSteps testCase = new TestCaseWithInterfaceSteps();
+        stepAnnotations.injectScenarioStepsInto(testCase, stepFactory);
+
+        Assert.assertEquals("InterfaceStepsImpl: step1", testCase.interfaceSteps.step1());
+    }
+
+    @Test
+    public void should_resolve_implementation_for_abstract_steps() {
+        classesStorage.put(AbstractClassSteps.class, AbstractClassStepsImpl.class);
+
+        TestCaseWithAbstractSteps testCase = new TestCaseWithAbstractSteps();
+        stepAnnotations.injectScenarioStepsInto(testCase, stepFactory);
+
+        Assert.assertEquals("AbstractClassStepsImpl: step1", testCase.abstractClassSteps.step1());
+    }
+
+    @Test
+    public void should_resolve_implementation_for_inherited_steps() {
+        classesStorage.put(SimpleBaseSteps.class, SimpleInheritedSteps.class);
+
+        TestCaseWithRegularSteps testCase = new TestCaseWithRegularSteps();
+        stepAnnotations.injectScenarioStepsInto(testCase, stepFactory);
+
+        Assert.assertEquals("SimpleInheritedSteps: step1", testCase.simpleBaseSteps.step1());
+    }
+
+    @Test
+    public void should_resolve_base_class_if_not_instructions_for_resolver() {
+        TestCaseWithRegularSteps testCase = new TestCaseWithRegularSteps();
+        stepAnnotations.injectScenarioStepsInto(testCase, stepFactory);
+
+        Assert.assertEquals("SimpleBaseSteps: step1", testCase.simpleBaseSteps.step1());
+    }
+
+}

--- a/serenity-core/src/test/resources/META-INF/services/net.thucydides.core.steps.construction.StepsClassResolver
+++ b/serenity-core/src/test/resources/META-INF/services/net.thucydides.core.steps.construction.StepsClassResolver
@@ -1,0 +1,1 @@
+net.thucydides.core.steps.WhenResolvingStepsObjects$StepsClassResolverImpl


### PR DESCRIPTION
I'd like to propose new feature to be added to Serenity - an option to resolve actual step object implementation at runtime. The idea behind that is to have several implementation of the same step object and provide possibility to pick up needed one based on some conditions or preferences. It might be the same action from business logic standpoint, but with some difference in the interactions with application under test. So we can extend parent class, override some method and then use this inherited class in some circumstances. 

It is completely up to the implementation how real class for the steps is resolved.

So now it should be possible to define step object as:
- interface
- abstract class
- regular class (and then define inherited class that should be used instead of parent)

In all of the cases above, actual implementation will be picked up based on the result of invocation of `StepsClassResolver#resolveStepsClass` method. The implementation is done with ServiceLoader concept, so there should be a class that implements `StepsClassResolver` interface and file placed in META-INF/services folder that fully qualify path to that implementation.

Also, it is possible to have a few resolves registered in the system, in such case first one that provides implementation for the class will be used.

For now I haven't put any logic to validate if provided class could be used to instantiate steps, so it is possible to specify invalid value in resolveStepsClass (e.g. class that doesn't implement interface or class that doesn't extend parent steps class). From my prospective it is zone of responsibility of the person who implements those concepts. General error messages should be helpful enough, as we have them now if you try to define steps object as something that couldn't instantiated.

From backward compatibility prospective there shouldn't be any impact - if no resolvers registered, steps will be instantiated with their originally defined class.

Set of basic unit tests added as well.

@wakaleo please take a look and let me know your thoughts.