### PR TITLE
:ambulance: FIX an error when executing actions on After methods

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/CleanupMethodLocator.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/CleanupMethodLocator.java
@@ -23,7 +23,7 @@ public class CleanupMethodLocator {
         return stream(stackTrace).anyMatch(this::isAnnotatedWithAFixtureMethod);
     }
 
-    private List<String> DEFAULT_CLEANUP_PACKAGES_TO_SKIP = Arrays.asList(
+    private final List<String> DEFAULT_CLEANUP_PACKAGES_TO_SKIP = Arrays.asList(
             "java.lang",
             "net.serenitybdd.core",
             "net.thucydides",
@@ -38,13 +38,10 @@ public class CleanupMethodLocator {
             Optional<Method> fixtureMethod = stream(forName(stackTraceElement.getClassName()).getMethods())
                                                             .filter(method -> method.getName().equals(stackTraceElement.getMethodName())).findFirst();
 
-            if (!fixtureMethod.isPresent()) {
-                return false;
-            }
-            return (stream(fixtureMethod.get().getAnnotations()).anyMatch(
+            return fixtureMethod.map(method -> (stream(method.getAnnotations()).anyMatch(
                     annotation -> (isAnAfterAnnotation(annotation.annotationType().getSimpleName())
                             || cleanupMethodsAnnotations.contains(annotation.toString()))
-            ));
+            ))).orElse(false);
         } catch (ClassNotFoundException ignored) {
             return false;
         }

--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
@@ -533,15 +533,17 @@ public class StepEventBus {
         driverReenabled = true;
     }
 
-    private boolean inFixureMethod() {
-        boolean activateWebDriverInFixtureMethods = SERENITY_ENABLE_WEBDRIVER_IN_FIXTURE_METHODS.booleanFrom(environmentVariables, true);
+    public boolean inFixtureMethod() {
+        return cleanupMethodLocator.currentMethodWasCalledFromACleanupMethod();
+    }
 
-        return (activateWebDriverInFixtureMethods && cleanupMethodLocator.currentMethodWasCalledFromACleanupMethod());
+    private boolean activateWebDriverInFixtureMethods() {
+        return SERENITY_ENABLE_WEBDRIVER_IN_FIXTURE_METHODS.booleanFrom(environmentVariables, true);
     }
 
     public boolean webdriverCallsAreSuspended() {
 
-        if (driverReenabled || inFixureMethod()) {
+        if (driverReenabled || (inFixtureMethod() && activateWebDriverInFixtureMethods())) {
             return false;
         }
         if (softAssertsActive()) {
@@ -943,7 +945,7 @@ public class StepEventBus {
     public boolean isASingleBrowserScenario() {
         return uniqueSession
                 || currentTestHasTag(TestTag.withValue("singlebrowser"))
-                ||  baseStepListener.currentStoryHasTag(TestTag.withValue("singlebrowser"));
+                || baseStepListener.currentStoryHasTag(TestTag.withValue("singlebrowser"));
     }
 
     public boolean isNewSingleBrowserScenario() {

--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
@@ -411,7 +411,7 @@ public class StepInterceptor implements MethodErrorReporter,Interceptor {
     }
 
     private boolean shouldRunInDryRunMode(final Method methodOrStep, final Class callingClass) {
-        return ((aPreviousStepHasFailed() || testIsPending() || isDryRun()) && declaredInSameDomain(methodOrStep, callingClass));
+        return !stepIsCalledFromCleanupMethod() && ((aPreviousStepHasFailed() || testIsPending() || isDryRun()) && declaredInSameDomain(methodOrStep, callingClass));
     }
 
     public void reportMethodError(Throwable generalException, Object obj, Method method, Object[] args) throws Throwable {

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/Actor.java
@@ -15,6 +15,8 @@ import net.thucydides.core.annotations.Step;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.steps.ExecutedStepDescription;
 import net.thucydides.core.steps.StepEventBus;
+import net.thucydides.core.steps.StepFactory;
+import net.thucydides.core.steps.StepInterceptor;
 import net.thucydides.core.util.EnvironmentVariables;
 
 import java.lang.reflect.Method;
@@ -418,7 +420,8 @@ public class Actor implements PerformsTasks, SkipNested, Agent {
 
     private void endPerformance(ErrorHandlingMode mode) {
         Broadcaster.getEventBus().post(new ActorEndsPerformanceEvent(name));
-        if (mode == THROW_EXCEPTION_ON_FAILURE) {
+        boolean isAFixtureMethod = StepEventBus.getEventBus().inFixtureMethod();
+        if (mode == THROW_EXCEPTION_ON_FAILURE && !isAFixtureMethod) {
             eventBusInterface.failureCause().ifPresent(
                     cause -> {
                         StepEventBus.getEventBus().notifyFailure();


### PR DESCRIPTION
Currently when an action or screenplay task is executed on the `@after` method, if the task was a Rest interaction then an NPE will be thrown if a previous step in the test had failed, this was due to the way how serenity invokes methods through byte-buddy, this PR, adds a logic to avoid DryRunExecution when a method is called inside a clean method (After hooks in Cucumber), with this fix when a method is invoked inside an After hook then a normal execution will be used.

With the previous fix, another thing appears, on Screenplay when a Task or Consequence is evaluated, at the end any previous exception will be rethrown which causes that if in an After hook you have multiple actions only the first one is executed, to avoid this, now the `endperfomance` logic will check if currently, we are in a fixture method (After hook) in which case the rethrown will not happen to allow the execution of all the actions or assertions inside the After hook.


FIX #2627 

@wakaleo  let me know what u think.