### PR TITLE
Update SerenityTestExecutionListener.java

### DIFF
--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/SerenityTestExecutionListener.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/SerenityTestExecutionListener.java
@@ -151,7 +151,7 @@ public class SerenityTestExecutionListener implements TestExecutionListener {
             String methodParameterTypes = methodTestSource.getMethodParameterTypes();
             List<Class> methodParameterClasses = null;
 
-            if (methodParameterTypes != null) {
+            if (methodParameterTypes != null !methodParameterTypes.isEmpty()) {
                 methodParameterClasses = Arrays.asList(methodParameterTypes.split(",")).stream().map(parameterClassName -> {
                     try {
                         //ClassUtils handles also simple data type like int, char..


### PR DESCRIPTION
check if methodParameterTypes is not empty before trying to get the method parameter classes.

FIX #2723