### PR TITLE
Deal consistently with steps throwing exception which is caught by enclosing step.

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
@@ -25,7 +25,6 @@ import net.thucydides.model.ThucydidesSystemProperty;
 import net.serenitybdd.annotations.TestAnnotations;
 import net.thucydides.core.junit.SerenityJUnitTestCase;
 import net.thucydides.model.domain.*;
-import net.thucydides.model.domain.failures.FailureAnalysis;
 import net.thucydides.model.domain.stacktrace.FailureCause;
 import net.thucydides.model.screenshots.ScreenshotAndHtmlSource;
 import net.thucydides.core.steps.session.TestSession;
@@ -905,8 +904,6 @@ public class BaseStepListener implements StepListener, StepPublisher {
         );
     }
 
-    FailureAnalysis failureAnalysis = new FailureAnalysis();
-
     public void stepFailed(StepFailure failure) {
 
         if (!aStepHasFailed() || StepEventBus.getEventBus().softAssertsActive()) {
@@ -918,9 +915,6 @@ public class BaseStepListener implements StepListener, StepPublisher {
 
             recordFailureDetails(failure);
         }
-
-        // In all cases, mark the step as done with the appropriate result
-        currentStepDone(failureAnalysis.resultFor(failure));
     }
 
     public void stepFailed(StepFailure failure,
@@ -937,8 +931,6 @@ public class BaseStepListener implements StepListener, StepPublisher {
 
             recordFailureDetails(failure);
         }
-        // Step marked as done with the appropriate result before
-        currentStepDone(failureAnalysis.resultFor(failure), timestamp);
     }
 
 
@@ -951,8 +943,7 @@ public class BaseStepListener implements StepListener, StepPublisher {
 
             recordFailureDetails(failure);
         }
-        currentStepDone(failureAnalysis.resultFor(failure));
-    }
+  }
 
     public void lastStepFailed(StepFailure failure) {
         takeEndOfStepScreenshotFor(FAILURE);

--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepEventBus.java
@@ -614,7 +614,6 @@ public class StepEventBus {
 
     public void stepFailed(final StepFailure failure) {
 
-        stepDone();
         getResultTally().logFailure(failure);
 
         for (StepListener stepListener : getAllListeners()) {
@@ -628,7 +627,6 @@ public class StepEventBus {
                            boolean isInDataDrivenTest,
                            ZonedDateTime timestamp) {
 
-        stepDone();
         getResultTally().logFailure(failure);
 
         for (StepListener stepListener : getAllListeners()) {

--- a/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/StepInterceptor.java
@@ -495,8 +495,12 @@ public class StepInterceptor implements MethodErrorReporter, Interceptor {
         if (StepEventBus.getEventBus().aStepInTheCurrentTestHasFailed() && !StepEventBus.getEventBus().softAssertsActive()) {
             return;
         }
-        notifyOfStepFailure(object, method, args, assertionError);
-        LOGGER.debug("STEP FAILED: {} - {}", StepName.fromStepAnnotationIn(method).orElse(method.getName()), assertionError.getMessage());
+        try {
+            LOGGER.debug("STEP FAILED: {} - {}", StepName.fromStepAnnotationIn(method).orElse(method.getName()), assertionError.getMessage());
+            notifyOfStepFailure(object, method, args, assertionError);
+        } finally {
+            notifyStepFinishedFor(method, args);
+        }
     }
 
     private Object executeTestStepMethod(Object obj, Method method, Object[] args, Method zuperMethod, Object result) throws Throwable {

--- a/serenity-cucumber/src/main/java/io/cucumber/core/plugin/ScenarioContextParallel.java
+++ b/serenity-cucumber/src/main/java/io/cucumber/core/plugin/ScenarioContextParallel.java
@@ -339,12 +339,6 @@ public class ScenarioContextParallel {
 
     public void addStepEventBusEvent(StepEventBusEvent event) {
         if (TestSession.isSessionStarted()) {
-            if (event instanceof StepFinishedWithResultEvent) {
-                if (Status.FAILED.equals(((StepFinishedWithResultEvent) event).getResult().getStatus()) && TestSession.currentStepHasFailed()) {
-                    LOGGER.debug("SRP:ignored event " + event + " " + Thread.currentThread() + " because current Step has already failed");
-                    return;
-                }
-            }
             TestSession.addEvent(event);
             event.setStepEventBus(stepEventBus);
         } else {

--- a/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/events/StepFinishedWithResultEvent.java
+++ b/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/events/StepFinishedWithResultEvent.java
@@ -71,6 +71,7 @@ public class StepFinishedWithResultEvent extends StepEventBusEventBase {
                 getStepEventBus().stepFailed(stepFailure, screenshots, isInDataDrivenTest);
             }
         }
+        this.getStepEventBus().stepFinished(this.screenshotList, this.getTimestamp());
     }
 
     private void skipped(String stepTitle, Throwable cause) {


### PR DESCRIPTION
If a step is calling a behaviour that calls a sub-step which fails in an error and the outer step is catching the error and does not throw, the test report produces a wrong indentation for the subsequent steps. 

This PR fixes that in such a way that a step failure does not automatically close the step but each step is alway claused by a step finished event. Thus, the subsequent event parsing only pops a step from the step stack when encountering a finished event and during a step, any number of (caught but reported) failures can occur without breaking the report.

This probably also fixes the issue https://github.com/serenity-bdd/serenity-core/issues/3489