### PR TITLE
Configure webdriver capabilities using maps/JSON objects

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/CapabilitySet.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/CapabilitySet.java
@@ -59,7 +59,10 @@ class CapabilitySet {
                     int lastColonIndex = capability.lastIndexOf(":", lastIndex);
                     if (lastColonIndex > 0) {
                         colonIndex = lastColonIndex;
-                        if ((capability.length() >= colonIndex + 1) && isFollowedByPathSeparator(capability, colonIndex)) {
+                        // Check if colon is part of file path or JSON object
+                        if ((capability.length() >= colonIndex + 1)
+                            && (isFollowedByPathSeparator(capability, colonIndex) || isWithinJsonObject(capability, colonIndex))) {
+
                             if (lastIndex == colonIndex - 1) {
                                 colonIndexFound = true;
                                 //been here before, only single colon followed by a path separator found
@@ -84,6 +87,16 @@ class CapabilitySet {
 
         private boolean isFollowedByPathSeparator(String capability, int colonIndex) {
             return (capability.charAt(colonIndex+1) =='\\') || (capability.charAt(colonIndex+1) =='/');
+        }
+
+        /**
+         * Check if colon is between opening and closing curly brackets
+         */
+        private boolean isWithinJsonObject(String capability, int colonIndex) {
+            int openingBracketIndex = capability.indexOf('{');
+            int closingBracketIndex = capability.indexOf('}');
+
+            return (openingBracketIndex > 0) && (openingBracketIndex < colonIndex) && (colonIndex < closingBracketIndex);
         }
 
         public String getName() {

--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/WhenConfiguringExtraWebdriverCapabilities.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/WhenConfiguringExtraWebdriverCapabilities.groovy
@@ -136,4 +136,14 @@ class WhenConfiguringExtraWebdriverCapabilities extends Specification {
         then:
         capabilitySet.capabilities == ["device":"iPhone 5S"]
     }
+
+    def "should add value-map capabilities"() {
+
+        given:
+        environmentVariables.setProperty("serenity.driver.capabilities","moon:options:{'enableVNC': true}")
+        when:
+        def capabilitySet = new CapabilitySet(environmentVariables)
+        then:
+        capabilitySet.capabilities == ["moon:options": ["enableVNC": true]]
+    }
 }


### PR DESCRIPTION
The problem was that nested JSON objects in capabilities configuration weren't correctly parsed. Instead of adding the whole JSON object as a value, first half of it was set as part of key.
The issue wasn't found previously because corresponding test wasn't written.
Additionally, adding a comment to the unclear logic in CapabilityToken.