### PR TITLE
fix: (gradle) serenity-junit fix dependencies leak (fixes #2815)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -402,11 +402,11 @@ subprojects {
                     }
                     // Preserve compile-scope dependencies
                     asNode().dependencies.'*'.findAll() {
-                        it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
+                        it.scope.text() == 'runtime' && project.configurations.implementation.allDependencies.find { dep ->
                             dep.name == it.artifactId.text()
                         }
                     }.each() {
-                        it.scope*.value = 'compile'
+                        it.scope*.value = 'implementation'
                     }
                 }
             }
@@ -435,7 +435,7 @@ subprojects {
     }
 
     task copyDeps(type: Copy) {
-        from configurations.runtime + configurations.testCompile
+        from configurations.runtime + configurations.testImplementation
         into project.projectDir.path + "/lib"
     }
 

--- a/serenity-ant-task/build.gradle
+++ b/serenity-ant-task/build.gradle
@@ -4,9 +4,9 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile "org.apache.ant:ant:${antVersion}"
+    implementation project(':serenity-core')
+    implementation "org.apache.ant:ant:${antVersion}"
 
-    testCompile ("org.apache.ant:ant-testutil:${antVersion}")
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation ("org.apache.ant:ant-testutil:${antVersion}")
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 }

--- a/serenity-asciidoc/build.gradle
+++ b/serenity-asciidoc/build.gradle
@@ -19,20 +19,20 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-model')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation project(':serenity-model')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    compile "org.freemarker:freemarker:${freemarkerVersion}"
-    compile("ca.szc.thirdparty.nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.0") {
+    implementation "org.freemarker:freemarker:${freemarkerVersion}"
+    implementation("ca.szc.thirdparty.nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.0") {
         exclude group: "org.ow2.asm", module: "asm"
         exclude group: "org.jsoup", module: "jsoup"
     }
 
     // TEST DEPENDENCIES
-    testCompile project(':serenity-core')
-    testCompile project(':serenity-junit')
-    testCompile ("net.serenity-bdd:serenity-cucumber:$serenity_cucumber_version") {
+    testImplementation project(':serenity-core')
+    testImplementation project(':serenity-junit')
+    testImplementation ("net.serenity-bdd:serenity-cucumber:$serenity_cucumber_version") {
         exclude group:"net.serenity-bdd", module: "serenity-core"
         exclude group:"org.slf4j", module: "slf4j-api"
     }

--- a/serenity-assertions/build.gradle
+++ b/serenity-assertions/build.gradle
@@ -3,8 +3,9 @@ ext {
 }
 
 dependencies {
-    compile 'org.assertj:assertj-core:3.12.2'
-    compile project(':serenity-core')
-    testCompile project(':serenity-screenplay')
-    testCompile project(':serenity-junit')
+    implementation project(':serenity-core')
+    implementation project(':serenity-junit')
+    implementation project(':serenity-screenplay')
+    implementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "junit:junit:${junitVersion}"
 }

--- a/serenity-browsermob-plugin/build.gradle
+++ b/serenity-browsermob-plugin/build.gradle
@@ -4,21 +4,21 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-model')
-    compile("net.lightbody.bmp:browsermob-core:${browsermobVersion}") {
+    implementation project(':serenity-core')
+    implementation project(':serenity-model')
+    implementation("net.lightbody.bmp:browsermob-core:${browsermobVersion}") {
         exclude group:'io.netty' ,module:'netty-all'
         exclude group: 'com.fasterxml.jackson.core', module:'jackson-annotations'
         exclude group: 'org.bouncycastle', module:'bcprov-jdk15on'
 	}
-    compile "io.netty:netty-all:4.1.69.Final"
-    compile "org.bouncycastle:bcprov-jdk15on:1.69"
-    compile "org.opentest4j:opentest4j:1.2.0"
+    implementation "io.netty:netty-all:4.1.69.Final"
+    implementation "org.bouncycastle:bcprov-jdk15on:1.69"
+    implementation "org.opentest4j:opentest4j:1.2.0"
 
     // TEST DEPENDENCIES
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile("org.spockframework:spock-core:${spockVersion}") {
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group:'org.junit.platform', module:'junit-platform-engine'
     }
 }

--- a/serenity-browserstack/build.gradle
+++ b/serenity-browserstack/build.gradle
@@ -3,10 +3,10 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile "org.apache.httpcomponents:httpcore:4.4.14"
-    compile "org.apache.httpcomponents:httpclient:4.5.13"
+    implementation project(':serenity-core')
+    implementation "org.apache.httpcomponents:httpcore:4.4.14"
+    implementation "org.apache.httpcomponents:httpclient:4.5.13"
     // TEST DEPENDENCIES
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "junit:junit:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "junit:junit:${junitVersion}"
 }

--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -38,45 +38,45 @@ integrationTests {
 //}
 dependencies {
 
-    compile project(':serenity-model')
-    compile project(':serenity-reports')
-    compile project(':serenity-report-resources')
-    compile "com.google.code.gson:gson:${gsonVersion}"
-    compile "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
-    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
-    compile "commons-codec:commons-codec:${commonsCodecVersion}"
-    compile "commons-io:commons-io:${commonsIoVersion}"
+    api project(':serenity-model')
+    api project(':serenity-reports')
+    implementation project(':serenity-report-resources')
+    api "com.google.code.gson:gson:${gsonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    implementation "commons-codec:commons-codec:${commonsCodecVersion}"
+    implementation "commons-io:commons-io:${commonsIoVersion}"
     // Selenium
-    compile("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {
+    api("org.seleniumhq.selenium:selenium-java:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile("org.seleniumhq.selenium:selenium-api:$seleniumVersion") {
+    api("org.seleniumhq.selenium:selenium-api:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile("org.seleniumhq.selenium:selenium-support:$seleniumVersion") {
+    implementation("org.seleniumhq.selenium:selenium-support:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile("org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion") {
+    implementation("org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile("org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion") {
+    implementation("org.seleniumhq.selenium:selenium-firefox-driver:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile("org.seleniumhq.selenium:selenium-edge-driver:$seleniumVersion") {
+    implementation("org.seleniumhq.selenium:selenium-edge-driver:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile("org.seleniumhq.selenium:selenium-ie-driver:$seleniumVersion") {
+    implementation("org.seleniumhq.selenium:selenium-ie-driver:$seleniumVersion") {
         exclude group: "net.bytebuddy", module:"byte-buddy"
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
     }
-    compile "org.projectlombok:lombok:1.18.20"
-    compile("io.appium:java-client:${appiumJavaClientVersion}") {
+    implementation "org.projectlombok:lombok:1.18.20"
+    api("io.appium:java-client:${appiumJavaClientVersion}") {
         exclude group: 'org.seleniumhq.selenium'
         exclude group: 'cglib', module: 'cglib'
         exclude group: 'junit', module: 'junit'
@@ -90,46 +90,46 @@ dependencies {
         exclude group: "net.bytebuddy", module:"byte-buddy-agent"
         exclude group: "org.springframework", module:"spring-context"
     }
-    compile "org.apache.groovy:groovy:${groovyVersion}"
-    compile "net.sf.opencsv:opencsv:${openCsvVersion}"
-    compile("commons-beanutils:commons-beanutils:${beanUtilsVersion}") {
+    api "org.apache.groovy:groovy:${groovyVersion}"
+    api "net.sf.opencsv:opencsv:${openCsvVersion}"
+    implementation("commons-beanutils:commons-beanutils:${beanUtilsVersion}") {
         exclude group: 'commons-logging', module: 'commons-logging'
     }
-    compile "org.apache.commons:commons-lang3:${commonsLang3Version}"
-    compile "commons-collections:commons-collections:${commonsCollectionsVersion}"
-    compile("org.fluentlenium:fluentlenium-core:${fluentleniumVersion}") {
+    implementation "org.apache.commons:commons-lang3:${commonsLang3Version}"
+    implementation "commons-collections:commons-collections:${commonsCollectionsVersion}"
+    implementation("org.fluentlenium:fluentlenium-core:${fluentleniumVersion}") {
         exclude group: 'org.seleniumhq.selenium', module: 'selenium-java'
         exclude group: 'junit', module: 'junit-dep'
     }
-    compile "io.github.bonigarcia:webdrivermanager:${webdrivermanagerVersion}"
-    compile "com.jhlabs:filters:${jhlabfiltersVersion}"
-    compile "com.paulhammant:ngwebdriver:${ngwebdriver}"
-    compile "joda-time:joda-time:${jodaTimeVersion}"
-    compile "org.hamcrest:hamcrest:${hamcrestVersion}"
-    compile "com.google.jimfs:jimfs:${jimfsVersion}"
-    compile "org.mockito:mockito-core:${mockitoCoreVersion}"
+    api "io.github.bonigarcia:webdrivermanager:${webdrivermanagerVersion}"
+    implementation "com.jhlabs:filters:${jhlabfiltersVersion}"
+    implementation "com.paulhammant:ngwebdriver:${ngwebdriver}"
+    implementation "joda-time:joda-time:${jodaTimeVersion}"
+    api "org.hamcrest:hamcrest:${hamcrestVersion}"
+    implementation "com.google.jimfs:jimfs:${jimfsVersion}"
+    api "org.mockito:mockito-core:${mockitoCoreVersion}"
 
     // TEST DEPENDENCIES
-    testCompile "junit:junit:${junitVersion}"
+    testImplementation "junit:junit:${junitVersion}"
     api "org.assertj:assertj-core:${assertjVersion}"
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    testCompile("org.spockframework:spock-core:${spockVersion}") {
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group: 'org.junit.platform', module:'junit-platform-engine'
     }
-    testCompile "org.springframework:spring-context:${springVersion}"
-    testCompile "org.springframework:spring-context-support:${springVersion}"
-    testCompile "org.springframework:spring-test:${springVersion}"
-    testCompile "org.skyscreamer:jsonassert:${jsonassertVersion}"
-    testCompile("org.jbehave:jbehave-core:${jbehaveVersion}") {
+    testImplementation "org.springframework:spring-context:${springVersion}"
+    testImplementation "org.springframework:spring-context-support:${springVersion}"
+    testImplementation "org.springframework:spring-test:${springVersion}"
+    testImplementation "org.skyscreamer:jsonassert:${jsonassertVersion}"
+    testImplementation("org.jbehave:jbehave-core:${jbehaveVersion}") {
         exclude module: 'freemarker'
         exclude module: 'junit'
         exclude module: 'xstream'
     }
-    compile "javax.xml.bind:jaxb-api:2.3.1"
-    compile "com.sun.xml.bind:jaxb-core:2.3.0.1"
-    compile "com.sun.xml.bind:jaxb-impl:2.3.3"
-    compile "javax.activation:activation:1.1.1"
+    implementation "javax.xml.bind:jaxb-api:2.3.1"
+    implementation "com.sun.xml.bind:jaxb-core:2.3.0.1"
+    implementation "com.sun.xml.bind:jaxb-impl:2.3.3"
+    implementation "javax.activation:activation:1.1.1"
 }
 
 processResources {

--- a/serenity-crossbrowsertesting/build.gradle
+++ b/serenity-crossbrowsertesting/build.gradle
@@ -3,10 +3,10 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-model')
-    compile group: 'com.konghq', name: 'unirest-java', version: '3.11.10'
+    implementation project(':serenity-core')
+    implementation project(':serenity-model')
+    implementation group: 'com.konghq', name: 'unirest-java', version: '3.11.10'
     // TEST DEPENDENCIES
-    compile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    compile "junit:junit:${junitVersion}"
+    implementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    implementation "junit:junit:${junitVersion}"
 }

--- a/serenity-ensure/build.gradle
+++ b/serenity-ensure/build.gradle
@@ -24,16 +24,16 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-model')
-    compile project(':serenity-junit')
-    compile project(':serenity-screenplay')
-    compile project(':serenity-screenplay-webdriver')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':serenity-model')
+    implementation project(':serenity-junit')
+    implementation project(':serenity-screenplay')
+    implementation project(':serenity-screenplay-webdriver')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    compile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    implementation "org.assertj:assertj-core:${assertjVersion}"
 }
 
 repositories {

--- a/serenity-json-summary-report/build.gradle
+++ b/serenity-json-summary-report/build.gradle
@@ -24,14 +24,14 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-stats')
-    compile project(':serenity-model')
-    compile project(':serenity-reports')
-    compile project(':serenity-reports-configuration')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':serenity-stats')
+    implementation project(':serenity-model')
+    implementation project(':serenity-reports')
+    implementation project(':serenity-reports-configuration')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 }
 
 repositories {

--- a/serenity-junit/build.gradle
+++ b/serenity-junit/build.gradle
@@ -8,24 +8,24 @@ test {
 }
 
 configurations {
-    compile {
+    implementation {
         exclude group: 'org.junit.jupiter'
     }
-    testCompile {
+    testImplementation {
         exclude group: 'org.junit.jupiter'
     }
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile "junit:junit:${junitVersion}"
+    implementation project(':serenity-core')
+    implementation "junit:junit:${junitVersion}"
     // TEST DEPENDENCIES
-    compile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    compile("org.spockframework:spock-core:${spockVersion}") {
+    implementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    implementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group:'org.junit.platform', module:'junit-platform-engine'
     }
-    compile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    testCompile "org.springframework:spring-jdbc:${springVersion}"
-    testCompile "org.springframework:spring-aop:${springVersion}"
-    testCompile "org.springframework:spring-orm:${springVersion}"
+    implementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testImplementation "org.springframework:spring-jdbc:${springVersion}"
+    testImplementation "org.springframework:spring-aop:${springVersion}"
+    testImplementation "org.springframework:spring-orm:${springVersion}"
 }

--- a/serenity-junit/build.gradle
+++ b/serenity-junit/build.gradle
@@ -17,7 +17,7 @@ configurations {
 }
 
 dependencies {
-    implementation project(':serenity-core')
+    api project(':serenity-core')
     implementation "junit:junit:${junitVersion}"
     // TEST DEPENDENCIES
     implementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"

--- a/serenity-junit5/build.gradle
+++ b/serenity-junit5/build.gradle
@@ -8,20 +8,20 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-model')
+    implementation project(':serenity-core')
+    implementation project(':serenity-model')
 
     // TEST DEPENDENCIES
-    compile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    compile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    compile "org.junit.jupiter:junit-jupiter-params:${junit5Version}"
-    compile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    compile "org.junit.platform:junit-platform-launcher:1.8.1"
-    compile "junit:junit:${junitVersion}"
-    compile("org.spockframework:spock-core:${spockVersion}") {
+    implementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    implementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    implementation "org.junit.jupiter:junit-jupiter-params:${junit5Version}"
+    implementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    implementation "org.junit.platform:junit-platform-launcher:1.8.1"
+    implementation "junit:junit:${junitVersion}"
+    implementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group:'org.junit.platform', module:'junit-platform-engine'
     }
-    compile "org.springframework:spring-core:${springVersion}"
-    testCompile "org.springframework:spring-aop:${springVersion}"
-    testCompile "org.springframework:spring-orm:${springVersion}"
+    implementation "org.springframework:spring-core:${springVersion}"
+    testImplementation "org.springframework:spring-aop:${springVersion}"
+    testImplementation "org.springframework:spring-orm:${springVersion}"
 }

--- a/serenity-model/build.gradle
+++ b/serenity-model/build.gradle
@@ -5,53 +5,53 @@ ext {
 
 dependencies {
 
-    compile project(':serenity-report-resources')
-    compile project(':serenity-sample-alternative-resources')
+    implementation project(':serenity-report-resources')
+    implementation project(':serenity-sample-alternative-resources')
 
-    compile "org.apache.commons:commons-lang3:${commonsLang3Version}"
-    testCompile "commons-lang:commons-lang:${commonsLang2Version}"
-    compile "commons-io:commons-io:${commonsIoVersion}"
-    compile "org.apache.commons:commons-text:${commonsTextVersion}"
-    compile "commons-beanutils:commons-beanutils-core:${beanUtilsVersion}"
-    compile "commons-net:commons-net:${commonsNetVersion}"
-    compile "commons-collections:commons-collections:${commonsCollectionsVersion}"
-    compile "commons-codec:commons-codec:${commonsCodecVersion}"
-    compile "com.google.guava:guava:${guavaVersion}"
-    compile "org.slf4j:slf4j-api:${slf4jVersion}"
-    compile "org.hamcrest:hamcrest:${hamcrestVersion}"
-    compile "com.google.inject:guice:${guiceVersion}"
-    compile "org.jsoup:jsoup:${jsoupVersion}"
-    compile "com.thoughtworks.xstream:xstream:${xstreamVersion}"
-    compile "joda-time:joda-time:${jodaTimeVersion}"
-    compile "io.cucumber:cucumber-core:${cucumberVersion}"
-    compile "io.cucumber:cucumber-java:${cucumberVersion}"
-    compile "com.google.code.gson:gson:${gsonVersion}"
-    compile "net.sf.opencsv:opencsv:${openCsvVersion}"
-    compile "com.typesafe:config:${typesafeConfigVersion}"
-    compile "org.imgscalr:imgscalr-lib:${imgscalrVersion}"
-    compile "org.awaitility:awaitility:${awaitilityVersion}"
-    compile "org.freemarker:freemarker:${freemarkerVersion}"
-    compile "io.github.classgraph:classgraph:4.8.138"
-    compile("net.sourceforge.jexcelapi:jxl:${jexcelapiVersion}") {
+    api "org.apache.commons:commons-lang3:${commonsLang3Version}"
+    testImplementation "commons-lang:commons-lang:${commonsLang2Version}"
+    api "commons-io:commons-io:${commonsIoVersion}"
+    implementation "org.apache.commons:commons-text:${commonsTextVersion}"
+    implementation "commons-beanutils:commons-beanutils-core:${beanUtilsVersion}"
+    implementation "commons-net:commons-net:${commonsNetVersion}"
+    implementation "commons-collections:commons-collections:${commonsCollectionsVersion}"
+    implementation "commons-codec:commons-codec:${commonsCodecVersion}"
+    implementation "com.google.guava:guava:${guavaVersion}"
+    api "org.slf4j:slf4j-api:${slf4jVersion}"
+    implementation "org.hamcrest:hamcrest:${hamcrestVersion}"
+    api "com.google.inject:guice:${guiceVersion}"
+    api "org.jsoup:jsoup:${jsoupVersion}"
+    implementation "com.thoughtworks.xstream:xstream:${xstreamVersion}"
+    api "joda-time:joda-time:${jodaTimeVersion}"
+    api "io.cucumber:cucumber-core:${cucumberVersion}"
+    api "io.cucumber:cucumber-java:${cucumberVersion}"
+    api "com.google.code.gson:gson:${gsonVersion}"
+    api "net.sf.opencsv:opencsv:${openCsvVersion}"
+    implementation "com.typesafe:config:${typesafeConfigVersion}"
+    implementation "org.imgscalr:imgscalr-lib:${imgscalrVersion}"
+    api "org.awaitility:awaitility:${awaitilityVersion}"
+    api "org.freemarker:freemarker:${freemarkerVersion}"
+    implementation "io.github.classgraph:classgraph:4.8.138"
+    implementation("net.sourceforge.jexcelapi:jxl:${jexcelapiVersion}") {
         exclude group: 'log4j', module: 'log4j'
     }
-    compile "org.apache.groovy:groovy:${groovyVersion}"
-    compile "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
-    compile "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
-    compile "org.objenesis:objenesis:${objenesisVersion}"
+    implementation "org.apache.groovy:groovy:${groovyVersion}"
+    implementation "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
+    implementation "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
+    implementation "org.objenesis:objenesis:${objenesisVersion}"
 
     // TEST DEPENDENCIES
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    testCompile("org.spockframework:spock-core:${spockVersion}") {
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group: "org.junit.platform"
     }
-    testCompile("org.mockito:mockito-core:${mockitoCoreVersion}") {
+    testImplementation("org.mockito:mockito-core:${mockitoCoreVersion}") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
         exclude group: 'org.objenesis', module: 'objenesis'
         exclude group: 'net.bytebuddy', module: 'byte-buddy'
         exclude group: 'net.bytebuddy', module: 'byte-buddy-agent'
     }
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 }

--- a/serenity-navigator-report/build.gradle
+++ b/serenity-navigator-report/build.gradle
@@ -22,17 +22,17 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-model')
-    compile project(':serenity-stats')
-    compile project(':serenity-reports')
-    compile "org.apache.commons:commons-compress:1.21"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
-    compile "org.apache.commons:commons-compress:$commonsCompressVersion"
-    compile "org.jsoup:jsoup:${jsoupVersion}"
+    implementation project(':serenity-model')
+    implementation project(':serenity-stats')
+    implementation project(':serenity-reports')
+    implementation "org.apache.commons:commons-compress:1.21"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlin_version}"
+    implementation "org.apache.commons:commons-compress:$commonsCompressVersion"
+    implementation "org.jsoup:jsoup:${jsoupVersion}"
     // JUNIT DEPENDENCIES
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junit5Version}"
 }
 

--- a/serenity-reports-configuration/build.gradle
+++ b/serenity-reports-configuration/build.gradle
@@ -24,13 +24,13 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-model')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':serenity-model')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     // Testing Dependencies
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 }
 
 repositories {

--- a/serenity-reports/build.gradle
+++ b/serenity-reports/build.gradle
@@ -27,39 +27,39 @@ compileTestKotlin {
 }
 
 dependencies {
-    compile project(':serenity-model')
-    compile project(':serenity-stats')
-    compile project(':serenity-reports-configuration')
-    compile("com.vladsch.flexmark:flexmark-all:0.34.30") {
+    implementation project(':serenity-model')
+    implementation project(':serenity-stats')
+    api project(':serenity-reports-configuration')
+    api("com.vladsch.flexmark:flexmark-all:0.34.30") {
         exclude group:'org.jsoup', module:'jsoup'
         exclude group:'junit', module:'junit'
     }
-    compile "es.nitaur.markdown:txtmark:0.16"
+    implementation "es.nitaur.markdown:txtmark:0.16"
 
     // Test Dependencies
-    testCompile project(':serenity-sample-alternative-resources')
+    testImplementation project(':serenity-sample-alternative-resources')
     // JUNIT DEPENDENCIES
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile("org.spockframework:spock-core:${spockVersion}") {
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group:'org.junit.platform', module:'junit-platform-engine'
     }
 
     // SELENIUM
-    testCompile("org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion") {
+    testImplementation("org.seleniumhq.selenium:selenium-chrome-driver:$seleniumVersion") {
         exclude group:'net.bytebuddy', module:'byte-buddy'
         exclude group:'net.bytebuddy', module:'byte-buddy-agent'
     }
-    testCompile "org.skyscreamer:jsonassert:${jsonassertVersion}"
-    testCompile("org.mockito:mockito-core:${mockitoCoreVersion}") {
+    testImplementation "org.skyscreamer:jsonassert:${jsonassertVersion}"
+    testImplementation("org.mockito:mockito-core:${mockitoCoreVersion}") {
         exclude group:'org.hamcrest', module:'harmcrest-core'
         exclude group:'org.objenesis', module:'oobjenesis'
         exclude group:'net.bytebuddy', module:'byte-buddy'
         exclude group:'net.bytebuddy', module:'byte-buddy-agent'
     }
-    testCompile "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
-    testCompile "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
-    testCompile "org.objenesis:objenesis:${objenesisVersion}"
+    testImplementation "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
+    testImplementation "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
+    testImplementation "org.objenesis:objenesis:${objenesisVersion}"
 }
 

--- a/serenity-rest-assured/build.gradle
+++ b/serenity-rest-assured/build.gradle
@@ -4,9 +4,9 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile "org.apache.httpcomponents:httpclient:4.5.13"
-    compile ("io.rest-assured:rest-assured:${restAssuredVersion}") {
+    implementation project(':serenity-core')
+    implementation "org.apache.httpcomponents:httpclient:4.5.13"
+    api ("io.rest-assured:rest-assured:${restAssuredVersion}") {
         //exclude group: 'io.rest-assured', module:'json-path'
         //exclude group: 'io.rest-assured', module:'xml-path'
 //        exclude group: 'org.apache.httpcomponents', module:'httpclient'
@@ -16,10 +16,10 @@ dependencies {
 //        exclude group: 'org.codehaus.groovy', module:'groovy-xml'
 //        exclude group: 'org.apache.commons', module:'commons-lang3'
     }
-    compile "org.apache.groovy:groovy-json:${groovyVersion}"
-    compile "org.apache.groovy:groovy-xml:${groovyVersion}"
-    compile "org.apache.groovy:groovy:${groovyVersion}"
-    compile("com.github.tomakehurst:wiremock:${wiremockVersion}") {
+    implementation "org.apache.groovy:groovy-json:${groovyVersion}"
+    implementation "org.apache.groovy:groovy-xml:${groovyVersion}"
+    implementation "org.apache.groovy:groovy:${groovyVersion}"
+    implementation("com.github.tomakehurst:wiremock:${wiremockVersion}") {
         exclude group:'com.google.guava', module:'guava'
         exclude group:'org.apache.httpcomponents', module:'httpclient'
         exclude group:'org.slf4j', module:'slf4j-api'
@@ -28,11 +28,11 @@ dependencies {
         exclude group:'org.eclipse.jetty', module:'jetty-io'
     }
     // TEST DEPENDENCIES
-    compile "org.opentest4j:opentest4j:1.2.0"
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    testCompile "org.junit.jupiter:junit-jupiter-params:${junit5Version}"
-    testCompile ("org.spockframework:spock-core:${spockVersion}") {
+    implementation "org.opentest4j:opentest4j:1.2.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit5Version}"
+    testImplementation ("org.spockframework:spock-core:${spockVersion}") {
         exclude group: 'org.junit.platform', module: 'junit-platform-engine'
     }
 }

--- a/serenity-sample-alternative-resources/build.gradle
+++ b/serenity-sample-alternative-resources/build.gradle
@@ -3,5 +3,5 @@ ext {
 }
 
 dependencies {
-    compile "junit:junit:${junitVersion}"
+    implementation "junit:junit:${junitVersion}"
 }

--- a/serenity-saucelabs/build.gradle
+++ b/serenity-saucelabs/build.gradle
@@ -3,10 +3,10 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-rest-assured')
-    compile project(':serenity-junit')
+    implementation project(':serenity-core')
+    implementation project(':serenity-rest-assured')
+    implementation project(':serenity-junit')
     // TEST DEPENDENCIES
-    testCompile "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "junit:junit:${junitVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
+    testImplementation "junit:junit:${junitVersion}"
 }

--- a/serenity-screenplay-rest/build.gradle
+++ b/serenity-screenplay-rest/build.gradle
@@ -4,8 +4,13 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-rest-assured')
-    compile project(':serenity-screenplay')
-    testCompile project(':serenity-junit')
+    implementation project(':serenity-core')
+    implementation project(':serenity-rest-assured')
+    implementation project(':serenity-screenplay')
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation project(':serenity-junit')
+
+    // Unit testing
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
 }

--- a/serenity-screenplay-webdriver/build.gradle
+++ b/serenity-screenplay-webdriver/build.gradle
@@ -4,7 +4,16 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-screenplay')
-    testCompile project(':serenity-junit')
+    implementation project(':serenity-core')
+    implementation project(':serenity-screenplay')
+    // Unit testing
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation project(':serenity-junit')
+    testImplementation project(':serenity-junit5')
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    implementation("org.spockframework:spock-core:${spockVersion}") {
+        exclude group:'org.junit.platform', module:'junit-platform-engine'
+    }
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 }

--- a/serenity-screenplay/build.gradle
+++ b/serenity-screenplay/build.gradle
@@ -4,13 +4,13 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile "junit:junit:${junitVersion}"
+    implementation project(':serenity-core')
+    implementation "junit:junit:${junitVersion}"
 
     // Unit testing
-    testCompile project(':serenity-junit')
-    testCompile "org.spockframework:spock-core:${spockVersion}"
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    compile project(':serenity-model')
+    testImplementation project(':serenity-junit')
+    testImplementation "org.spockframework:spock-core:${spockVersion}"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    implementation project(':serenity-model')
 }

--- a/serenity-shutterbug/build.gradle
+++ b/serenity-shutterbug/build.gradle
@@ -3,8 +3,8 @@ ext {
 }
 
 dependencies {
-    compile 'org.assertj:assertj-core:3.12.2'
-    compile project(':serenity-core')
-    testCompile project(':serenity-screenplay')
-    testCompile project(':serenity-junit')
+    implementation 'org.assertj:assertj-core:3.12.2'
+    implementation project(':serenity-core')
+    testImplementation project(':serenity-screenplay')
+    testImplementation project(':serenity-junit')
 }

--- a/serenity-shutterbug1x/build.gradle
+++ b/serenity-shutterbug1x/build.gradle
@@ -3,8 +3,8 @@ ext {
 }
 
 dependencies {
-    compile 'org.assertj:assertj-core:3.12.2'
-    compile project(':serenity-core')
-    testCompile project(':serenity-screenplay')
-    testCompile project(':serenity-junit')
+    implementation 'org.assertj:assertj-core:3.12.2'
+    implementation project(':serenity-core')
+    testImplementation project(':serenity-screenplay')
+    testImplementation project(':serenity-junit')
 }

--- a/serenity-single-page-report/build.gradle
+++ b/serenity-single-page-report/build.gradle
@@ -23,24 +23,24 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-stats')
-    compile project(':serenity-model')
-    compile project(':serenity-reports')
-    compile project(':serenity-reports-configuration')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile ("org.thymeleaf:thymeleaf:${thymeleafVersion}") {
+    implementation project(':serenity-stats')
+    implementation project(':serenity-model')
+    implementation project(':serenity-reports')
+    implementation project(':serenity-reports-configuration')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation ("org.thymeleaf:thymeleaf:${thymeleafVersion}") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'org.javassist'
     }
-    compile("org.javassist:javassist:${javassistVersion}")
-    compile "org.knowm.xchart:xchart:${xchartVersion}"
-    compile ('org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE') {
+    implementation("org.javassist:javassist:${javassistVersion}")
+    implementation "org.knowm.xchart:xchart:${xchartVersion}"
+    implementation ('org.thymeleaf.extras:thymeleaf-extras-java8time:3.0.4.RELEASE') {
         exclude group: "org.thymeleaf", module:"thymeleaf"
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     testImplementation"org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 }
 repositories {
     mavenCentral()

--- a/serenity-smoketests/build.gradle
+++ b/serenity-smoketests/build.gradle
@@ -50,18 +50,18 @@ apply plugin: "net.serenity-bdd.aggregator"
 println "serenityCoreVersion= $serenityCoreVersion"
 
 dependencies {
-    compile "net.serenity-bdd:serenity-core:$serenityCoreVersion"
-    compile "net.serenity-bdd:serenity-junit:$serenityCoreVersion"
-    compile("net.serenity-bdd:serenity-screenplay:$serenityCoreVersion")
-    compile("net.serenity-bdd:serenity-screenplay-webdriver:$serenityCoreVersion")
-    compile("net.serenity-bdd:serenity-cucumber:$serenityCoreVersion")
-    compile("net.serenity-bdd:serenity-browserstack:$serenityCoreVersion")
-    compile("net.serenity-bdd:serenity-saucelabs:$serenityCoreVersion")
+    implementation "net.serenity-bdd:serenity-core:$serenityCoreVersion"
+    implementation "net.serenity-bdd:serenity-junit:$serenityCoreVersion"
+    implementation("net.serenity-bdd:serenity-screenplay:$serenityCoreVersion")
+    implementation("net.serenity-bdd:serenity-screenplay-webdriver:$serenityCoreVersion")
+    implementation("net.serenity-bdd:serenity-cucumber:$serenityCoreVersion")
+    implementation("net.serenity-bdd:serenity-browserstack:$serenityCoreVersion")
+    implementation("net.serenity-bdd:serenity-saucelabs:$serenityCoreVersion")
 
-    compile 'org.slf4j:slf4j-simple:1.7.30'
-    testCompile "junit:junit:4.13.1"
-    compile 'org.assertj:assertj-core:3.18.0'
-    compile 'org.hamcrest:hamcrest:2.2'
+    implementation 'org.slf4j:slf4j-simple:1.7.30'
+    testImplementation "junit:junit:4.13.1"
+    implementation 'org.assertj:assertj-core:3.18.0'
+    implementation 'org.hamcrest:hamcrest:2.2'
 }
 
 
@@ -80,6 +80,6 @@ task wrapper(type: Wrapper) {
 }
 
 task copyDeps(type: Copy) {
-    from configurations.runtime + configurations.testCompile
+    from configurations.runtime + configurations.testImplementation
     into project.projectDir.path + "/lib"
 }

--- a/serenity-spring/build.gradle
+++ b/serenity-spring/build.gradle
@@ -4,24 +4,24 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
-    compile project(':serenity-junit')
-    compile "junit:junit:${junitVersion}"
-    compile ("org.springframework:spring-test:${springVersion}")
-    compile ("org.springframework:spring-context:${springVersion}")
-    compile ("org.springframework:spring-context-support:${springVersion}")
+    implementation project(':serenity-core')
+    implementation project(':serenity-junit')
+    implementation "junit:junit:${junitVersion}"
+    implementation ("org.springframework:spring-test:${springVersion}")
+    implementation ("org.springframework:spring-context:${springVersion}")
+    implementation ("org.springframework:spring-context-support:${springVersion}")
 
     // Unit testing
-    testCompile "org.springframework:spring-jdbc:${springVersion}"
-    testCompile "org.springframework:spring-aop:${springVersion}"
-    testCompile "org.springframework:spring-orm:${springVersion}"
-    testCompile("org.springframework.boot:spring-boot-test:${springBootVersion}") {
+    testImplementation "org.springframework:spring-jdbc:${springVersion}"
+    testImplementation "org.springframework:spring-aop:${springVersion}"
+    testImplementation "org.springframework:spring-orm:${springVersion}"
+    testImplementation("org.springframework.boot:spring-boot-test:${springBootVersion}") {
         exclude group:'org.springframework', module:'spring-context'
         exclude group:'org.springframework', module:'spring-core'
     }
-    testCompile 'commons-dbcp:commons-dbcp:1.4'
-    testCompile 'javax.annotation:javax.annotation-api:1.3.2'
-    testCompile ("org.hibernate:hibernate-entitymanager:5.2.12.Final") {
+    testImplementation 'commons-dbcp:commons-dbcp:1.4'
+    testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
+    testImplementation ("org.hibernate:hibernate-entitymanager:5.2.12.Final") {
         exclude group: 'commons-logging'
         exclude group: 'org.javassist'
         exclude group: 'org.slf4j'
@@ -29,6 +29,10 @@ dependencies {
         exclude group: 'org.jboss.logging'
         exclude group: 'com.fasterxml', module:'classmate'
     }
+    testImplementation("org.spockframework:spock-core:${spockVersion}") {
+        exclude group: "org.junit.platform"
+    }
+    implementation "org.opentest4j:opentest4j:1.2.0"
 }
 
 test {

--- a/serenity-stats/build.gradle
+++ b/serenity-stats/build.gradle
@@ -24,21 +24,21 @@ test {
 }
 
 dependencies {
-    compile project(':serenity-model')
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation project(':serenity-model')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     // Testing Dependencies
-    testCompile "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
-    testCompile("org.mockito:mockito-core:${mockitoCoreVersion}") {
+    testImplementation("org.mockito:mockito-core:${mockitoCoreVersion}") {
         exclude group:'org.objenesis', module:'objenesis'
         exclude group:'net.bytebuddy', module:'byte-buddy'
         exclude group:'net.bytebuddy', module:'byte-buddy-agent'
     }
-    testCompile "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
-    testCompile "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
-    testCompile "org.objenesis:objenesis:${objenesisVersion}"
+    testImplementation "net.bytebuddy:byte-buddy:${byteBuddyVersion}"
+    testImplementation "net.bytebuddy:byte-buddy-agent:${byteBuddyVersion}"
+    testImplementation "org.objenesis:objenesis:${objenesisVersion}"
 
 }
 repositories {

--- a/serenity-zalenium/build.gradle
+++ b/serenity-zalenium/build.gradle
@@ -3,10 +3,10 @@ ext {
 }
 
 dependencies {
-    compile project(':serenity-core')
+    implementation project(':serenity-core')
     // Unit testing
-    testCompile "junit:junit:${junitVersion}"
-    testCompile project(':serenity-junit')
-    testCompile "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
-    testCompile "org.junit.vintage:junit-vintage-engine:${junit5Version}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation project(':serenity-junit')
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junit5Version}"
+    testImplementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
 }


### PR DESCRIPTION
The gradle build for serenity-junit was using `compile` and `testCompile` configurations that leak dependencies to external projects. This commit fixes the leak