### PR TITLE
fix: Actor abilities/facts not recorded in Cucumber parallel mode

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/events/AssignAbilityToActorEvent.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/events/AssignAbilityToActorEvent.java
@@ -1,0 +1,19 @@
+package net.thucydides.core.steps.events;
+
+public class AssignAbilityToActorEvent extends StepEventBusEventBase {
+
+    private final String actorName;
+    private final String ability;
+
+    public AssignAbilityToActorEvent(String actorName, String ability) {
+        this.actorName = actorName;
+        this.ability = ability;
+    }
+
+    @Override
+    public void play() {
+        getStepEventBus().getBaseStepListener().latestTestOutcome().ifPresent(
+                testOutcome -> testOutcome.assignAbility(actorName, ability)
+        );
+    }
+}

--- a/serenity-core/src/main/java/net/thucydides/core/steps/events/AssignFactToActorEvent.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/events/AssignFactToActorEvent.java
@@ -1,0 +1,19 @@
+package net.thucydides.core.steps.events;
+
+public class AssignFactToActorEvent extends StepEventBusEventBase {
+
+    private final String actorName;
+    private final String fact;
+
+    public AssignFactToActorEvent(String actorName, String fact) {
+        this.actorName = actorName;
+        this.fact = fact;
+    }
+
+    @Override
+    public void play() {
+        getStepEventBus().getBaseStepListener().latestTestOutcome().ifPresent(
+                testOutcome -> testOutcome.assignFact(actorName, fact)
+        );
+    }
+}

--- a/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/EventBusInterface.java
+++ b/serenity-screenplay/src/main/java/net/serenitybdd/screenplay/EventBusInterface.java
@@ -163,22 +163,26 @@ public class EventBusInterface {
         if (!StepEventBus.getParallelEventBus().isBaseStepListenerRegistered()) {
             return;
         }
-        StepEventBus.getParallelEventBus().getBaseStepListener().latestTestOutcome().ifPresent(
-                testOutcome -> testOutcome.assignFact(actor.getName(), fact)
-        );
+        if (!TestSession.isSessionStarted()) {
+            StepEventBus.getParallelEventBus().getBaseStepListener().latestTestOutcome().ifPresent(
+                    testOutcome -> testOutcome.assignFact(actor.getName(), fact)
+            );
+        } else {
+            TestSession.addEvent(new AssignFactToActorEvent(actor.getName(), fact));
+        }
     }
 
     public void assignAbilityToActor(Actor actor, String ability) {
         if (!StepEventBus.getParallelEventBus().isBaseStepListenerRegistered()) {
             return;
         }
-        if (StepEventBus.getParallelEventBus().getBaseStepListener().latestTestOutcome() == null) {
-            return;
+        if (!TestSession.isSessionStarted()) {
+            StepEventBus.getParallelEventBus().getBaseStepListener().latestTestOutcome().ifPresent(
+                    testOutcome -> testOutcome.assignAbility(actor.getName(), ability)
+            );
+        } else {
+            TestSession.addEvent(new AssignAbilityToActorEvent(actor.getName(), ability));
         }
-
-        StepEventBus.getParallelEventBus().getBaseStepListener().latestTestOutcome().ifPresent(
-                testOutcome -> testOutcome.assignAbility(actor.getName(), ability)
-        );
     }
 
 }

--- a/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/facts/WhenDeclaringFactsAboutActors.java
+++ b/serenity-screenplay/src/test/java/net/serenitybdd/screenplay/facts/WhenDeclaringFactsAboutActors.java
@@ -5,9 +5,12 @@ import net.serenitybdd.model.exceptions.TestCompromisedException;
 import net.serenitybdd.screenplay.Ability;
 import net.serenitybdd.screenplay.Actor;
 import net.thucydides.core.steps.StepEventBus;
+import net.thucydides.core.steps.events.StepEventBusEvent;
+import net.thucydides.core.steps.session.TestSession;
 import net.thucydides.model.domain.CastMember;
 import net.thucydides.model.domain.Story;
 import net.thucydides.model.domain.TestOutcome;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,6 +27,14 @@ public class WhenDeclaringFactsAboutActors {
         Serenity.initialize(this);
         StepEventBus.getParallelEventBus().testSuiteStarted(Story.called("sample story"));
         StepEventBus.getParallelEventBus().testStarted("sample test");
+    }
+
+    @After
+    public void cleanup() {
+        if (TestSession.isSessionStarted()) {
+            TestSession.closeSession();
+        }
+        TestSession.cleanupSession();
     }
 
     static List<String> knownAccounts = new ArrayList<>();
@@ -147,5 +158,34 @@ public class WhenDeclaringFactsAboutActors {
         assertThat(castMember.getCan()).contains("Do his accounts");
     }
 
+     @Test
+    public void facts_and_abilities_are_recorded_in_test_reports_when_test_session_is_active() {
+        // Given
+        StepEventBus stepEventBus = StepEventBus.getParallelEventBus();
+        TestSession.startSession("parallel-abilities", stepEventBus);
+
+        Actor tim = Actor.named("Tim");
+        tim.whoCan(new DoHisAccounts());
+        givenThat(tim).has(AnAccount.numbered("999888"));
+
+        TestSession.closeSession();
+
+        // When
+        stepEventBus.testStarted("parallel abilities test");
+        for (StepEventBusEvent event : TestSession.getTestSessionContext().getStepEventBusEvents()) {
+            event.setStepEventBus(stepEventBus);
+            event.play();
+        }
+        stepEventBus.testFinished();
+
+        // Then
+        TestOutcome testOutcome = stepEventBus.getBaseStepListener().latestTestOutcome().get();
+
+        assertThat(testOutcome.getActors()).isNotEmpty();
+        CastMember castMember = testOutcome.getActors().get(0);
+        assertThat(castMember.getName()).isEqualTo("Tim");
+        assertThat(castMember.getHas()).containsExactly("An account numbered 999888");
+        assertThat(castMember.getCan()).containsExactly("Do his accounts");
+    }
 }
 


### PR DESCRIPTION
Fixes #3730

- Add `AssignAbilityToActorEvent` and `AssignFactToActorEvent` mirroring `CastActorEvent` pattern
- Update `EventBusInterface.assignAbilityToActor()` and `assignFactToActor()` to use `TestSession` when session is active
- Add parallel test that fails without fix, passes with fix applied

Also built the jar and ran against the [bug reproduction project](https://github.com/lsmarsden/serenity-demo/tree/cast-bug) which showed the report now populating the abilities and facts in the Cast section:

<img width="1324" height="774" alt="CastDetailsInReportWithFixedJar" src="https://github.com/user-attachments/assets/5d4030b6-4068-4a50-b527-85c0264fc153" />

Let me know if there are any stylistic changes or other checks required. I wasn't sure how to assess the impact of changing EventBusInterface (without just trusting current test coverage).