### PR TITLE
enable list matcher to be used with Check class

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/conditions/Check.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/conditions/Check.java
@@ -12,7 +12,7 @@ public class Check {
         return new ConditionalPerformableOnQuestion(condition);
     }
 
-    public static <T> ConditionalPerformable whether(Question<T> question, Matcher<T> matcher) {
+    public static <T> ConditionalPerformable whether(Question<? extends T> question, Matcher<T> matcher) {
         Question<Boolean> condition = actor -> matcher.matches(question.answeredBy(actor));
 
         return new ConditionalPerformableOnQuestion(condition);


### PR DESCRIPTION
### Problem Description:

The `Check` class does not support list matchers from hamcrest (e.g. `org.hamcrest.Matcher.hasItem`) because subclasses are not supported.

For instance the code
```
Check.whether( QuestionReturningA.stringList(), hasItem( "1" )).andIfSo(...);
```
where the used question implements `Question<List<String>>` throws the following error in IDE:
```
question: Question<T> Question<List<String>>
matcher: Matcher<T> Matcher<Iterable<String>>
no instance(s) of type variable(s) T, T exist so that Iterable<T> conforms to List<String>
```

### Solution:
To fix this the question the generic type of `Question` is extended to support subclasses.

### Note:
This extended `Question` parameter type is already used in the function `seeThat` in `GivenWhenThen.java`:
```
public static <T> Consequence<T> seeThat(Question<? extends T> actual, Matcher<T> expected)
```