### PR TITLE
Improve reporting of the 'CheckCheckbox'-tasks

### DIFF
--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/CheckCheckboxOfElement.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/CheckCheckboxOfElement.java
@@ -14,6 +14,7 @@ public class CheckCheckboxOfElement extends ClickOnClickable {
     }
 
     @Override
+    @Step("{0} sets value of checkbox #element to #expectedToBeChecked")
     public <T extends Actor> void performAs(T actor) {
         boolean isSelected = element.isSelected();
         if(isSelected != expectedToBeChecked) actor.attemptsTo(Click.on(element));

--- a/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/CheckCheckboxOfTarget.java
+++ b/serenity-screenplay-webdriver/src/main/java/net/serenitybdd/screenplay/actions/CheckCheckboxOfTarget.java
@@ -14,6 +14,7 @@ public class CheckCheckboxOfTarget extends ClickOnClickable {
     }
 
     @Override
+    @Step("{0} sets value of checkbox #target to #expectedToBeChecked")
     public <T extends Actor> void performAs(T actor) {
         boolean isSelected = actor.asksFor(SelectedStatus.of(target));
         if (isSelected != expectedToBeChecked) actor.attemptsTo(Click.on(target));


### PR DESCRIPTION
- Currently, the only thing being reported when using ootb tasks 'CheckCheckbox' or 'UncheckCheckbox' is "{Actor} check checkbox of target".
- As an improvement, include the value to-be-set and the actual target name in the reporting of these tasks.