### PR TITLE
#132 Fix adding files to corresponding test steps in the report

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/reports/AddReportContentEvent.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/reports/AddReportContentEvent.java
@@ -1,22 +1,23 @@
 package net.serenitybdd.core.reports;
 
 import net.thucydides.core.steps.events.StepEventBusEventBase;
+import net.thucydides.model.domain.ReportData;
 
 public class AddReportContentEvent extends StepEventBusEventBase {
 
 
 	private ReportDataSaver reportDataSaver;
-	private String contents;
+	private ReportData reportData;
 
-	public AddReportContentEvent(final ReportDataSaver reportDataSaver,String contents) {
+	public AddReportContentEvent(final ReportDataSaver reportDataSaver,ReportData reportData) {
 		this.reportDataSaver = reportDataSaver;
-		this.contents =  contents;
+		this.reportData =  reportData;
 	}
 
 
 	@Override
 	public void play() {
-		reportDataSaver.doAddContents(contents);
+		reportDataSaver.doAddContents(reportData);
 	}
 
 	public String toString() {

--- a/serenity-core/src/main/java/net/serenitybdd/core/reports/ReportDataSaver.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/reports/ReportDataSaver.java
@@ -33,17 +33,22 @@ public class ReportDataSaver implements WithTitle, AndContent, FromFile {
 
     @Override
     public void andContents(String contents) {
+        ReportData reportData = ReportData.withTitle(title).andContents(contents).asEvidence(isEvidence);
+        addReportContent(reportData);
+    }
+
+    private void addReportContent(ReportData reportData) {
         if(!TestSession.isSessionStarted()) {
-            doAddContents(contents);
+            doAddContents(reportData);
         } else {
-            TestSession.addEvent(new AddReportContentEvent(this,contents));
+            TestSession.addEvent(new AddReportContentEvent(this,reportData));
         }
     }
 
-    public void doAddContents(String contents) {
+    public void doAddContents(ReportData reportData) {
         eventBus.getBaseStepListener().latestTestOutcome().ifPresent(
-                outcome -> currentStepOrBackgroundIn(outcome)
-                        .withReportData(ReportData.withTitle(title).andContents(contents).asEvidence(isEvidence))
+            outcome -> currentStepOrBackgroundIn(outcome)
+                .withReportData(reportData)
         );
     }
 
@@ -64,16 +69,10 @@ public class ReportDataSaver implements WithTitle, AndContent, FromFile {
 
     @Override
     public void fromFile(Path source, Charset encoding) throws IOException {
-
-        Optional<TestOutcome> outcome = eventBus.getBaseStepListener().latestTestOutcome();
-
-        if (outcome.isPresent()) {
-            ReportData reportData = (fileIsDownloadable) ?
-                    ReportData.withTitle(title).fromPath(source).asEvidence(isEvidence) :
-                    ReportData.withTitle(title).fromFile(source, encoding).asEvidence(isEvidence);
-
-            outcome.get().currentStep().get().withReportData(reportData);
-        }
+        ReportData reportData = (fileIsDownloadable) ?
+            ReportData.withTitle(title).fromPath(source).asEvidence(isEvidence) :
+            ReportData.withTitle(title).fromFile(source, encoding).asEvidence(isEvidence);
+        addReportContent(reportData);
     }
 
     @Override


### PR DESCRIPTION
#### Summary of this PR
Refactor the code to add files to test steps to follow the same methods and way as adding text. This fixes the adding of files to corresponding test steps in the report as that is currently not working.

#### Intended effect
When using the method `Serenity.recordReportData().withTitle(String title).fromFile(Path path));` the file will be connected in the report to the corresponding step.

#### How should this be manually tested?
To test this use the method described above in your code and verify the existance of the button to download the file at the corresponding step in the generated report.

#### Side effects
-
#### Documentation
-
#### Relevant tickets
https://github.com/serenity-bdd/serenity-cucumber-starter/issues/132

#### Screenshots (if appropriate)
![Screenshot 2023-12-12 at 11 22 57](https://github.com/serenity-bdd/serenity-core/assets/151131559/fc881a5f-0b98-4a85-b9d0-f3d769fa27a6)
