### PR TITLE
:bug: Fix Appium errors taking screenshot

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/photography/WebDriverScreenShooter.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/photography/WebDriverScreenShooter.java
@@ -1,5 +1,6 @@
 package net.serenitybdd.core.photography;
 
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -25,7 +26,7 @@ public class WebDriverScreenShooter implements ScreenShooter {
     public byte[] takeScreenshot() throws IOException {
         try {
             return (driver instanceof TakesScreenshot) ? ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES) : new byte[]{};
-        } catch(ScreenshotException failedToTakeScreenshot) {
+        } catch(Exception failedToTakeScreenshot) {
             LOGGER.warn("Failed to take screenshot - Selenium reported the following error", failedToTakeScreenshot);
             return new byte[]{};
         }

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/SerenityWebdriverManager.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/SerenityWebdriverManager.java
@@ -1,5 +1,6 @@
 package net.thucydides.core.webdriver;
 
+import io.appium.java_client.AppiumDriver;
 import net.thucydides.core.util.EnvironmentVariables;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.WebDriver;
@@ -157,6 +158,9 @@ public class SerenityWebdriverManager implements WebdriverManager {
     private String nameOf(WebDriver driver) {
         if (driver instanceof WebDriverFacade) {
             return ((WebDriverFacade) driver).getDriverName();
+        }
+        if(driver instanceof AppiumDriver){
+            return "appium";
         }
         if ((driver instanceof RemoteWebDriver) && ((RemoteWebDriver) driver).getCapabilities() != null) {
             return ((RemoteWebDriver) driver).getCapabilities().getBrowserName();

--- a/serenity-core/src/main/java/net/thucydides/core/webdriver/WebdriverInstances.java
+++ b/serenity-core/src/main/java/net/thucydides/core/webdriver/WebdriverInstances.java
@@ -171,10 +171,18 @@ public class WebdriverInstances {
     }
 
     private boolean matchingDriver(WebDriver mappedDriver, WebDriver driver) {
+        //compare using equals assuming both are Webdriver
+
         if (mappedDriver == driver) {
             return true;
         }
 
+        //compare now if mapped is Facade and expedted driver is not
+        if (mappedDriver instanceof WebDriverFacade && !(driver instanceof WebDriverFacade)) {
+            return ((WebDriverFacade) mappedDriver).proxiedWebDriver == driver;
+        }
+
+        //lastly assume driver is facade
         return ((driver instanceof WebDriverFacade) && (mappedDriver == ((WebDriverFacade) driver).proxiedWebDriver));
     }
 
@@ -250,9 +258,18 @@ public class WebdriverInstances {
 
 
         public void forDriver(final WebDriver driver) {
-            if (!driverMap.values().contains(driver)) {
+            boolean alreadyInMap = false;
+            //check if the driver is not already present in driverMap
+            for (WebDriver mappedDriver : driverMap.values()) {
+                alreadyInMap = matchingDriver(mappedDriver, driver);
+                if (alreadyInMap)
+                    break;
+            }
+            //if driver is not present, then add it
+            if (!alreadyInMap) {
                 driverMap.put(driverName, driver);
             }
+
         }
     }
 


### PR DESCRIPTION
1. When a new driver is going to be added to the map of the Webdriver instance, Serenity will check using a more smart approach, first, it will check if both drivers are equals, if not then it will see if the mapped driver is a Facade and the new driver is not, in that case, the check will happen against the proxied driver, finally, if previous checks fail it will assume the new driver is a facade and mapped one isn't.

2. If the driver is Appiumdriver assume the driver name as appium, currently chrome was used.

3. If an exception happens taking a screenshot, log a warn, it doesn't matter the exception type. 

FIX #2757 