### PR TITLE
fix: BrowserStack session properties not parsed correctly if null

### DIFF
--- a/serenity-browserstack/src/main/java/net/serenitybdd/browserstack/BrowserStackTestSession.java
+++ b/serenity-browserstack/src/main/java/net/serenitybdd/browserstack/BrowserStackTestSession.java
@@ -2,6 +2,7 @@ package net.serenitybdd.browserstack;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.stream.MalformedJsonException;
 import net.thucydides.core.model.TestOutcome;
@@ -171,7 +172,8 @@ public class BrowserStackTestSession {
         }
 
         JsonElement automationSession = sessionElement.getAsJsonObject().get("automation_session");
-        return automationSession.getAsJsonObject().get(propertyName).getAsString();
+        JsonElement element = automationSession.getAsJsonObject().get(propertyName);
+        return element.isJsonNull() ? null : element.getAsString();
     }
 
 


### PR DESCRIPTION
#### Summary of this PR
Fixes a minor issue. Retrieving null session properties should no longer throw an exception.

#### How should this be manually tested?
- Attempt to retrieve a session property that is null (e.g. The browser version of a mobile device).
- This should no longer throw an exception

