### PR TITLE
style: rename maven module serenity-browsermob-plugin

### DIFF
--- a/serenity-browsermob-plugin/pom.xml
+++ b/serenity-browsermob-plugin/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <artifactId>serenity-browsermob-plugin</artifactId>
     <packaging>jar</packaging>
-    <name>Serenity Report Resources</name>
+    <name>Serenity BrowserMob Plugin</name>
     <properties>
         <browsermob.version>2.1.5</browsermob.version>
     </properties>


### PR DESCRIPTION
to reflect its purpose. Original name was wrong probably due to copy/paste.