### PR TITLE
fix: Fix withQueryParameters() and withPathParameters() get wrong value

### DIFF
--- a/serenity-screenplay-rest/src/main/java/net/serenitybdd/screenplay/rest/questions/RestQuestionBuilder.java
+++ b/serenity-screenplay-rest/src/main/java/net/serenitybdd/screenplay/rest/questions/RestQuestionBuilder.java
@@ -43,7 +43,7 @@ public class RestQuestionBuilder<T> implements To<T>, Returning<T> {
         int paramIndex = 0;
         while (paramIndex < otherParams.length) {
             String param = otherParams[paramIndex].toString();
-            Object value = otherParams[paramIndex];
+            Object value = otherParams[paramIndex + 1];
             paramIndex = paramIndex + 2;
             RestQueryFunction restQueryFunction = request -> request.pathParam(param, value);
             this.queries.add(restQueryFunction);
@@ -68,7 +68,7 @@ public class RestQuestionBuilder<T> implements To<T>, Returning<T> {
         int paramIndex = 0;
         while (paramIndex < otherParams.length) {
             String param = otherParams[paramIndex].toString();
-            Object value = otherParams[paramIndex];
+            Object value = otherParams[paramIndex + 1];
             paramIndex = paramIndex + 2;
             this.queries.add(request -> request.queryParam(param, value));
         }


### PR DESCRIPTION
Now, `withQueryParameters(String param1, Object value1, Object... otherParams)` and `withPathParameters(String param1, Object value1, Object... otherParams)` get wrong value. For example

```
.withQueryParameters("page", page, "count", 1)
```
will produce wrong result
```
https://reqres.in/api/users?page=2&count=count
```

After the fix, the result will be
```
https://reqres.in/api/users?page=2&count=1
```
