### PR TITLE
3522: fixing issues with report where scenario outlines contained quo…

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -503,11 +503,11 @@
                                                                                 <a href="${scenario.parentReport}">${scenario.parentName}</a>
                                                                             </#if>
                                                                         </td>
-                                                                        <td data-order="${scenario.title}">
+                                                                        <td data-order="<#outputformat 'HTML'>${scenario.title}</#outputformat>">
                                                                             <#if (scenario.hasExamples() && scenario.getExampleOutcomes()?has_content)>
                                                                             <i class="bi bi-table"
                                                                                title="Data Driven Scenario"> <a
-                                                                                        href="${scenario.scenarioReport}">${scenario.title}</a>
+                                                                                        href="${scenario.scenarioReport}"><#outputformat 'HTML'>${scenario.title}</#outputformat></a>
                                                                                 <br/>
                                                                                 <#list scenario.getResultCounts() as resultCount>
                                                                                     <#assign outcome_icon = formatter.resultIcon().forResult(resultCount.result) />

--- a/serenity-report-resources/src/main/resources/freemarker/requirements.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/requirements.ftl
@@ -587,7 +587,7 @@
                                                                     </td>
                                                                     <td>
                                                                         <#if (scenario.hasExamples() && scenario.getExampleOutcomes()?has_content)>
-                                                                        <i class="bi bi-table" title="Data Driven Scenario"> <a href="${scenario.scenarioReport}">${scenario.title}</a>
+                                                                        <i class="bi bi-table" title="Data Driven Scenario"> <a href="${scenario.scenarioReport}"><#outputformat 'HTML'>${scenario.title}</#outputformat></a>
                                                                             <br/>
                                                                             <#list scenario.getResultCounts() as resultCount>
                                                                                 <#assign outcome_icon = formatter.resultIcon().forResult(resultCount.result) />

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
@@ -437,7 +437,8 @@ public class Formatter {
 
     private static final CharSequenceTranslator ESCAPE_SPECIAL_CHARS = new AggregateTranslator(
             new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE()),
-            new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE())
+            new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE()),
+            new LookupTranslator(new String[][] { {"<", "&lt;"}, {">", "&gt;"}})
     );
 
     private final CharSequenceTranslator BASIC_XML = new AggregateTranslator(


### PR DESCRIPTION
…tes or lt/gt tags in the title. Titles like "Test access to "<color>"" caused strange effects on the report (data-order attribute got unbound by the quotes, <color> was interpreted as HTML tag.