### PR TITLE
Updated the baseMethodName so that we can effectively handle display names, display name generators, and methods without JUnit custom display names

### DIFF
--- a/serenity-junit5/src/main/java/net/serenitybdd/junit5/ParameterizedTestsOutcomeAggregator.java
+++ b/serenity-junit5/src/main/java/net/serenitybdd/junit5/ParameterizedTestsOutcomeAggregator.java
@@ -148,7 +148,7 @@ public class ParameterizedTestsOutcomeAggregator {
     }
 
     private String baseMethodName(TestOutcome testOutcome) {
-        return testOutcome.getMethodName();
+        return testOutcome.getName(); //Updated the baseMethodName so that we can effectively handle display names, display name generators, and methods without JUnit custom display names.
     }
 
     private String alternativeMethodName(TestOutcome testOutcome) {

--- a/serenity-junit5/src/test/java/net/serenitybdd/junit5/samples/integration/displayName/JUnit5CustomDisplayNameExample.java
+++ b/serenity-junit5/src/test/java/net/serenitybdd/junit5/samples/integration/displayName/JUnit5CustomDisplayNameExample.java
@@ -3,6 +3,8 @@ package net.serenitybdd.junit5.samples.integration.displayName;
 import net.serenitybdd.junit5.SerenityJUnit5Extension;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @ExtendWith(SerenityJUnit5Extension.class)
 @DisplayNameGeneration(JUnit5CustomDisplayNameGenerated.class)
@@ -12,10 +14,18 @@ public class JUnit5CustomDisplayNameExample {
     void sample_custom_display_name_test() {
     }
 
-    //@DisplayName takes precedence over generation
+   //@DisplayName takes precedence over generation
     @Test
     @DisplayName("Sample Test With Display Name")
     void sample_display_name_test() {
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "200,Occasional,2,204"
+    })
+    void sample_custom_display_name_parameterized_test() {
+
     }
 
 }


### PR DESCRIPTION
Updated the baseMethodName so that we can effectively handle display names, display name generators, and methods without JUnit custom display names