### PR TITLE
Bugfixs/3523 newpr

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/default.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/default.ftl
@@ -38,11 +38,14 @@
         <#list breadcrumbs as breadcrumb>
             <#assign breadcrumbReport = absoluteReportName.forRequirement(breadcrumb) />
             <#assign breadcrumbTitle = breadcrumb.displayName > <!-- inflection.of(breadcrumb.displayName).asATitle()-->
-            > <a href="${breadcrumbReport}">${formatter.htmlCompatibleStoryTitle(breadcrumbTitle)}</a>
+            > <a href="${breadcrumbReport}">
+            ${formatter.escapeHtmlTags(formatter.htmlCompatibleStoryTitle(breadcrumbTitle))}
+        </a>
         </#list>
 <#--        > ${formatter.htmlCompatibleTestTitle(formatter.renderTitle(testOutcome.title))}-->
 <#--        > ${formatter.htmlCompatibleTestTitle(testOutcome.title)}-->
-        > ${formatter.htmlCompatibleTestTitle(formatter.humanReadableFormOf(testOutcome.title))}
+        >
+            ${formatter.escapeHtmlTags(formatter.htmlCompatibleTestTitle(formatter.humanReadableFormOf(testOutcome.title)))}
         </span>
         </div>
         <div class="rightbg"></div>
@@ -346,7 +349,7 @@
                                 <#assign roeResult = row.result/>
                             </#if>
                             <td class="test-${roeResult}"><a
-                                        href="#${rowIndex}">${formatter.plainHtmlCompatible(value)}</a>
+                                        href="#${rowIndex}"><#outputformat 'HTML'>${formatter.plainHtmlCompatible(value)}</#outputformat></a>
                             </td>
                         </#list>
                     </tr>

--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -503,11 +503,11 @@
                                                                                 <a href="${scenario.parentReport}">${scenario.parentName}</a>
                                                                             </#if>
                                                                         </td>
-                                                                        <td data-order="${scenario.title}">
+                                                                        <td data-order="<#outputformat 'HTML'>${scenario.title}</#outputformat>">
                                                                             <#if (scenario.hasExamples() && scenario.getExampleOutcomes()?has_content)>
                                                                             <i class="bi bi-table"
                                                                                title="Data Driven Scenario"> <a
-                                                                                        href="${scenario.scenarioReport}">${scenario.title}</a>
+                                                                                        href="${scenario.scenarioReport}"><#outputformat 'HTML'>${scenario.title}</#outputformat></a>
                                                                                 <br/>
                                                                                 <#list scenario.getResultCounts() as resultCount>
                                                                                     <#assign outcome_icon = formatter.resultIcon().forResult(resultCount.result) />

--- a/serenity-report-resources/src/main/resources/freemarker/junit5/default.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/junit5/default.ftl
@@ -338,7 +338,7 @@
                                     <#assign roeResult = row.result/>
                                 </#if>
                                 <td class="test-${roeResult}"><a
-                                            href="#${rowIndex}">${formatter.plainHtmlCompatible(value)}</a>
+                                            href="#${rowIndex}"><#outputformat 'HTML'>${formatter.plainHtmlCompatible(value)}</#outputformat></a>
                                 </td>
                             </#list>
                         </tr>

--- a/serenity-report-resources/src/main/resources/freemarker/requirements.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/requirements.ftl
@@ -587,7 +587,7 @@
                                                                     </td>
                                                                     <td>
                                                                         <#if (scenario.hasExamples() && scenario.getExampleOutcomes()?has_content)>
-                                                                        <i class="bi bi-table" title="Data Driven Scenario"> <a href="${scenario.scenarioReport}">${scenario.title}</a>
+                                                                        <i class="bi bi-table" title="Data Driven Scenario"> <a href="${scenario.scenarioReport}"><#outputformat 'HTML'>${scenario.title}</#outputformat></a>
                                                                             <br/>
                                                                             <#list scenario.getResultCounts() as resultCount>
                                                                                 <#assign outcome_icon = formatter.resultIcon().forResult(resultCount.result) />

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
@@ -437,8 +437,7 @@ public class Formatter {
 
     private static final CharSequenceTranslator ESCAPE_SPECIAL_CHARS = new AggregateTranslator(
             new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE()),
-            new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE()),
-            new LookupTranslator(new String[][] { {"<", "&lt;"}, {">", "&gt;"}})
+            new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE())
     );
 
     private final CharSequenceTranslator BASIC_XML = new AggregateTranslator(
@@ -479,6 +478,10 @@ public class Formatter {
 
         return (MarkdownRendering.configuredIn(environmentVariables).renderMarkdownFor(MarkdownRendering.RenderedElements.story)) ?
                 (htmlCompatible(renderMarkdownWithoutTags(firstLine))) : htmlCompatible(firstLine);
+    }
+
+    public String escapeHtmlTags(String fieldValue) {
+        return fieldValue.replace("<", "&lt;").replace(">", "&gt;");
     }
 
     public String htmlCompatibleTestTitle(Object fieldValue) {

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/Formatter.java
@@ -437,7 +437,8 @@ public class Formatter {
 
     private static final CharSequenceTranslator ESCAPE_SPECIAL_CHARS = new AggregateTranslator(
             new LookupTranslator(EntityArrays.ISO8859_1_ESCAPE()),
-            new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE())
+            new LookupTranslator(EntityArrays.HTML40_EXTENDED_ESCAPE()),
+            new LookupTranslator(new String[][] { {"<", "&lt;"}, {">", "&gt;"}})
     );
 
     private final CharSequenceTranslator BASIC_XML = new AggregateTranslator(

--- a/serenity-reports/src/test/java/net/thucydides/core/reports/integration/WhenGeneratingAnHtmlReport.java
+++ b/serenity-reports/src/test/java/net/thucydides/core/reports/integration/WhenGeneratingAnHtmlReport.java
@@ -20,17 +20,18 @@ import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
 
     @Mock
     TestOutcomes allTestOutcomes;
-    
+
     @Before
     public void setupWorkingDirectory() throws IOException {
-        
+
         MockitoAnnotations.initMocks(this);
-        
+
         File screenshotsSourceDirectory = FileSystemUtils.getResourceAsFile("screenshots");
         File[] screenshots = screenshotsSourceDirectory.listFiles();
 
@@ -50,7 +51,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
 
         File htmlReport = reporter.generateReportFor(testOutcome);
 
-        assertThat(htmlReport.exists(), is(true));
+        assertThat(htmlReport, anExistingFile());
     }
 
     @Test
@@ -61,7 +62,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         testOutcome.determineTestFailureCause(new AssertionError("test failed"));
         File htmlReport = reporter.generateReportFor(testOutcome);
 
-        assertThat(htmlReport.exists(), is(true));
+        assertThat(htmlReport, anExistingFile());
     }
 
     @Test
@@ -73,7 +74,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         testOutcome.setAnnotatedResult(TestResult.FAILURE);
         File htmlReport = reporter.generateReportFor(testOutcome);
 
-        assertThat(htmlReport.exists(), is(true));
+        assertThat(htmlReport, anExistingFile());
     }
 
 
@@ -82,10 +83,10 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         TestOutcome testOutcome = new TestOutcome("a_simple_test_case");
         testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1"));
         reporter.generateReportFor(testOutcome);
-        
+
         File cssDir = new File(outputDirectory, "css");
         File cssStylesheet = new File(cssDir, "core.css");
-        assertThat(cssStylesheet.exists(), is(true));
+        assertThat(cssStylesheet, anExistingFile());
     }
 
     @Test
@@ -99,7 +100,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
 
         File cssDir = new File(differentOutputDirectory, "css");
         File cssStylesheet = new File(cssDir, "core.css");
-        assertThat(cssStylesheet.exists(), is(true));
+        assertThat(cssStylesheet, anExistingFile());
     }
 
     @Test
@@ -109,14 +110,14 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         testOutcome.recordStep(TestStepFactory.successfulTestStepCalled("step 1"));
 
         reporter.generateReportFor(testOutcome);
-        
+
         File report = new File(outputDirectory,Digest.ofTextValue("a_simple_test_case") + ".html");
         File cssDir = new File(outputDirectory, "css");
         File cssStylesheet = new File(cssDir, "core.css");
-        assertThat(cssStylesheet.exists(), is(true));
-        assertThat(report.exists(), is(true));
+        assertThat(cssStylesheet, anExistingFile());
+        assertThat(report, anExistingFile());
     }
-    
+
     @Test
     public void screenshots_should_have_a_separate_html_report()  throws Exception {
         TestOutcome testOutcome = TestOutcome.forTest("should_do_this", SomeTestScenario.class);
@@ -130,7 +131,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         File report = reporter.generateReportFor(testOutcome);
         File screenshotReport = withSuffix(report,"_screenshots");
 
-        assertThat(screenshotReport.exists(), is(true));
+        assertThat(screenshotReport, anExistingFile());
 
     }
 
@@ -215,7 +216,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         final String alternativeResourceDirectory = "alt-report-resources";
         reporter.setResourceDirectory(alternativeResourceDirectory);
         reporter.generateReportFor(testOutcome);
-        
+
         File expectedCssStylesheet = new File(new File(outputDirectory,"css"), "alternative.css");
         assertThat(expectedCssStylesheet.exists(), is(true));
     }
@@ -242,7 +243,7 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
 
         environmentVariables.setProperty("thucydides.report.resources", "alt-report-resources");
         reporter.generateReportFor(testOutcome);
-        
+
         File expectedCssStylesheet = new File(new File(outputDirectory,"css"), "alternative.css");
         assertThat(expectedCssStylesheet.exists(), is(true));
     }
@@ -256,12 +257,12 @@ public class WhenGeneratingAnHtmlReport extends AbstractReportGenerationTest {
         final String alternativeResourceDirectory = "alt-report-resources";
         reporter.setResourceDirectory(alternativeResourceDirectory);
         reporter.generateReportFor(testOutcome);
-        
+
         File defaultCssStylesheet = new File(new File(outputDirectory,"css"), "core.css");
         assertThat(defaultCssStylesheet.exists(), is(false));
     }
 
-    
+
     @Test
     public void a_sample_report_should_be_generated_in_the_target_directory() throws Exception {
 


### PR DESCRIPTION
redone the previous branch, now consisting of the following changes:

1) added escapeHtmlTags to Formatter which is used in breadcrumbs to escape example parameters used in scenario titles (especially the < and > characters

Scenario Outline: This is a dummy title for <message>

would as of now end up in breadcrumbs as "This is a dummy title for"

2) using <#outputFormat 'HTML'> on some locations in the ftl files where such a title would cause a misformatting or "sucking" the param string. Also in the tables showing the example values if one of the values itself would be an html tag like for example: 
Examples:
| value|
|red|
|<yellowtagged>|

would yield a table with no visible value in the second row

lastly the test code uses hamcrest for checking if file exists by checking if exists returns true, whereas hamcrest suggest to use the anExistingFile() method approach