### PR TITLE
feat: extend Check by targat state condition

### DIFF
--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/conditions/Check.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/conditions/Check.java
@@ -17,4 +17,8 @@ public class Check {
 
         return new ConditionalPerformableOnQuestion(condition);
     }
+
+    public static <T> ConditionalPerformable whetherThe(Target target, Matcher<WebElementState> expectedState) {
+        return new ConditionalPerformableOnTargetState(target, expectedState);
+    }
 }

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/conditions/ConditionalPerformableOnTargetState.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/conditions/ConditionalPerformableOnTargetState.java
@@ -1,0 +1,27 @@
+package net.serenitybdd.screenplay.conditions;
+
+import static net.serenitybdd.screenplay.questions.WebElementQuestion.the;
+
+import org.hamcrest.Matcher;
+
+import net.serenitybdd.core.pages.WebElementState;
+import net.serenitybdd.screenplay.Actor;
+import net.serenitybdd.screenplay.conditions.ConditionalPerformable;
+import net.serenitybdd.screenplay.targets.Target;
+
+public class ConditionalPerformableOnTargetState extends ConditionalPerformable {
+    private final Target target;
+
+    private final Matcher<WebElementState> expectedState;
+
+    public ConditionalPerformableOnTargetState(Target target, Matcher<WebElementState> expectedState) {
+        super();
+        this.target = target;
+        this.expectedState = expectedState;
+    }
+
+    @Override
+    protected Boolean evaluatedConditionFor(Actor actor) {
+        return expectedState.matches(the(target).answeredBy(actor));
+    }
+}

--- a/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/WhenTasksAreRunConditionally.java
+++ b/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/shopping/WhenTasksAreRunConditionally.java
@@ -1,14 +1,20 @@
 package net.serenitybdd.screenplay.shopping;
 
+import java.util.Arrays;
+import net.serenitybdd.core.pages.ListOfWebElementFacades;
+import net.serenitybdd.core.pages.WebElementFacade;
 import net.serenitybdd.junit.runners.SerenityRunner;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Question;
 import net.serenitybdd.screenplay.conditions.Check;
 import net.serenitybdd.screenplay.shopping.tasks.Purchase;
+import net.serenitybdd.screenplay.targets.Target;
+import org.mockito.Mockito;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static net.serenitybdd.screenplay.matchers.WebElementStateMatchers.isCurrentlyVisible;
 import static net.serenitybdd.screenplay.shopping.tasks.Purchase.purchase;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -119,6 +125,42 @@ public class WhenTasksAreRunConditionally {
 
         assertThat(purchaseAnApple.theItemWasPurchased).isFalse();
         assertThat(purchaseAPear.theItemWasPurchased).isTrue();
+    }
+
+    @Test
+    public void shouldBeAbleToPerformATaskConditionallyUsingATargetStateMatcher() {
+        Purchase purchaseAPear = purchase().aPear().thatCosts(5).dollars();
+        Purchase purchaseAnApple = purchase().anApple().thatCosts(10).dollars();
+
+        Target target = Mockito.mock(Target.class);
+        WebElementFacade webElementFacade = Mockito.mock(WebElementFacade.class);
+        Mockito.when(target.resolveAllFor(dana))
+                .thenReturn(new ListOfWebElementFacades(Arrays.asList(webElementFacade)));
+        Mockito.when(webElementFacade.isCurrentlyVisible()).thenReturn(true);
+
+        dana.attemptsTo(
+                Check.whetherThe(target, isCurrentlyVisible()).andIfSo(purchaseAPear).otherwise(purchaseAnApple));
+
+        assertThat(purchaseAnApple.theItemWasPurchased).isFalse();
+        assertThat(purchaseAPear.theItemWasPurchased).isTrue();
+    }
+
+    @Test
+    public void shouldBeAbleToPerformAnAlternativeTaskConditionallyUsingATargetStateMatcher() {
+        Purchase purchaseAPear = purchase().aPear().thatCosts(5).dollars();
+        Purchase purchaseAnApple = purchase().anApple().thatCosts(10).dollars();
+
+        Target target = Mockito.mock(Target.class);
+        WebElementFacade webElementFacade = Mockito.mock(WebElementFacade.class);
+        Mockito.when(target.resolveAllFor(dana))
+                .thenReturn(new ListOfWebElementFacades(Arrays.asList(webElementFacade)));
+        Mockito.when(webElementFacade.isCurrentlyVisible()).thenReturn(false);
+
+        dana.attemptsTo(
+                Check.whetherThe(target, isCurrentlyVisible()).andIfSo(purchaseAPear).otherwise(purchaseAnApple));
+
+        assertThat(purchaseAnApple.theItemWasPurchased).isTrue();
+        assertThat(purchaseAPear.theItemWasPurchased).isFalse();
     }
 }
 


### PR DESCRIPTION
This small improvement will make it is easier to use conditions with a target:

To use Check with a target a `the` call is needed:
```
Check.whether(the(APPLY_BUTTON), isCurrentlyVisible())).andIfSo(...);
```

With this change, the target can be provided directly to Check using `whetherThe`:
```
Check.whetherThe(APPLY_BUTTON, isCurrentlyVisible()).andIfSo(...);
```