### PR TITLE
fix: make StepEventBus.registeredListeners thread-safe (#3540)

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
@@ -32,6 +32,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
@@ -128,7 +129,7 @@ public class StepEventBus {
         STICKY_EVENT_BUSES.remove(key);
     }
 
-    private List<StepListener> registeredListeners = new ArrayList<>();
+    private List<StepListener> registeredListeners = new CopyOnWriteArrayList<>();
     /**
      * A reference to the base step listener, if registered.
      */


### PR DESCRIPTION
to alleviate a race condition iterating and deleting listeners concurrently