### PR TITLE
fix: Adjusting AppiumConfiguration rules regarding browserName

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/appium/AppiumConfiguration.java
@@ -204,7 +204,7 @@ public class AppiumConfiguration {
     }
 
     private void ensureAppOrBrowserPathDefinedIn(Properties appiumProperties) {
-        if (!(appiumProperties.containsKey("app") || (appiumProperties.containsKey("appPackage") && appiumProperties.containsKey("appActivity"))  && !appiumProperties.containsKey("browserName"))) {
+        if (!(appiumProperties.containsKey("app") || (appiumProperties.containsKey("appPackage") && appiumProperties.containsKey("appActivity"))  || appiumProperties.containsKey("browserName"))) {
             throw new ThucydidesConfigurationException("The browser under test or path to the app or (appPackage and appActivity) needs to be provided in the appium.app or appium.browserName property.");
         }
     }

--- a/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
+++ b/serenity-core/src/test/groovy/net/thucydides/core/webdriver/appium/WhenConfiguringAnAppiumDriver.groovy
@@ -255,5 +255,43 @@ class WhenConfiguringAnAppiumDriver extends Specification {
 
     }
 
+    def "should be able to build appium mobile driver capabilities using only browserName without app, appPackage or appActivity"() {
+        given:
+        environmentVariables.setProperty("webdriver.driver", "appium")
+        environmentVariables.setProperty("appium.platformName", "Android")
+        environmentVariables.setProperty("appium.platformVersion", "9.0")
+        environmentVariables.setProperty("appium.browserName", "Chrome")
+        def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
+        when:
+        appiumConfiguration.capabilities
+        then:
+        appiumConfiguration.capabilities != null
+    }
 
+    def "should be able to build appium mobile driver capabilities using only app without appPackage, appActivity or browserName"() {
+        given:
+        environmentVariables.setProperty("webdriver.driver", "appium")
+        environmentVariables.setProperty("appium.platformName", "Android")
+        environmentVariables.setProperty("appium.platformVersion", "9.0")
+        environmentVariables.setProperty("appium.app", "MyCustomApp")
+        def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
+        when:
+        appiumConfiguration.capabilities
+        then:
+        appiumConfiguration.capabilities != null
+    }
+
+    def "should be able to build appium mobile driver capabilities using only appPackage and appActivity without app or browserName"() {
+        given:
+        environmentVariables.setProperty("webdriver.driver", "appium")
+        environmentVariables.setProperty("appium.platformName", "Android")
+        environmentVariables.setProperty("appium.platformVersion", "9.0")
+        environmentVariables.setProperty("appium.appPackage", "com.example.android.myApp")
+        environmentVariables.setProperty("appium.appActivity", "SplashActivity")
+        def appiumConfiguration = AppiumConfiguration.from(environmentVariables)
+        when:
+        appiumConfiguration.capabilities
+        then:
+        appiumConfiguration.capabilities != null
+    }
 }


### PR DESCRIPTION
#### Summary of this PR
Fix for wrong condition trowing an exception when creating an AppiumDriver using only appium.browserName for mobile browser tests on android. 

This PR actually make the framework according to the documentation example [here](https://serenity-bdd.github.io/theserenitybook/latest/remote.html#_running_tests_on_appium)

You can see that on the documentation example there is no app, appPackage or appName.
This was throwing the following exception: 
`ThucydidesConfigurationException("The browser under test or path to the app or (appPackage and appActivity) needs to be provided in the appium.app or appium.browserName property.")`

#### Intended effect
With this fix you can now successfully build appiumdriver (AndroidDriver) using only appium.browserName without the need to use appium.app, appium.appPackage or appium.appActivity.
#### How should this be manually tested?
It can be tested against any website using local appium server or remote one.
I tested against SauceLabs with the following serenity.properties config:

`webdriver.driver=appium
webdriver.base.url = https://www.wikipedia.org/
appium.hub = https://<yourSauceLabsCloud>:<YourKey>@ondemand.eu-central-1.saucelabs.com:443/wd/hub
appium.platformName = Android
appium.platformVersion = 9.0
appium.deviceName = Android GoogleAPI Emulator
appium.browserName = Chrome`

#### Side effects
There should be no side effect, since it is a fix to make it work as documentation actually mention. (check documentation bellow)
#### Documentation
This PR actually make the framework according to the documentation example [here](https://serenity-bdd.github.io/theserenitybook/latest/remote.html#_running_tests_on_appium)

#### Relevant tickets
Running browser based tests using AppiumDriver(AndroidDriver) throws expection when only using broserName #2587
#### Screenshots
Not applicable.