### PR TITLE
fix: throw exception immediately

### DIFF
--- a/serenity-core/src/main/java/net/serenitybdd/core/Serenity.java
+++ b/serenity-core/src/main/java/net/serenitybdd/core/Serenity.java
@@ -348,7 +348,7 @@ public class Serenity {
     public static boolean shouldThrowErrorsImmediately() {
         // Throw errors immediately if this is a Cucumber test
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-        return Arrays.stream(stackTrace).anyMatch(element -> element.getClassName().contains("io.cucumber.core"));
+        return throwExceptionsImmediately.get() || Arrays.stream(stackTrace).anyMatch(element -> element.getClassName().contains("io.cucumber.core"));
     }
 
     public static WebDriverConfigurer webdriver() {


### PR DESCRIPTION
It seems recently the functionality for throwsExceptionImmediately has changed, a new thread local was created but it seems it was not used