### PR TITLE
feat: improve contrast of tag at failed test in the report.

### DIFF
--- a/serenity-report-resources/src/main/resources/report-resources/css/core.css
+++ b/serenity-report-resources/src/main/resources/report-resources/css/core.css
@@ -2745,3 +2745,7 @@ div.code {
 .dataTables_filter input {
     font-weight: normal;
 }
+
+.scenario-docs.card-header.failure a.tagLink {
+    color: bisque;
+}


### PR DESCRIPTION
Tags are difficult to read at failed scenarios in the report - see the "Before" screenshot:

Before:
![Image](https://github.com/user-attachments/assets/bb0683ac-fcdd-4127-8849-61642fb42c76)

After:
![Image](https://github.com/user-attachments/assets/e9b7824f-6b01-42df-a8d4-850422b3f924)

Used test scenarios: https://github.com/Rudolf-AT/serenity-report-tag-contrast