### PR TITLE
serenity-junit5: replace junti4 with org.opentest4j pendants

### DIFF
--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/PendingTestException.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/PendingTestException.java
@@ -1,21 +1,14 @@
 package net.serenitybdd.junit5;
 
-import org.hamcrest.Matcher;
-import org.junit.AssumptionViolatedException;
+import org.opentest4j.TestAbortedException;
 
-public class PendingTestException extends AssumptionViolatedException {
-    public <T> PendingTestException(T actual, Matcher<T> matcher) {
-        super(actual, matcher);
-    }
-
-    public <T> PendingTestException(String message, T expected, Matcher<T> matcher) {
-        super(message, expected, matcher);
-    }
+public class PendingTestException extends TestAbortedException {
 
     public PendingTestException(String message) {
         super(message);
     }
 
+    @SuppressWarnings("unused")
     public PendingTestException(String message, Throwable t) {
         super(message, t);
     }

--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/SkippedTestException.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/SkippedTestException.java
@@ -1,21 +1,14 @@
 package net.serenitybdd.junit5;
 
-import org.hamcrest.Matcher;
-import org.junit.AssumptionViolatedException;
+import org.opentest4j.TestAbortedException;
 
-public class SkippedTestException extends AssumptionViolatedException {
-    public <T> SkippedTestException(T actual, Matcher<T> matcher) {
-        super(actual, matcher);
-    }
-
-    public <T> SkippedTestException(String message, T expected, Matcher<T> matcher) {
-        super(message, expected, matcher);
-    }
+public class SkippedTestException extends TestAbortedException {
 
     public SkippedTestException(String message) {
         super(message);
     }
 
+    @SuppressWarnings("unused")
     public SkippedTestException(String message, Throwable t) {
         super(message, t);
     }


### PR DESCRIPTION
replaced junit4 dependency with junit5 compatible version of org.opentest4j to solve  #2686