### PR TITLE
Fix for incorrect final test result when JUnit test throws exception (ticket #3298)

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/model/domain/TestResult.java
+++ b/serenity-model/src/main/java/net/thucydides/model/domain/TestResult.java
@@ -15,37 +15,22 @@ import java.util.Set;
  * and of the overall acceptance test case itself.
  * 
  * @author johnsmart
- *
  */
 public enum TestResult {
     /**
-     * Either failure, error or compromised - internal use only
+     * Test result not known yet.
      */
-    UNSUCCESSFUL(6, true, "Unsuccessful"),
+    UNDEFINED(0, false, "Undefined"),
     /**
-     * Test failures due to external events or systems that compromise the validity of the test.
+     * The test or test case ran as expected.
      */
-    COMPROMISED(5, true, "Compromised"),
+    SUCCESS(1, true, "Passing"),
     /**
-     *  Test failure, due to some other exception.
+     * A pending test is one that has been specified but not yet implemented.
+     * In a JUnit test case, you can use the (Thucydides) @Pending annotation to mark this.
+     * A pending test case is a test case that has at least one pending test.
      */
-     ERROR(4, true, "Broken"),
-    /**
-     * Test failure, due to an assertion error
-     * For a test case, this means one of the tests in the test case failed.
-     */
-    FAILURE(3, true, "Failing"),
-
-    /**
-     * Test is skipped due to a failing assumption
-     */
-    ABORTED(2, false, "Aborted"),
-
-    /**
-     * The test step was not executed because a previous step in this test case failed.
-     * A whole test case can be skipped using tags or annotations to indicate that it is currently "work-in-progress"
-     */
-    SKIPPED(2, false, "Skipped"),
+    PENDING(2, false, "Pending"),
     /**
      * The test or test case was deliberately ignored.
      * Tests can be ignored via the @Ignore annotation in JUnit, for example.
@@ -54,23 +39,32 @@ public enum TestResult {
      * ignored test can be a temporarily-deactivated test (during refactoring, for example).
      */
     IGNORED(2, false, "Ignored"),
-
     /**
-     * A pending test is one that has been specified but not yet implemented.
-     * In a JUnit test case, you can use the (Thucydides) @Pending annotation to mark this.
-     * A pending test case is a test case that has at least one pending test.
+     * The test step was not executed because a previous step in this test case failed.
+     * A whole test case can be skipped using tags or annotations to indicate that it is currently "work-in-progress"
      */
-    PENDING(2, false, "Pending"),
-
+    SKIPPED(2, false, "Skipped"),
     /**
-     * The test or test case ran as expected.
+     * Test is skipped due to a failing assumption
      */
-    SUCCESS(1, true, "Passing"),
-    
+    ABORTED(2, false, "Aborted"),
     /**
-     * Test result not known yet.
+     * Test failure, due to an assertion error
+     * For a test case, this means one of the tests in the test case failed.
      */
-    UNDEFINED(0, false, "Undefined");
+    FAILURE(3, true, "Failing"),
+    /**
+     * Test failure, due to some other exception.
+     */
+    ERROR(4, true, "Broken"),
+    /**
+     * Test failures due to external events or systems that compromise the validity of the test.
+     */
+    COMPROMISED(5, true, "Compromised"),
+    /**
+     * Either failure, error or compromised - internal use only
+     */
+    UNSUCCESSFUL(6, true, "Unsuccessful");
 
     private final int priority;
     private final boolean executedResultsCount;

--- a/serenity-model/src/test/java/net/thucydides/model/domain/TestResultTest.java
+++ b/serenity-model/src/test/java/net/thucydides/model/domain/TestResultTest.java
@@ -1,0 +1,68 @@
+package net.thucydides.model.domain;
+
+import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Enclosed.class)
+public class TestResultTest {
+
+    @RunWith(Parameterized.class)
+    public static class IsMoreSevereTest {
+        private final TestResult firstStatus;
+        private final TestResult secondStatus;
+        private final boolean expectedResult;
+
+        public IsMoreSevereTest(TestResult firstStatus, TestResult secondStatus, boolean expectedResult) {
+            this.firstStatus = firstStatus;
+            this.secondStatus = secondStatus;
+            this.expectedResult = expectedResult;
+        }
+
+        @Test
+        public void should_detect_more_severe_results() {
+            Assertions.assertEquals(firstStatus.isMoreSevereThan(secondStatus), expectedResult);
+        }
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {TestResult.FAILURE, TestResult.SUCCESS, true},
+                    {TestResult.FAILURE, TestResult.FAILURE, false},
+                    {TestResult.SUCCESS, TestResult.FAILURE, false}
+            });
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class IsLessSevereTest {
+        private final TestResult firstStatus;
+        private final TestResult secondStatus;
+        private final boolean expectedResult;
+
+        public IsLessSevereTest(TestResult firstStatus, TestResult secondStatus, boolean expectedResult) {
+            this.firstStatus = firstStatus;
+            this.secondStatus = secondStatus;
+            this.expectedResult = expectedResult;
+        }
+
+        @Test
+        public void should_detect_less_severe_results() {
+            Assertions.assertEquals(firstStatus.isLessSevereThan(secondStatus), expectedResult);
+        }
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {TestResult.FAILURE, TestResult.SUCCESS, false},
+                    {TestResult.FAILURE, TestResult.FAILURE, false},
+                    {TestResult.SUCCESS, TestResult.FAILURE, true}
+            });
+        }
+    }
+}


### PR DESCRIPTION
#### Summary of this PR
Fix for incorrect final test result in `SerenityTestExecutionListener` when JUnit test throws exception.
#### Intended effect
net.serenitybdd.junit5.SerenityTestExecutionListener#testFinished returns FAILED result for JUnit tests failed with exception.
#### How should this be manually tested?
use tests from #3298.
Unit test is added.
#### Side effects
Not sure.
#### Relevant tickets
#3298