### PR TITLE
Fix for #3258 - Handle path related issues in Windows

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/model/domain/Story.java
+++ b/serenity-model/src/main/java/net/thucydides/model/domain/Story.java
@@ -99,7 +99,7 @@ public class Story {
             Path storyPath = null;
             try {
                 storyPath = Paths.get(new URI(path));
-            } catch (URISyntaxException e) {
+            } catch (URISyntaxException | IllegalArgumentException e) {
                 storyPath = Paths.get(path);
             }
             for (int i = 0; i < storyPath.getNameCount(); i++) {


### PR DESCRIPTION
Edge case scenario converting file name to uri which misses the scheme leading to failure