### PR TITLE
Fix junit5 dependency version and review Cucumber dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ subprojects {
     }
 
     test {
+        useJUnitPlatform()
         testLogging {
             events "failed"//, "passed", "skipped"
             exceptionFormat = 'full'
@@ -181,6 +182,7 @@ subprojects {
     }
 
     integrationTests {
+        useJUnitPlatform()
         testLogging {
             events "failed"//, "passed", "skipped"
             exceptionFormat = 'full'

--- a/gradle.properties
+++ b/gradle.properties
@@ -76,8 +76,7 @@ spockVersion=2.2-M1-groovy-4.0
 spockExtensionsVersion=0.1.4
 assertjVersion=3.22.0
 jsonassertVersion=1.5.0
-junit5Version=5.8.2
-junitPlatformLauncher=1.8.1
+junit5Version=5.10.0
 opentest4jVersion=1.2.0
 # Bintray configuration
 bintrayBaseUrl=https://api.bintray.com/maven

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <connection>scm:git:https://github.com/serenity-bdd/serenity-core.git</connection>
         <developerConnection>scm:git:https://github.com/serenity-bdd/serenity-core.git</developerConnection>
         <url>https://github.com/serenity-bdd/serenity-core</url>
-        <tag>3.6.15</tag>
+        <tag>4.0.0-beta-3-SNAPSHOT</tag>
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -276,30 +276,6 @@
                 <artifactId>commons-codec</artifactId>
                 <version>${commons.codec.version}</version>
             </dependency>
-            <!-- Cucumber dependencies -->
-            <dependency>
-                <groupId>io.cucumber</groupId>
-                <artifactId>cucumber-core</artifactId>
-                <version>${cucumber.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apiguardian</groupId>
-                        <artifactId>apiguardian-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.cucumber</groupId>
-                <artifactId>cucumber-java</artifactId>
-                <version>${cucumber.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.apiguardian</groupId>
-                        <artifactId>apiguardian-api</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
@@ -317,24 +293,6 @@
             </dependency>
 
             <!-- Testing -->
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-api</artifactId>
-                <version>${junit5.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>${junit5.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>${junit5.version}</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.skyscreamer</groupId>
                 <artifactId>jsonassert</artifactId>
@@ -479,6 +437,24 @@
                 <version>${xchart.version}</version>
             </dependency>
 
+            <!-- BOM should be latest to overwrite versions -->
+
+            <!-- Cucumber -->
+            <dependency>
+                <groupId>io.cucumber</groupId>
+                <artifactId>cucumber-bom</artifactId>
+                <version>${cucumber.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Junit 5 -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit5.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <distributionManagement>

--- a/serenity-assertions/pom.xml
+++ b/serenity-assertions/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/serenity-bitbar/pom.xml
+++ b/serenity-bitbar/pom.xml
@@ -58,7 +58,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <optional>true</optional>
             <scope>test</scope>
         </dependency>

--- a/serenity-browserstack/pom.xml
+++ b/serenity-browserstack/pom.xml
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <optional>true</optional>
             <scope>test</scope>
         </dependency>

--- a/serenity-cli/pom.xml
+++ b/serenity-cli/pom.xml
@@ -117,7 +117,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/serenity-core/pom.xml
+++ b/serenity-core/pom.xml
@@ -360,7 +360,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-crossbrowsertesting/pom.xml
+++ b/serenity-crossbrowsertesting/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/serenity-cucumber/pom.xml
+++ b/serenity-cucumber/pom.xml
@@ -69,7 +69,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
@@ -92,17 +91,26 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
-            <version>${cucumber.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apiguardian</groupId>
+                    <artifactId>apiguardian-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>${cucumber.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apiguardian</groupId>
+                    <artifactId>apiguardian-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>${cucumber.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>
@@ -119,7 +127,6 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java8</artifactId>
-            <version>${cucumber.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -131,7 +138,6 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>datatable-matchers</artifactId>
-            <version>${cucumber.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -142,6 +148,11 @@
         </dependency>
 
         <!-- TEST DEPENDENCIES -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -161,26 +172,21 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite-api</artifactId>
-            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
          <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite-engine</artifactId>
-            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-testkit -->
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-testkit</artifactId>
-            <version>1.8.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -205,12 +211,6 @@
             <artifactId>spring-orm</artifactId>
             <version>${spring.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-           <groupId>io.cucumber</groupId>
-           <artifactId>cucumber-junit-platform-engine</artifactId>
-           <version>${cucumber.version}</version>
-           <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/serenity-jira-plugin/pom.xml
+++ b/serenity-jira-plugin/pom.xml
@@ -227,13 +227,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/serenity-jira-requirements-provider/pom.xml
+++ b/serenity-jira-requirements-provider/pom.xml
@@ -37,14 +37,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
 

--- a/serenity-json-summary-report/pom.xml
+++ b/serenity-json-summary-report/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-junit/pom.xml
+++ b/serenity-junit/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>compile</scope>
         </dependency>
 
@@ -55,7 +54,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/serenity-junit5/build.gradle
+++ b/serenity-junit5/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "org.junit.jupiter:junit-jupiter-engine:${junit5Version}"
     implementation "org.junit.jupiter:junit-jupiter-params:${junit5Version}"
     implementation "org.junit.vintage:junit-vintage-engine:${junit5Version}"
-    implementation "org.junit.platform:junit-platform-launcher:1.8.1"
+    implementation "org.junit.platform:junit-platform-launcher"
     implementation "junit:junit:${junitVersion}"
     implementation("org.spockframework:spock-core:${spockVersion}") {
         exclude group:'org.junit.platform', module:'junit-platform-engine'

--- a/serenity-junit5/pom.xml
+++ b/serenity-junit5/pom.xml
@@ -44,19 +44,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit5.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -68,7 +65,6 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.9.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/serenity-model/pom.xml
+++ b/serenity-model/pom.xml
@@ -198,19 +198,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-navigator-report/pom.xml
+++ b/serenity-navigator-report/pom.xml
@@ -93,13 +93,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/serenity-reports-configuration/pom.xml
+++ b/serenity-reports-configuration/pom.xml
@@ -25,21 +25,14 @@
         </dependency>
 
         <!-- Testing Dependencies -->
-<!--        <dependency>-->
-<!--            <groupId>org.assertj</groupId>-->
-<!--            <artifactId>assertj-core</artifactId>-->
-<!--            <scope>test</scope>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-reports/pom.xml
+++ b/serenity-reports/pom.xml
@@ -98,13 +98,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-rest-assured/pom.xml
+++ b/serenity-rest-assured/pom.xml
@@ -111,19 +111,16 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-saucelabs/pom.xml
+++ b/serenity-saucelabs/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/serenity-screenplay-playwright/pom.xml
+++ b/serenity-screenplay-playwright/pom.xml
@@ -74,13 +74,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/serenity-shutterbug/pom.xml
+++ b/serenity-shutterbug/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>

--- a/serenity-single-page-report/pom.xml
+++ b/serenity-single-page-report/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/serenity-smoketests/pom.xml
+++ b/serenity-smoketests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>serenity-bdd</artifactId>
         <groupId>net.serenity-bdd</groupId>
-        <version>4.0.0-beta-2-SNAPSHOT</version>
+        <version>4.0.0-beta-3-SNAPSHOT</version>
     </parent>
     <artifactId>serenity-smoketests</artifactId>
     <packaging>jar</packaging>
@@ -62,18 +62,15 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
         </dependency>
     </dependencies>
     <build>

--- a/serenity-stats/pom.xml
+++ b/serenity-stats/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit5.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
@wakaleo I struggle to update serenity version >3.8.1 due to junit error

Junit5 dependency version was not the same on all modules, so to fix it, I used the bom junit5
The same done for cucumber.

Note: for gradle, I just see the requirements in https://docs.gradle.org/current/userguide/java_testing.html#using_junit5, but did not test it

Note2: After this fix, this allows me to identify again issues with 2 versions of groovy in rest-assured module (3.0.18 + 4.0.13)