### PR TITLE
fix: clickable mismatch message

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/matchers/statematchers/isClickableMatcher.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/matchers/statematchers/isClickableMatcher.java
@@ -18,6 +18,6 @@ public class isClickableMatcher<T extends WebElementState> extends TypeSafeMatch
 
     @Override
     protected void describeMismatchSafely(T item, Description mismatchDescription) {
-        mismatchDescription.appendText(WebElementStateDescription.forElement(item)).appendText(" was not clicked");
+        mismatchDescription.appendText(WebElementStateDescription.forElement(item)).appendText(" was not clickable");
     }
 }


### PR DESCRIPTION
This fixes the clickable mismatch message from
```
Expected: an element that is clickable
     but: no matching element found by [[RemoteWebDriver] -> css selector: button[value='submit']] was not clicked
```
to
```
Expected: an element that is clickable
     but: no matching element found by [[RemoteWebDriver] -> css selector: button[value='submit']] was not clickable
```