### PR TITLE
Added filter to ListOfWebElementFacades

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/pages/ListOfWebElementFacades.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/pages/ListOfWebElementFacades.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -21,7 +22,7 @@ public class ListOfWebElementFacades extends ArrayList<WebElementFacade> {
      * Returns a list of the text values of each element in the collection
      */
     public List<String> texts() {
-        return convert((list) -> list.stream().map(WebElementFacade::getText).collect(Collectors.toList()));
+        return map(WebElementFacade::getText);
     }
 
     /**
@@ -29,11 +30,15 @@ public class ListOfWebElementFacades extends ArrayList<WebElementFacade> {
      * This can be useful when elements are not visible on the page but are still in the DOM.
      */
     public List<String> textContents() {
-        return convert((list) -> list.stream().map(WebElementFacade::getTextContent).collect(Collectors.toList()));
+        return map(WebElementFacade::getTextContent);
     }
 
     public <T> List<T> map(Function<? super WebElementFacade, T> elementConverter) {
         return convert((list) -> list.stream().map(elementConverter).collect(Collectors.toList()));
+    }
+
+    public List<? super WebElementFacade> filter(Predicate<? super WebElementFacade> condition) {
+        return convert((list) -> list.stream().filter(condition).collect(Collectors.toList()));
     }
 
     public void setFallback(Function<PageObject, ListOfWebElementFacades> fallbackMethod, PageObject page) {


### PR DESCRIPTION
Given there is more than 1 element returned by the locator so gets resolved to ListOfWebElementFacades
And I want to filter the resulting list based on the predicate (isDisplayed for instance)
And I want to benefit from fallback functionality handling StaleElementReferenceException
When I filter ListOfWebElementFacades
I should get the resulting list matching the condition provided