### PR TITLE
Fix invalid characters in trace file name

### DIFF
--- a/serenity-screenplay-playwright/src/main/java/net/serenitybdd/screenplay/playwright/abilities/BrowseTheWebWithPlaywright.java
+++ b/serenity-screenplay-playwright/src/main/java/net/serenitybdd/screenplay/playwright/abilities/BrowseTheWebWithPlaywright.java
@@ -144,7 +144,7 @@ public class BrowseTheWebWithPlaywright implements Ability, RefersToActor {
                 Optional<TestOutcome> latestOutcome = StepEventBus.getParallelEventBus().getBaseStepListener().latestTestOutcome();
 
                 guessedTestName = latestOutcome.map(
-                    testOutcome -> Optional.of(testOutcome.getStoryTitle() + ": " + testOutcome.getTitle())
+                    testOutcome -> Optional.of(testOutcome.getStoryTitle() + " - " + testOutcome.getTitle())
                 ).orElseGet(RemoteTestName::fromCurrentTest);
 
                 guessedTestName.ifPresent(name -> {


### PR DESCRIPTION
Fix: Replaced colon (":") with hyphen ("-") in the test outcome name used for generating the trace file name. This update ensures that generated file names are valid across all operating systems.