### PR TITLE
fix: PageObject#open() with parameters adds base url twice to page DefaultUrl

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/PageUrls.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/PageUrls.java
@@ -178,12 +178,12 @@ public class PageUrls {
     private String urlWithParametersSubstituted(final String template,
                                                 final String[] parameterValues) {
 
-        String url = addBaseUrlTo(template);
+        String url = template;
         for (int i = 0; i < parameterValues.length; i++) {
             String variable = String.format("{%d}", i + 1);
             url = url.replace(variable, parameterValues[i]);
         }
-//        return addBaseUrlTo(url);
+
         return url;
     }
 


### PR DESCRIPTION
Fixes issue #2753.

When calling 
`page.open(withParameters(...))`

webdriver.base.url won`t be processed twice.