### PR TITLE
Make bindings customizable

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/core/guice/Injectors.java
+++ b/serenity-model/src/main/java/net/thucydides/core/guice/Injectors.java
@@ -1,32 +1,47 @@
 package net.thucydides.core.guice;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
 
 /**
  * Somewhere to hold the Guice injector.
  * There might be a better way to do this.
  */
 public class Injectors {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Injectors.class);
 
-    private static Map<String,Injector>  injectors = Collections.synchronizedMap(new HashMap<>());
+    private static final Map<String, Injector> injectors = Collections.synchronizedMap(new HashMap<>());
 
+    private static Module defaultModule;
+
+    public static synchronized void setDefaultModule(Module module) {
+        defaultModule = module;
+        LOGGER.trace("Set default guice module {}", module);
+    }
 
     public static synchronized Injector getInjector() {
-        return getInjector(new ThucydidesModule());
+        if (defaultModule == null) {
+            defaultModule = new ThucydidesModule();
+        }
+        return getInjector(defaultModule);
     }
-    
+
     public static synchronized Injector getInjector(com.google.inject.Module module) {
         String moduleClassName = module.getClass().getCanonicalName();
         Injector injector = injectors.get(moduleClassName);
         if (injector == null) {
-    		injector = Guice.createInjector(module);
-    		injectors.put(moduleClassName, injector);
-    	}
-    	return injector;
+            injector = Guice.createInjector(module);
+            injectors.put(moduleClassName, injector);
+            LOGGER.debug("Created injector for module {}", moduleClassName);
+        }
+        return injector;
     }
 }

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
@@ -53,7 +53,6 @@ public class HtmlAggregateStoryReporter extends HtmlReporter implements UserStor
     private final ReportNameProvider reportNameProvider;
     private final Requirements requirements;
 
-    private final EnvironmentVariables environmentVariables;
     private FormatConfiguration formatConfiguration;
     private boolean generateTestOutcomeReports = false;
 
@@ -100,11 +99,11 @@ public class HtmlAggregateStoryReporter extends HtmlReporter implements UserStor
                                       final IssueTracking issueTracking,
                                       final EnvironmentVariables environmentVariables,
                                       final Requirements requirements) {
+        super(environmentVariables);
         this.projectName = projectName;
         this.relativeLink = relativeLink;
         this.issueTracking = issueTracking;
         this.requirementsConfiguration = new RequirementsConfiguration(getEnvironmentVariables());
-        this.environmentVariables = environmentVariables;
         this.formatConfiguration = new FormatConfiguration(environmentVariables);
         this.reportNameProvider = new ReportNameProvider(NO_CONTEXT, ReportType.HTML, requirements.getRequirementsService());
         this.requirements = requirements;

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlReporter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlReporter.java
@@ -33,7 +33,7 @@ public abstract class HtmlReporter extends ThucydidesReporter {
     private static final String DEFAULT_SOURCE_DIR = "target/site/serenity";
     private String resourceDirectory = DEFAULT_RESOURCE_DIRECTORY;
     private final TemplateManager templateManager;
-    private final EnvironmentVariables environmentVariables;
+    protected final EnvironmentVariables environmentVariables;
     private final Charset charset;
     protected final ConsoleColors colored;
 


### PR DESCRIPTION
The current guice module configuration (https://github.com/serenity-bdd/serenity-core/blob/cfecbd98a95e875d7540c0b8123d3e33363d4ed7/serenity-model/src/main/java/net/thucydides/core/guice/ThucydidesModule.java#L68-L72) declares https://github.com/serenity-bdd/serenity-core/blob/008f81a8e37d87a4b3b6711e252b4ffd897f2e34/serenity-model/src/main/java/net/thucydides/core/util/EnvironmentVariables.java as Singletone.

When using gradle in its default configuration as daemon and applying the serenity-gradle-plugin, this Singleton is created on first run and cannot be modified later. Any configuration change requires restarting the gradle daemon. What is worse is that there is no indication of this happening.

This PR allows for providing a different guice configuration. The serenity-gradle-plugin can use `Injectors#setDefaultModule` to provide an alternative no-singleton guice configuration, where `EnvironmentVariables` would be recreated on demand.