### PR TITLE
Ensure HTML is properly escaped for all user-provided text properties

### DIFF
--- a/serenity-report-resources/src/main/resources/freemarker/home.ftl
+++ b/serenity-report-resources/src/main/resources/freemarker/home.ftl
@@ -528,7 +528,7 @@
                                                                         <td>${context_icon}<span style="display:none">${context_label}</span>
                                                                         </td>
                                                                         <td>${scenario.stepCount}</td>
-                                                                        <td>${scenario.allStepsText}</td>
+                                                                        <td><#outputformat 'HTML'>${scenario.allStepsText}</#outputformat></td>
                                                                         <td data-order="${scenario.timestamp}">${scenario.formattedStartTime}</td>
                                                                         <td>${scenario.formattedDuration}</td>
                                                                         <td>${outcome_icon} <span
@@ -658,7 +658,7 @@
                                                                 <#list evidence as evidenceRecord>
                                                                     <tr>
                                                                         <td>${evidenceRecord.scenario}</td>
-                                                                        <td>${evidenceRecord.title}</td>
+                                                                        <td><#outputformat 'HTML'>${evidenceRecord.title}</#outputformat></td>
                                                                         <td>${evidenceRecord.detailsLink}</td>
                                                                     </tr>
                                                                 </#list>


### PR DESCRIPTION
This fixes a problem in generated reports, when the user provided text fields contain HTML

<img width="379" alt="Bildschirmfoto 2024-12-06 um 09 32 17" src="https://github.com/user-attachments/assets/00f495de-f14f-4c87-921e-53e62c637c92">

The HTML in the fields is escaped. This PR builds on the work done in https://github.com/serenity-bdd/serenity-core/pull/3523