### PR TITLE
fix: passing the blacklisted headers list to the logging so it will be masked in logs

### DIFF
--- a/serenity-rest-assured/src/main/java/net/serenitybdd/rest/filters/FieldsRecordingFilter.java
+++ b/serenity-rest-assured/src/main/java/net/serenitybdd/rest/filters/FieldsRecordingFilter.java
@@ -36,7 +36,7 @@ public class FieldsRecordingFilter implements Filter {
         BlacklistFilter blacklistFilter = new BlacklistFilter(requestSpec.getConfig().getLogConfig().blacklistedHeaders());
         try (ByteArrayOutputStream output = new ByteArrayOutputStream();
              PrintStream recordingStream = new PrintStream(output, true, StandardCharsets.UTF_8.toString())) {
-            final RequestLoggingFilter filter = new RequestLoggingFilter(this.logDetail, shouldPrettyPrint, recordingStream);
+            final RequestLoggingFilter filter = new RequestLoggingFilter(this.logDetail, shouldPrettyPrint, recordingStream,true,requestSpec.getConfig().getLogConfig().blacklistedHeaders());
             final Response response = filter.filter(requestSpec, responseSpec, ctx);
             recordingStream.flush();
             this.recorded = new String(output.toByteArray(), StandardCharsets.UTF_8);


### PR DESCRIPTION
Description: Passing the blacklisted headers list to the logging filter, so headers will be masked in the logs output.

Background: Original issue to mask blacklisted headers was to mask these headers in both report and logs. https://github.com/serenity-bdd/serenity-core/issues/2660.
But its only masking the reports and not in logs. After this fix it will mask in the logs as well.