### PR TITLE
Segregate junit4 dependencies 

### DIFF
--- a/serenity-cucumber/src/main/java/io/cucumber/core/plugin/LineFilters.java
+++ b/serenity-cucumber/src/main/java/io/cucumber/core/plugin/LineFilters.java
@@ -2,7 +2,7 @@ package io.cucumber.core.plugin;
 
 import io.cucumber.messages.types.Examples;
 import io.cucumber.messages.types.TableRow;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -29,7 +29,7 @@ public class LineFilters {
     }
 
     private Map<URI, Set<Integer>> newLineFilters() {
-        Map<URI, Set<Integer>> lineFiltersFromRuntime = CucumberWithSerenity.currentRuntimeOptions().getLineFilters();
+        Map<URI, Set<Integer>> lineFiltersFromRuntime = CucumberWithSerenityRuntime.currentRuntimeOptions().getLineFilters();
         if (lineFiltersFromRuntime == null) {
             return new HashMap<>();
         } else {

--- a/serenity-cucumber/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
+++ b/serenity-cucumber/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
@@ -16,7 +16,7 @@ import io.cucumber.tagexpressions.Expression;
 import net.serenitybdd.core.Serenity;
 import net.serenitybdd.core.SerenityListeners;
 import net.serenitybdd.core.SerenityReports;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.serenitybdd.cucumber.formatting.ScenarioOutlineDescription;
 import net.serenitybdd.cucumber.util.PathUtils;
 import net.serenitybdd.cucumber.util.StepDefinitionAnnotationReader;
@@ -33,7 +33,6 @@ import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.ThucydidesWebDriverSupport;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.internal.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -491,10 +490,10 @@ public class SerenityReporter implements Plugin, ConcurrentEventListener {
     }
 
     private List<Expression> getCucumberRuntimeTags() {
-        if (CucumberWithSerenity.currentRuntimeOptions() == null) {
+        if (CucumberWithSerenityRuntime.currentRuntimeOptions() == null) {
             return new ArrayList<>();
         } else {
-            return CucumberWithSerenity.currentRuntimeOptions().getTagExpressions();
+            return CucumberWithSerenityRuntime.currentRuntimeOptions().getTagExpressions();
         }
     }
 
@@ -914,7 +913,11 @@ public class SerenityReporter implements Plugin, ConcurrentEventListener {
     }
 
     private boolean isAssumptionFailure(Throwable rootCause) {
-        return (AssumptionViolatedException.class.isAssignableFrom(rootCause.getClass()));
+    	try {
+			return (Class.forName("org.junit.internal.AssumptionViolatedException").isAssignableFrom(rootCause.getClass()));
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
     }
 
     private String stepTitleFrom(io.cucumber.messages.types.Step currentStep, TestStep testStep) {

--- a/serenity-cucumber/src/main/java/io/cucumber/junit/LiteralExpression.java
+++ b/serenity-cucumber/src/main/java/io/cucumber/junit/LiteralExpression.java
@@ -8,7 +8,7 @@ public class LiteralExpression implements Expression {
 
     private final String value;
 
-    LiteralExpression(String value) {
+    public LiteralExpression(String value) {
         this.value = value;
     }
 

--- a/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/CucumberWithSerenityRuntime.java
+++ b/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/CucumberWithSerenityRuntime.java
@@ -1,12 +1,30 @@
 package net.serenitybdd.cucumber;
 
 
+import io.cucumber.core.eventbus.EventBus;
+import io.cucumber.core.feature.FeatureParser;
+import io.cucumber.core.options.CucumberProperties;
+import io.cucumber.core.options.CucumberPropertiesParser;
 import io.cucumber.core.options.RuntimeOptions;
+import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.core.plugin.SerenityReporter;
+import io.cucumber.core.runtime.FeaturePathFeatureSupplier;
 import io.cucumber.core.runtime.Runtime;
+import io.cucumber.core.runtime.TimeServiceEventBus;
+import io.cucumber.junit.LiteralExpression;
+import net.serenitybdd.cucumber.util.Splitter;
+import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
+import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
 
+import static java.util.stream.Collectors.toList;
+
+import java.time.Clock;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 
@@ -19,18 +37,91 @@ public class CucumberWithSerenityRuntime {
     }
 
 
-    private static Runtime createSerenityEnabledRuntime(Supplier<ClassLoader> classLoaderSupplier,
-                                                        RuntimeOptions runtimeOptions,
-                                                        Configuration systemConfiguration) {
-        //ClassFinder resolvedClassFinder = Optional.ofNullable(classFinder).orElse(new ResourceLoaderClassFinder(resourceLoader, classLoader));
-        SerenityReporter reporter = new SerenityReporter(systemConfiguration);
-        //Runtime runtime = Runtime.builder().withResourceLoader(resourceLoader).withClassFinder(resolvedClassFinder).
-        //        withClassLoader(classLoader).withRuntimeOptions(runtimeOptions).withAdditionalPlugins(reporter).build();
+	public static Runtime createSerenityEnabledRuntime(/*ResourceLoader resourceLoader,*/
+	        Supplier<ClassLoader> classLoaderSupplier,
+	        RuntimeOptions runtimeOptions,
+	        Configuration systemConfiguration) {
+	    RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
+	    Collection<String> allTagFilters = environmentSpecifiedTags(runtimeOptions.getTagExpressions());
+	    for (String tagFilter : allTagFilters) {
+	        runtimeOptionsBuilder.addTagFilter(new LiteralExpression(tagFilter));
+	    }
+	    runtimeOptionsBuilder.build(runtimeOptions);
+	    setRuntimeOptions(runtimeOptions);
+	
+	
+	    EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
+	    FeatureParser parser = new FeatureParser(bus::generateId);
+	    FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoaderSupplier, runtimeOptions, parser);
+	
+	    SerenityReporter serenityReporter = new SerenityReporter(systemConfiguration);
+	    Runtime runtime = Runtime.builder().withClassLoader(classLoaderSupplier).withRuntimeOptions(runtimeOptions).
+	            withAdditionalPlugins(serenityReporter).
+	            withEventBus(bus).withFeatureSupplier(featureSupplier).
+	            build();
+	
+	    return runtime;
+	}
 
-        Runtime runtime = Runtime.builder().
-                withClassLoader(classLoaderSupplier).
-                withRuntimeOptions(runtimeOptions).
-                withAdditionalPlugins(reporter).build();
-        return runtime;
-    }
+	public static ThreadLocal<RuntimeOptions> RUNTIME_OPTIONS = new ThreadLocal<>();
+	public static RuntimeOptions DEFAULT_RUNTIME_OPTIONS = buildRuntimeOptions(null);
+
+
+	public static RuntimeOptions buildRuntimeOptions(Function<RuntimeOptions, RuntimeOptions> configurer) {
+	    RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
+	            .parse(CucumberProperties.fromPropertiesFile())
+	            .build();
+	
+	    RuntimeOptions annotationOptions = configurer != null ?
+	    		configurer.apply(propertiesFileOptions) : propertiesFileOptions;
+	
+	    RuntimeOptions environmentOptions = new CucumberPropertiesParser()
+	            .parse(CucumberProperties.fromEnvironment())
+	            .build(annotationOptions);
+	
+	    RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
+	            .parse(CucumberProperties.fromSystemProperties())
+	            .addDefaultSummaryPrinterIfNotDisabled()
+	            .build(environmentOptions);
+	
+	    RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
+	    Collection<String> tagFilters = environmentSpecifiedTags(runtimeOptions.getTagExpressions());
+	    for (String tagFilter : tagFilters) {
+	        runtimeOptionsBuilder.addTagFilter(new LiteralExpression(tagFilter));
+	    }
+	    runtimeOptionsBuilder.build(runtimeOptions);
+	    return runtimeOptions;
+	}
+
+
+	public static void setRuntimeOptions(RuntimeOptions runtimeOptions) {
+	    RUNTIME_OPTIONS.set(runtimeOptions);
+	}
+
+
+	public static RuntimeOptions currentRuntimeOptions() {
+	    return (RUNTIME_OPTIONS.get() != null) ? RUNTIME_OPTIONS.get() : DEFAULT_RUNTIME_OPTIONS;
+	}
+
+
+	private static Collection<String> environmentSpecifiedTags(List<?> existingTags) {
+	    EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+	    String tagsExpression = ThucydidesSystemProperty.TAGS.from(environmentVariables, "");
+	    List<String> existingTagsValues = existingTags.stream().map(Object::toString).collect(toList());
+	    return Splitter.on(",").trimResults().omitEmptyStrings().splitToList(tagsExpression).stream()
+	            .map(CucumberWithSerenityRuntime::toCucumberTag).filter(t -> !existingTagsValues.contains(t)).collect(toList());
+	}
+
+
+	public static String toCucumberTag(String from) {
+	    String tag = from.replaceAll(":", "=");
+	    if (tag.startsWith("~@") || tag.startsWith("@")) {
+	        return tag;
+	    }
+	    if (tag.startsWith("~")) {
+	        return "~@" + tag.substring(1);
+	    }
+	
+	    return "@" + tag;
+	}
 }

--- a/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/cli/Main.java
+++ b/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/cli/Main.java
@@ -4,7 +4,6 @@ import io.cucumber.core.options.CommandlineOptionsParser;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.runtime.Runtime;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
 import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 
 import java.io.IOException;
@@ -21,7 +20,7 @@ public class Main {
 
     public static byte run(String[] argv, Supplier<ClassLoader> classLoaderSupplier) throws IOException {
         RuntimeOptions  runtimeOptions = new CommandlineOptionsParser(System.out).parse(argv).build() ;
-        CucumberWithSerenity.setRuntimeOptions(runtimeOptions);
+        CucumberWithSerenityRuntime.setRuntimeOptions(runtimeOptions);
         Runtime runtime = CucumberWithSerenityRuntime.using(classLoaderSupplier, runtimeOptions);
 
         runtime.run();

--- a/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/integration/intellij/CucumberWithSerenityRuntimeMain.java
+++ b/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/integration/intellij/CucumberWithSerenityRuntimeMain.java
@@ -4,7 +4,7 @@ import io.cucumber.core.options.CommandlineOptionsParser;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.runtime.Runtime;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.webdriver.Configuration;
 
@@ -42,7 +42,7 @@ public class CucumberWithSerenityRuntimeMain {
         //ResourceLoader resourceLoader = new MultiLoader(classLoader);
         Configuration systemConfiguration = Injectors.getInjector().getInstance(Configuration.class);
         //Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
-        Runtime serenityRuntime = CucumberWithSerenity.createSerenityEnabledRuntime(/*resourceLoader,*/
+        Runtime serenityRuntime = CucumberWithSerenityRuntime.createSerenityEnabledRuntime(/*resourceLoader,*/
                 classLoaderSupplier,
                 runtimeOptions,
                 systemConfiguration);

--- a/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/model/StoredFeatureFile.java
+++ b/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/model/StoredFeatureFile.java
@@ -1,6 +1,6 @@
 package net.serenitybdd.cucumber.model;
 
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class StoredFeatureFile {
     
 
     public File fromTheConfiguredPaths() throws IOException {
-        for(URI uri : CucumberWithSerenity.currentRuntimeOptions().getFeaturePaths()) {
+        for(URI uri : CucumberWithSerenityRuntime.currentRuntimeOptions().getFeaturePaths()) {
             if (Files.exists(candidatePath(uri, featureFileName))) {
                 return candidatePath(uri, featureFileName).toFile();
             }

--- a/serenity-cucumber/src/test/java/io/cucumber/junit/CucumberRunner.java
+++ b/serenity-cucumber/src/test/java/io/cucumber/junit/CucumberRunner.java
@@ -5,7 +5,7 @@ import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.runtime.Runtime;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.thucydides.core.configuration.SystemPropertiesConfiguration;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.SystemEnvironmentVariables;
@@ -43,7 +43,7 @@ public class CucumberRunner {
         Configuration systemConfiguration = new SystemPropertiesConfiguration(environmentVariables);
         systemConfiguration.setOutputDirectory(outputDirectory);
         Supplier<ClassLoader> classLoaderSupplier = ClassLoaders::getDefaultClassLoader;
-        return CucumberWithSerenity.createSerenityEnabledRuntime(classLoaderSupplier, annotationOptions, systemConfiguration);
+        return CucumberWithSerenityRuntime.createSerenityEnabledRuntime(classLoaderSupplier, annotationOptions, systemConfiguration);
     }
 
     public static Runtime serenityRunnerForCucumberTestRunner(Class testClass, Configuration systemConfiguration) {
@@ -58,7 +58,7 @@ public class CucumberRunner {
         RuntimeOptions runtimeOptionsBuilder =  new RuntimeOptionsBuilder().build(annotationOptions);
 
         Supplier<ClassLoader> classLoaderSupplier = ClassLoaders::getDefaultClassLoader;
-        return CucumberWithSerenity.createSerenityEnabledRuntime( classLoaderSupplier,  runtimeOptionsBuilder, systemConfiguration);
+        return CucumberWithSerenityRuntime.createSerenityEnabledRuntime( classLoaderSupplier,  runtimeOptionsBuilder, systemConfiguration);
     }
 
 }


### PR DESCRIPTION
to allow using with cucumber-junit-platform-engine and junit-platform-suite

followup of https://github.com/serenity-bdd/serenity-cucumber6/issues/35 and https://github.com/serenity-bdd/serenity-cucumber5/pull/3

makes https://github.com/nicerloop/serenity-cucumber-starter/tree/use-cucumber-junit-platform-engine-7.0.0 work
