### PR TITLE
fix: change is no currently matcher error messages

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/matchers/statematchers/IsNotCurrentlyEnabledMatcher.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/matchers/statematchers/IsNotCurrentlyEnabledMatcher.java
@@ -17,7 +17,7 @@ public class IsNotCurrentlyEnabledMatcher<T extends WebElementState> extends Bas
 
     @Override
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
-        mismatchDescription.appendText(WebElementStateDescription.forElement(item)).appendText(" was not currently enabled");
+        mismatchDescription.appendText(WebElementStateDescription.forElement(item)).appendText(" was enabled");
     }
 
 }

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/matchers/statematchers/IsNotCurrentlyVisibleMatcher.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/matchers/statematchers/IsNotCurrentlyVisibleMatcher.java
@@ -20,6 +20,6 @@ public class IsNotCurrentlyVisibleMatcher<T extends WebElementState>
 
     @Override
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
-        mismatchDescription.appendText(WebElementStateDescription.forElement(item)).appendText(" was not currently visible");
+        mismatchDescription.appendText(WebElementStateDescription.forElement(item)).appendText(" was visible");
     }
 }


### PR DESCRIPTION
This PR fixes the wrong error messages in `IsNotCurrentlyEnabledMatcher.java` and `IsNotCurrentlyVisibleMatcher.java`.

Before this change the error message for a failed `IsNotCurrentlyVisible()` call is for instance:
```
Expected: an element that is not currently visible
     but: the element identified by [[RemoteWebDriver] -> css selector: .some-css-class] [] was not currently visible
```

After the change the error message is for instance:
```
Expected: an element that is not currently visible
     but: the element identified by [[RemoteWebDriver] -> css selector: .some-css-class] [] was visible
```