### PR TITLE
Fix #3117 recognize serenity-tests with multiple @ExtendWith and fix gradle-build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=false
 # Dependency versions
-seleniumVersion=4.1.4
+seleniumVersion=4.8.3
 groovyVersion=4.0.1
 gradleVersion=5.6.2
 junitVersion=4.13.2
@@ -9,7 +9,7 @@ springVersion=5.3.16
 springBootVersion=2.1.0.RELEASE
 guavaVersion=31.1-jre
 okioVersion=1.14.1
-restAssuredVersion=5.0.1
+restAssuredVersion=5.3.0
 mockitoCoreVersion=3.1.0
 jbehaveVersion=4.8.3
 commonsIoVersion=2.11.0
@@ -26,7 +26,7 @@ gsonVersion=2.9.0
 typesafeConfigVersion=1.4.2
 freemarkerVersion=2.3.31
 wiremockVersion=1.58
-cucumberVersion=7.2.3
+cucumberVersion=7.11.0
 commonsLoggingVersion=1.2
 xmlApisVersion=1.4.01
 cglibVersion=3.3.0
@@ -61,9 +61,9 @@ websocketVersion=1.1
 javassistVersion=3.28.0-GA
 jacksonVersion=2.13.2
 # Webdriver libraries
-appiumJavaClientVersion=8.0.0
+appiumJavaClientVersion=8.3.0
 operaDriverVersion=1.5
-htmlunitDriverVersion=2.45.0
+htmlunitDriverVersion=4.8.1
 ngwebdriver=1.1.6
 webdrivermanagerVersion=5.1.0
 # Photo libraries

--- a/serenity-core/build.gradle
+++ b/serenity-core/build.gradle
@@ -126,10 +126,12 @@ dependencies {
         exclude module: 'junit'
         exclude module: 'xstream'
     }
-    implementation "javax.xml.bind:jaxb-api:2.3.1"
+    api "javax.xml.bind:jaxb-api:2.3.1"
     implementation "com.sun.xml.bind:jaxb-core:2.3.0.1"
     implementation "com.sun.xml.bind:jaxb-impl:2.3.3"
     implementation "javax.activation:activation:1.1.1"
+    implementation "org.htmlunit:htmlunit:3.0.0"
+    implementation "org.seleniumhq.selenium:htmlunit3-driver:${htmlunitDriverVersion}"
 }
 
 processResources {

--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/SerenityTestExecutionListener.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/SerenityTestExecutionListener.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.thucydides.core.reports.ReportService.getDefaultReporters;
@@ -551,8 +552,7 @@ public class SerenityTestExecutionListener implements TestExecutionListener {
 
     static boolean isSerenityTestClass(Class<?> testClass) {
         return classNestStructure(testClass).stream()
-                .filter(clazz -> clazz.getAnnotation(ExtendWith.class) != null)
-                .map(clazz -> clazz.getAnnotation(ExtendWith.class))
+                .flatMap(clazz -> Stream.of(clazz.getAnnotationsByType(ExtendWith.class)))
                 .anyMatch(annotation -> Arrays.asList(annotation.value()).contains(SerenityJUnit5Extension.class));
     }
 

--- a/serenity-junit5/src/test/java/net/serenitybdd/junit5/WhenDetectingASerenityJUnit5TestClass.java
+++ b/serenity-junit5/src/test/java/net/serenitybdd/junit5/WhenDetectingASerenityJUnit5TestClass.java
@@ -2,6 +2,8 @@ package net.serenitybdd.junit5;
 
 import net.serenitybdd.junit5.samples.integration.JUnit5NestedExample;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extensions;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -12,5 +14,24 @@ public class WhenDetectingASerenityJUnit5TestClass {
     public void a_class_with_the_extension_SerenityJUnit5Extension_should_be_recognized_as_Serenity_test() {
         assertThat(SerenityTestExecutionListener.isSerenityTestClass(JUnit5NestedExample.class), is(true));
         assertThat(SerenityTestExecutionListener.isSerenityTestClass(WhenDetectingASerenityJUnit5TestClass.class), is(false));
+    }
+
+    @Test
+    public void a_class_with_multiple_SerenityJUnit5Extension_should_be_recognized_as_Serenity_test() {
+        assertThat(SerenityTestExecutionListener.isSerenityTestClass(ClassWithMultipleExtensions.class), is(true));
+    }
+
+    @Test
+    public void a_class_with_the_wrapper_extensions_SerenityJUnit5Extension_should_be_recognized_as_Serenity_test() {
+        assertThat(SerenityTestExecutionListener.isSerenityTestClass(ClassWithWrapperExtensions.class), is(true));
+    }
+
+    @ExtendWith(SerenityJUnit5Extension.class)
+    @ExtendWith(SerenityJUnit5Extension.class)
+    private class ClassWithMultipleExtensions {
+    }
+
+    @Extensions(@ExtendWith(SerenityJUnit5Extension.class))
+    private class ClassWithWrapperExtensions {
     }
 }

--- a/serenity-model/build.gradle
+++ b/serenity-model/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     api "io.cucumber:cucumber-java:${cucumberVersion}"
     api "com.google.code.gson:gson:${gsonVersion}"
     api "net.sf.opencsv:opencsv:${openCsvVersion}"
-    implementation "com.typesafe:config:${typesafeConfigVersion}"
+    api "com.typesafe:config:${typesafeConfigVersion}"
     implementation "org.imgscalr:imgscalr-lib:${imgscalrVersion}"
     api "org.awaitility:awaitility:${awaitilityVersion}"
     api "org.freemarker:freemarker:${freemarkerVersion}"

--- a/serenity-reports/build.gradle
+++ b/serenity-reports/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation project(':serenity-model')
     implementation project(':serenity-stats')
     api project(':serenity-reports-configuration')
-    api("com.vladsch.flexmark:flexmark-all:0.34.30") {
+    api("com.vladsch.flexmark:flexmark-all:0.62.2") {
         exclude group:'org.jsoup', module:'jsoup'
         exclude group:'junit', module:'junit'
     }


### PR DESCRIPTION
#### Summary of this PR
Fixes #3117: tests that were using multiple @ExtendWith- or the @Extension-annotation were not recognized are serenity-tests.
Updated gradle-dependencies to match maven-versions if I encountered compile errors (at first I didn't know which of both tools I should use).

#### Relevant tickets
#3117
