### PR TITLE
#3498 Issue fix

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/PageObjectDependencyInjector.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/PageObjectDependencyInjector.java
@@ -95,9 +95,9 @@ public class PageObjectDependencyInjector implements DependencyInjector {
 
     private void updatePageObject(Object pageObject) {//, Pages pages) {
         if (pageObject instanceof PageObject) {
-            if (Serenity.getWebdriverManager().hasAnInstantiatedDriver()) {
+//            if (Serenity.getWebdriverManager().hasAnInstantiatedDriver()) {
                 ((PageObject) pageObject).setDriver(Serenity.getWebdriverManager().getWebdriver());
-            }
+//            }
         }
     }
 


### PR DESCRIPTION
This PR fixes an issue where WebDriver was not automatically assigned in Serenity 4.2.x.(Issue #3498)
The `setDriver()` method was not being called due to changes in `PageObjectDependencyInjector`. Check this commit by wakaleo 74a5af8
