### PR TITLE
feat: Searching for step text should return matching results

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/model/domain/TestStep.java
+++ b/serenity-model/src/main/java/net/thucydides/model/domain/TestStep.java
@@ -273,6 +273,14 @@ public class TestStep implements Cloneable {
         return new ArrayList(children);
     }
 
+    public String getAllStepsText() {
+        StringBuilder allStepsText = new StringBuilder();
+        for (TestStep testStep : getFlattenedSteps()) {
+            allStepsText.append(testStep.getDescription() + "\n");
+        }
+        return allStepsText.toString();
+    }
+
     public List<ScreenshotAndHtmlSource> getScreenshots() {
         return new ArrayList(screenshots);
     }

--- a/serenity-model/src/main/java/net/thucydides/model/reports/TestOutcomes.java
+++ b/serenity-model/src/main/java/net/thucydides/model/reports/TestOutcomes.java
@@ -1172,6 +1172,16 @@ public class TestOutcomes {
                 .count();
     }
 
+    public String getAllStepsText() {
+        StringBuilder allStepsText = new StringBuilder();
+        for (TestOutcome outcome : outcomes) {
+            for (TestStep testStep : outcome.getFlattenedTestSteps()) {
+                allStepsText.append(testStep.getDescription() + "\n");
+            }
+        }
+        return allStepsText.toString();
+    }
+
     private int totalImplementedTests() {
         return outcomes.stream()
                 .mapToInt(TestOutcome::getImplementedTestCount)

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ExampleOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ExampleOutcome.java
@@ -12,14 +12,16 @@ public class ExampleOutcome {
     private ZonedDateTime startTime;
     private final long duration;
     private final long stepCount;
+    private final String allStepsText;
 
-    public ExampleOutcome(String title, String subtitle, TestResult result, ZonedDateTime startTime, long duration, long stepCount) {
+    public ExampleOutcome(String title, String subtitle, TestResult result, ZonedDateTime startTime, long duration, long stepCount, String allStepsText) {
         this.title = title;
         this.subtitle = subtitle;
         this.result = result;
         this.startTime = startTime;
         this.duration = duration;
         this.stepCount = stepCount;
+        this.allStepsText = allStepsText;
     }
 
     public String getTitle() {
@@ -48,6 +50,10 @@ public class ExampleOutcome {
 
     public long getStepCount() {
         return stepCount;
+    }
+
+    public String getAllStepsText() {
+        return allStepsText;
     }
 
     public String getFormattedStartTime() {

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ExampleOutcomes.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ExampleOutcomes.java
@@ -17,7 +17,8 @@ public class ExampleOutcomes {
                                     testStep.getResult(),
                                     testStep.getStartTime(),
                                     testStep.getDuration(),
-                                    testStep.getChildren().size()
+                                    testStep.getChildren().size(),
+                                    testStep.getAllStepsText()
                             )).collect(Collectors.toList());
         } else {
             return new ArrayList<>();

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/RequirementOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/RequirementOutcome.java
@@ -267,6 +267,10 @@ public class RequirementOutcome {
         return testOutcomes.getScenarioCount();
     }
 
+    public String getAllStepsText() {
+        return testOutcomes.getAllStepsText();
+    }
+
     public long getTestCount() {
         return testOutcomes.getTotal();
     }

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/RequirementsOutcomes.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/RequirementsOutcomes.java
@@ -104,6 +104,10 @@ public class RequirementsOutcomes {
         return this.testOutcomes.getScenarioCount();
     }
 
+    public String getAllStepsText() {
+        return this.testOutcomes.getAllStepsText();
+    }
+
     public List<Requirement> getRequirements() {
         return requirementOutcomes.stream().map(RequirementOutcome::getRequirement).collect(Collectors.toList());
     }

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ScenarioOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ScenarioOutcome.java
@@ -43,6 +43,8 @@ public interface ScenarioOutcome {
 
     Integer getStepCount();
 
+    String getAllStepsText();
+
     ZonedDateTime getStartTime();
 
     Long getTimestamp();

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ScenarioSummaryOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/ScenarioSummaryOutcome.java
@@ -159,6 +159,14 @@ public class ScenarioSummaryOutcome implements ScenarioOutcome {
         return steps.size();
     }
 
+    public String getAllStepsText() {
+        StringBuilder allStepsText = new StringBuilder();
+        for (String step : steps) {
+            allStepsText.append(step + "\n");
+        }
+        return allStepsText.toString();
+    }
+
     public List<TestCaseResultCount> getResultCounts() {
         List<TestCaseResultCount> resultCounts = new ArrayList<>();
         // Create an initial list of results in a logical order

--- a/serenity-model/src/main/java/net/thucydides/model/requirements/reports/SingleScenarioOutcome.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/reports/SingleScenarioOutcome.java
@@ -35,7 +35,6 @@ public class SingleScenarioOutcome implements ScenarioOutcome {
     private Rule rule;
     private ExternalLink externalLink;
     private final Collection<TestTag> scenarioTags;
-
     private final String context;
 
     public SingleScenarioOutcome(String name,
@@ -157,6 +156,13 @@ public class SingleScenarioOutcome implements ScenarioOutcome {
         return steps.size();
     }
 
+    public String getAllStepsText() {
+        StringBuilder allStepsText = new StringBuilder();
+        for (String step : steps) {
+            allStepsText.append(step + "\n");
+        }
+        return allStepsText.toString();
+    }
 
     public ZonedDateTime getStartTime() {
         return startTime;

--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -51,7 +51,11 @@
                     search: ""
                 },
                 columnDefs: [
-                    {type: 'time-elapsed-dhms', targets: 5}
+                    {
+                        targets: 4,
+                        visible: false
+                    },
+                    {type: 'time-elapsed-dhms', targets: 6}
                 ]
             })
             $("#manual-scenario-results").DataTable({
@@ -60,6 +64,12 @@
                     searchPlaceholder: "Filter",
                     search: ""
                 },
+                columnDefs: [
+                    {
+                        targets: 4,
+                        visible: false
+                    },
+                ]
             })
 
             // Results table
@@ -80,7 +90,17 @@
             $(".feature-coverage-table").DataTable({
                 searching: true,
                 paging: false,
-                info: false
+                info: false,
+                language: {
+                    searchPlaceholder: "Filter",
+                    search: ""
+                },
+                columnDefs: [
+                    {
+                        targets: 2,
+                        visible: false
+                    },
+                ]
             });
 
             $(".feature-coverage-table-with-pagination").DataTable({
@@ -90,7 +110,13 @@
                 language: {
                     searchPlaceholder: "Filter",
                     search: ""
-                }
+                },
+                columnDefs: [
+                    {
+                        targets: 2,
+                        visible: false
+                    },
+                ]
             });
         });
     </script>
@@ -331,12 +357,12 @@
                                                                     <#assign sectionTitle = inflection.of(tagCoverageByType.tagType).inPluralForm().asATitle() >
                                                                     <h4>${inflection.of(tagCoverageByType.tagType).inPluralForm().asATitle()}</h4>
 
-                                                                    <table class="table ${coverageTableClass}"
-                                                                           id="${tagCoverageByType.tagType}">
+                                                                    <table class="table ${coverageTableClass}" id="${tagCoverageByType.tagType}" style="width:100%">
                                                                         <thead>
                                                                         <tr>
                                                                             <th>${formatter.humanReadableFormOf(tagCoverageByType.tagType)}</th>
                                                                             <th style="width:1em;">Scenarios</th>
+                                                                            <th style="width:1em;">StepsText</th>
                                                                             <th style="width:1em;">Test&nbsp;Cases</th>
                                                                             <th style="width:1em;">%&nbsp;Pass</th>
                                                                             <th style="width:1em;">Result</th>
@@ -361,6 +387,7 @@
                                                                                         </#if>
                                                                                     </td>
                                                                                     <td>${tagCoverage.scenarioCount}</td>
+                                                                                    <td>${tagCoverage.allStepsText}</td>
                                                                                     <td>${tagCoverage.testCount}</td>
                                                                                     <td>${tagCoverage.successRate}</td>
                                                                                     <td>
@@ -452,14 +479,14 @@
                                                         <h3><i class="bi bi-gear"></i> Automated Scenarios</h3>
 
                                                         <#if (automatedTestCases?has_content)>
-                                                            <table class="scenario-result-table table"
-                                                                   id="scenario-results">
+                                                            <table class="scenario-result-table table" id="scenario-results" style="width:100%">
                                                                 <thead>
                                                                 <tr>
                                                                     <th>${leafRequirementType}</th>
                                                                     <th class="test-name-column">Scenario</th>
                                                                     <th>Context</th>
                                                                     <th>Steps</th>
+                                                                    <th>StepsText</th>
                                                                     <th>Started</th>
                                                                     <th>Total Duration</th>
                                                                     <th>Result</th>
@@ -501,6 +528,7 @@
                                                                         <td>${context_icon}<span style="display:none">${context_label}</span>
                                                                         </td>
                                                                         <td>${scenario.stepCount}</td>
+                                                                        <td>${scenario.allStepsText}</td>
                                                                         <td data-order="${scenario.timestamp}">${scenario.formattedStartTime}</td>
                                                                         <td>${scenario.formattedDuration}</td>
                                                                         <td>${outcome_icon} <span
@@ -522,14 +550,14 @@
                                                         <h3><i class="bi bi-hand-index-thumb"></i> Manual Tests</h3>
 
                                                         <#if (manualTestCases?has_content)>
-                                                            <table class="scenario-result-table table"
-                                                                   id="manual-scenario-results">
+                                                            <table class="scenario-result-table table" id="manual-scenario-results" style="width:100%">
                                                                 <thead>
                                                                 <tr>
                                                                     <th>${leafRequirementType}</th>
                                                                     <th class="test-name-column">Scenario</th>
                                                                     <th>Context</th>
                                                                     <th>Steps</th>
+                                                                    <th>StepsText</th>
                                                                     <th>Result</th>
                                                                 </tr>
                                                                 </thead>
@@ -557,6 +585,7 @@
                                                                                 </td>
                                                                                 <td><i class="bi bi-person"></i></td>
                                                                                 <td>${exampleOutcome.stepCount}</td>
+                                                                                <td>${exampleOutcome.allStepsText}</td>
                                                                                 <td>${example_outcome_icon} <span
                                                                                             style="display:none">${exampleOutcome.result}</span>
                                                                                     <#if (scenario.externalLink)?? && (scenario.externalLink.url)??>
@@ -582,6 +611,7 @@
                                                                             </td>
                                                                             <td><i class="bi bi-person"></i></td>
                                                                             <td>${scenario.stepCount}</td>
+                                                                            <td>${scenario.allStepsText}</td>
                                                                             <td>${outcome_icon} <span
                                                                                         style="display:none">${scenario.result}</span>
                                                                                 <#if (scenario.externalLink)?? && (scenario.externalLink.url)??>

--- a/serenity-stats/src/main/kotlin/net/serenitybdd/reports/model/TagCoverage.kt
+++ b/serenity-stats/src/main/kotlin/net/serenitybdd/reports/model/TagCoverage.kt
@@ -164,6 +164,7 @@ class CoverageByTagType(
             testOutcomesForTag.testCaseCount,
             successRate,
             testOutcomesForTag.result,
+            testOutcomesForTag.allStepsText,
             reportNameProvider.forRequirementOrTag(testTag),    //            ReportNameProvider().forRequirementOrTag(testTag),
             countByResultLabelFrom(testOutcomesForTag),
             percentageByResultFrom(testOutcomesForTag)
@@ -191,6 +192,7 @@ class CoverageByTag(
     val testCount: Long,
     val successRate: String,
     val result: TestResult,
+    var allStepsText: String,
     val report: String,
     val countByResult: Map<String, Long>,
     val percentageByResult: Map<String, Double>


### PR DESCRIPTION
#### Summary of this PR
Currently it's not possible search manual test results by the step contents.

This has been resolved by adding a hidden column to the tables that can be searched, which contains all the step text of the scenario(s)/features(s). This is then, by default, included in the terms which can be searched.
#### Intended effect
This adds the ability to search manual test results by the step contents, but doesn't display the steps test.
#### How should this be manually tested?
Check the Filters work as expected, picking up the Steps as match values.
#### Side effects
One strangeness was I had to put "width: 100%" on the HTML tables when hiding the steps text columns. I believe this is a bug in the js library being used.
#### Documentation
I believe this now works more like the user would expect.
#### Relevant tickets
https://github.com/serenity-bdd/serenity-core/issues/3438
#### Screenshots (if appropriate)
If this PR change something, that can change view of report or console output, etc – please include 
screenshots “what was before this PR” and how it will be changed”. 
