### PR TITLE
fix: ensure not reporting question subject for boolean assert (#1818)

### DIFF
--- a/serenity-ensure/src/main/kotlin/net/serenitybdd/screenplay/ensure/BooleanEnsure.kt
+++ b/serenity-ensure/src/main/kotlin/net/serenitybdd/screenplay/ensure/BooleanEnsure.kt
@@ -12,7 +12,7 @@ class BooleanEnsure(override val value: KnowableValue<Boolean?>,
 
     constructor(value: Boolean?) : this(
         KnownValue<Boolean?>(value, if (value == null) "<null>" else "\"$value\""),
-        java.util.Comparator.naturalOrder<Boolean>()
+        Comparator.naturalOrder<Boolean>()
     )
     
     fun isTrue() = PerformablePredicate<KnowableValue<Boolean?>?>(value, IS_TRUE, isNegated(), descriptionOf(value))


### PR DESCRIPTION
An Ensure.that(Question that returns boolean).isEqualto(true) did not report the subject of a Boolean-question. This was earlier reported in #1818. This fix restores the reporting of the subject.