### PR TITLE
feat: Allow screenplay rest ensure interaction to be silent.

### DIFF
--- a/serenity-screenplay-rest/src/main/java/net/serenitybdd/screenplay/rest/interactions/Ensure.java
+++ b/serenity-screenplay-rest/src/main/java/net/serenitybdd/screenplay/rest/interactions/Ensure.java
@@ -1,6 +1,7 @@
 package net.serenitybdd.screenplay.rest.interactions;
 
 import io.restassured.response.ValidatableResponse;
+import net.serenitybdd.markers.CanBeSilent;
 import net.serenitybdd.rest.SerenityRest;
 import net.serenitybdd.screenplay.Actor;
 import net.serenitybdd.screenplay.Interaction;
@@ -10,14 +11,16 @@ import java.util.function.Consumer;
 
 import static net.serenitybdd.screenplay.Tasks.instrumented;
 
-public class Ensure implements Interaction {
+public class Ensure implements Interaction, CanBeSilent {
 
     private final String description;
     private final Consumer<ValidatableResponse> check;
+    private final boolean isSilent;
 
-    public Ensure(String description, Consumer<ValidatableResponse> check) {
+    public Ensure(String description, Consumer<ValidatableResponse> check, boolean isSilent) {
         this.description = description;
         this.check = check;
+        this.isSilent = isSilent;
     }
 
     @Step("Ensure that #description")
@@ -27,6 +30,15 @@ public class Ensure implements Interaction {
     }
 
     public static Ensure that(String description, Consumer<ValidatableResponse> check) {
-        return instrumented(Ensure.class, description, check);
+        return instrumented(Ensure.class, description, check, false);
+    }
+
+    public static Ensure silentlyThat(Consumer<ValidatableResponse> check) {
+        return instrumented(Ensure.class, "", check, true);
+    }
+
+    @Override
+    public boolean isSilent() {
+        return isSilent;
     }
 }


### PR DESCRIPTION
#### Summary of this PR
Added CanBeSilent interface to the Ensure class and created a new method silentlyThat that sets isSilent to true.
The existing method signature and behaviour is unchanged.

#### Intended effect
Ensure can now be used in a test and not show on the report.

#### How should this be manually tested?
Create a test such as 

```
import net.serenitybdd.screenplay.rest.interactions.Ensure;

...

bob.attemptsTo(
    Get.resource("/xyz")
    Ensure.silentlyThat(response->response.statusCode(200))
    Ensure.that("gets a successful response", response->response.statusCode(200))
);
```
Only the second check will be displayed on the report.
#### Side effects
There are no side effects. The existing functions signature and behaviour is unchanged.

#### Documentation
I could not find any documentation for this version of Ensure.

#### Relevant tickets
#### Screenshots (if appropriate)