### PR TITLE
Bug fix: W3c non-compliant capability "bstack:options"

### DIFF
--- a/serenity-browserstack/src/main/java/net/serenitybdd/plugins/browserstack/BrowserStackConfiguration.java
+++ b/serenity-browserstack/src/main/java/net/serenitybdd/plugins/browserstack/BrowserStackConfiguration.java
@@ -12,7 +12,7 @@ import org.openqa.selenium.WebDriver;
  */
 class BrowserStackConfiguration {
 
-    public static final String BROWSERSTACK_OPTIONS = "\"bstack:options\"";
+    public static final String BROWSERSTACK_OPTIONS = "bstack:options";
     public static final String BROWSERSTACK_OPTIONS_PATH = "webdriver.capabilities." + BROWSERSTACK_OPTIONS;
 
     static boolean isActiveFor(EnvironmentVariables environmentVariables) {


### PR DESCRIPTION
Automatically Session Name marking broken in `serenity-browserstack-plugin` due to
```
WARNING: Support for Legacy Capabilities is deprecated; You are sending the following invalid capabilities: ["bstack:options"]; Please update to W3C Syntax: https://www.selenium.dev/blog/2022/legacy-protocol-support/
```