### PR TITLE
feat: add source() to get the source of a page

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/questions/page/TheWebPage.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/questions/page/TheWebPage.java
@@ -15,4 +15,8 @@ public class TheWebPage {
     public static Question<String> alertText() {
         return Question.about("alert text").answeredBy(actor -> BrowseTheWeb.as(actor).getAlert().getText());
     }
+
+    public static Question<String> source() {
+        return Question.about("page source").answeredBy(actor -> BrowseTheWeb.as(actor).getDriver().getPageSource());
+    }
 }


### PR DESCRIPTION
By adding `source()` to `TheWebPage.java` the actor is able to validate source code of the page, e.g.

```
actor.should( seeThat( TheWebPage.source(), containsString( "Test" ) ) );
```