### PR TITLE
perf: avoid creating unused StepEventBuses

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
@@ -106,9 +106,8 @@ public class StepEventBus {
         if (key == null) {
             return new SilentEventBus(ConfiguredEnvironment.getEnvironmentVariables());
         }
-        STICKY_EVENT_BUSES.putIfAbsent(key, new StepEventBus(ConfiguredEnvironment.getEnvironmentVariables(),
-                ConfiguredEnvironment.getConfiguration()));
-        return STICKY_EVENT_BUSES.get(key);
+        return STICKY_EVENT_BUSES.computeIfAbsent(key, (unused) -> new StepEventBus(
+                ConfiguredEnvironment.getEnvironmentVariables(), ConfiguredEnvironment.getConfiguration()));
     }
 
     public static void setCurrentBusToEventBusFor(Object key) {


### PR DESCRIPTION
instead, use computeIfAbsent() to instantiate StepEventBus only when needed