### PR TITLE
fix: TestStep - optimize method to obtain result

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/model/domain/TestStep.java
+++ b/serenity-model/src/main/java/net/thucydides/model/domain/TestStep.java
@@ -491,12 +491,14 @@ public class TestStep implements Cloneable {
         return TestResultList.overallResultFrom(getChildResults());
     }
 
-
     private List<TestResult> getChildResults() {
         List<TestResult> childResults = new ArrayList<>();
         for (TestStep step : getChildren()) {
-            if (step != null && step.getResult() != null) {
-                childResults.add(step.getResult());
+            if (step != null) {
+                TestResult stepResult = step.getResult();
+                if (stepResult != null) {
+                    childResults.add(stepResult);
+                }
             }
         }
         return childResults;


### PR DESCRIPTION
For the cases when TestStep has nested steps (=children), `getChildResults(`) will be invoked in order to calculate the final result.  It will be done for every node, that has children itself. However, with the current implementation amount of those calls is enormous. 

Let's imagine following case, when there is 3 level of nested steps:

```
TestStep parentStep = new TestStep("Test Step: Level 0");
int level = 3;
TestStep currentStep = parentStep;
for (int i = 1; i <= level; i++) {
    TestStep childStep = new TestStep("Test Step: Level "+ i);
    currentStep.addChildStep(childStep);
    currentStep = childStep;
}
```

With current implementation call to `getResult()` method would produce the output like (debug output was added for demonstration purposes):

```
Get result for step on level: 0
Get child results for step on level: 0
	Get result for step on level: 1
	Get child results for step on level: 1
		Get result for step on level: 2
		Get child results for step on level: 2
			Get result for step on level: 3
			Get result for step on level: 3
		Get result for step on level: 2
		Get child results for step on level: 2
			Get result for step on level: 3
			Get result for step on level: 3
	Get result for step on level: 1
	Get child results for step on level: 1
		Get result for step on level: 2
		Get child results for step on level: 2
			Get result for step on level: 3
			Get result for step on level: 3
		Get result for step on level: 2
		Get child results for step on level: 2
			Get result for step on level: 3
			Get result for step on level: 3
```

With updated version, it will be like that:

```
Get result for step on level: 0
Get child results for step on level: 0
	Get result for step on level: 1
	Get child results for step on level: 1
		Get result for step on level: 2
		Get child results for step on level: 2
			Get result for step on level: 3		
```

I'm not sure if this behavior might be covered with unit tests.
