### PR TITLE
Notify step failure in StepInterceptor if soft assertion enabled

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
@@ -492,7 +492,7 @@ public class StepInterceptor implements MethodErrorReporter, Interceptor {
     }
 
     private void logStepFailure(Object object, Method method, Object[] args, Throwable assertionError) throws Throwable {
-        if (StepEventBus.getEventBus().aStepInTheCurrentTestHasFailed()) {
+        if (StepEventBus.getEventBus().aStepInTheCurrentTestHasFailed() && !StepEventBus.getEventBus().softAssertsActive()) {
             return;
         }
         notifyOfStepFailure(object, method, args, assertionError);

--- a/serenity-core/src/test/java/net/thucydides/core/steps/samples/FlatScenarioSteps.java
+++ b/serenity-core/src/test/java/net/thucydides/core/steps/samples/FlatScenarioSteps.java
@@ -67,6 +67,11 @@ public class FlatScenarioSteps extends ScenarioSteps {
         throw new AssertionError("Step failed");
     }
 
+    @Step
+    public void failingWithExceptionStep() throws Exception {
+        throw new Exception("Step failed due to exception");
+    }
+
     @Ignore
     @Step
     public void ignoredStep() {}


### PR DESCRIPTION
This PR fixes the condition introduced in [this](https://github.com/serenity-bdd/serenity-core/commit/f6224ed203963689c41880b33a5946c3c39db535) commit. In our case, if the soft assertions are enabled, step results should be reported accordingly without checking if one of the previous steps failed. However, with this change, if there was a failing step (e.g. with exception) during test execution, listener wasn't notified properly - so that new group was created for every failing step (except the first one, which was processed correctly).

Unit test added to cover this scenario