### PR TITLE
fix(requirements): RootDirectory honours serenity.test.requirements.basedir (#3733)

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/model/requirements/RootDirectory.java
+++ b/serenity-model/src/main/java/net/thucydides/model/requirements/RootDirectory.java
@@ -265,6 +265,23 @@ public class RootDirectory {
             URI serenityReqDir = new File(ThucydidesSystemProperty.SERENITY_REQUIREMENTS_DIR.from(environmentVariables)).toURI();
             return Optional.of(Paths.get(serenityReqDir));
         }
+
+        // The Gradle plugin's `AggregateTask` wires its `requirementsBaseDir` DSL field
+        // into `serenity.test.requirements.basedir`, but does not mirror it into
+        // `serenity.requirements.dir`. For multi-module Gradle builds the working
+        // directory during aggregation is the root project (not the sub-module owning
+        // the feature files), so the classpath / resource scans below do not find the
+        // feature tree. Honouring the `basedir` property here makes the existing
+        // plugin wiring work without requiring callers to double-configure the same
+        // path under two property names.
+        if (ThucydidesSystemProperty.SERENITY_TEST_REQUIREMENTS_BASEDIR.isDefinedIn(environmentVariables)) {
+            File basedir = new File(
+                    ThucydidesSystemProperty.SERENITY_TEST_REQUIREMENTS_BASEDIR.from(environmentVariables));
+            if (basedir.isDirectory()) {
+                return Optional.of(basedir.toPath());
+            }
+        }
+
         List<File> resourceDirectories = getResourceDirectories(Paths.get(relativeRoot), environmentVariables);
         List<File> resourceDirectoriesByIncreasingDepth = resourceDirectories.stream()
                 .sorted(Comparator.comparingInt(dir -> dir.getAbsolutePath().length()))

--- a/serenity-model/src/test/java/net/thucydides/model/requirements/WhenFindingTheRootDirectoryForFeatureFiles.java
+++ b/serenity-model/src/test/java/net/thucydides/model/requirements/WhenFindingTheRootDirectoryForFeatureFiles.java
@@ -3,9 +3,16 @@ package net.thucydides.model.requirements;
 import net.thucydides.model.environment.MockEnvironmentVariables;
 import net.thucydides.model.util.EnvironmentVariables;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WhenFindingTheRootDirectoryForFeatureFiles {
 
@@ -23,5 +30,55 @@ public class WhenFindingTheRootDirectoryForFeatureFiles {
         String featureDirectory = new File("src/test/resources/features").getAbsolutePath();
         RootDirectory rootDirectory = new RootDirectory(environmentVariables,featureDirectory);
         Set<String> directoryPaths = rootDirectory.getRootDirectoryPaths();
+    }
+
+    @Test
+    void featuresOrStoriesRootDirectoryFallsBackToTestRequirementsBasedir(@TempDir Path tempDir) throws Exception {
+        // Simulates the Gradle plugin's AggregateTask wiring: `requirementsBaseDir` is set,
+        // but `serenity.requirements.dir` is not. featuresOrStoriesRootDirectory() should
+        // pick up the basedir instead of falling through to the working-directory scan
+        // (which misfires in multi-module Gradle builds because user.dir == root project).
+        Path featuresDir = tempDir.resolve("features");
+        Files.createDirectories(featuresDir);
+
+        environmentVariables.setProperty("serenity.test.requirements.basedir", featuresDir.toString());
+
+        RootDirectory rootDirectory = new RootDirectory(environmentVariables, ".");
+        Optional<Path> resolved = rootDirectory.featuresOrStoriesRootDirectory();
+
+        assertTrue(resolved.isPresent(), "Expected featuresOrStoriesRootDirectory() to honour serenity.test.requirements.basedir");
+        assertEquals(featuresDir.toAbsolutePath(), resolved.get().toAbsolutePath());
+    }
+
+    @Test
+    void serenityRequirementsDirTakesPrecedenceOverBasedir(@TempDir Path tempDir) throws Exception {
+        // When both properties are set, the existing behaviour (SERENITY_REQUIREMENTS_DIR wins)
+        // must be preserved — the new fallback must not regress that order.
+        Path primary = tempDir.resolve("primary/features");
+        Path fallback = tempDir.resolve("fallback/features");
+        Files.createDirectories(primary);
+        Files.createDirectories(fallback);
+
+        environmentVariables.setProperty("serenity.requirements.dir", primary.toString());
+        environmentVariables.setProperty("serenity.test.requirements.basedir", fallback.toString());
+
+        Optional<Path> resolved = new RootDirectory(environmentVariables, ".").featuresOrStoriesRootDirectory();
+
+        assertTrue(resolved.isPresent());
+        assertEquals(primary.toAbsolutePath(), resolved.get().toAbsolutePath());
+    }
+
+    @Test
+    void basedirFallbackIgnoresNonExistentPaths(@TempDir Path tempDir) {
+        // Guard against a stale basedir value masking the classpath/working-dir fallback.
+        String nonExistent = tempDir.resolve("does-not-exist").toString();
+        environmentVariables.setProperty("serenity.test.requirements.basedir", nonExistent);
+
+        Optional<Path> resolved = new RootDirectory(environmentVariables, ".").featuresOrStoriesRootDirectory();
+
+        // The fallback must not hand back a path that does not exist — callers treat the
+        // Optional.of(...) result as authoritative.
+        resolved.ifPresent(path -> assertTrue(path.toFile().exists(),
+                "featuresOrStoriesRootDirectory() should not return a non-existent basedir: " + path));
     }
 }


### PR DESCRIPTION
## Summary

Adds a fallback in `RootDirectory.featuresOrStoriesRootDirectory()` so it honours `serenity.test.requirements.basedir` when `serenity.requirements.dir` is unset. This makes the existing `serenity-gradle-plugin` `AggregateTask` wiring work for multi-module Gradle builds without asking callers to configure the same path under two property names.

Fixes #3733.

## Intended effect

For a multi-module Gradle project that puts its feature tree in a sub-module (e.g. `<module>/src/main/resources/features/`) and configures:

```kotlin
serenity {
    requirementsBaseDir = file("src/main/resources/features").absolutePath
    outputDirectory = "build/site/report"
}
```

…running `./gradlew :<module>:aggregate` will now load the full requirements tree and emit the usual hierarchical HTML pages (`requirement_type_theme.html`, `requirement_type_capability.html`, `requirement_type_feature.html`, `theme_*.html`, `capability_*.html`) plus any narratives from per-directory `narrative.md` files.

Before this change, the same setup yielded a flat `capabilities.html` with no hierarchy and no narratives, while the aggregate log simultaneously reported "Generating test results for 47 tests" and "0 requirements loaded" — because `FileSystemRequirementsTagProvider`'s no-arg constructor fell back to `user.dir + "/src/test/resources/features"` (the root project during `:module:aggregate`, not the sub-module). Full analysis in #3733.

## How this was manually tested

On the affected downstream project:

```bash
./gradlew :<module>:aggregate --rerun-tasks --debug
```

Before the fix, the aggregate log shows:

```
0 requirements loaded after 335 ms
```

After the fix (with `SERENITY_TEST_REQUIREMENTS_BASEDIR` set by the Gradle plugin, which is already the default wiring):

```
54 requirements loaded after 210 ms
```

and the report output directory gains ~20 additional HTML files corresponding to the three requirement types and every theme/capability under the feature tree, plus rendered narratives from `narrative.md`.

Equivalent confirmation by setting `-Dserenity.requirements.dir=<abs path>` on the aggregate task on the unpatched build — same outcome — isolates the path resolution as the sole cause.

## Tests

`serenity-model/src/test/java/net/thucydides/model/requirements/WhenFindingTheRootDirectoryForFeatureFiles.java` gains three cases, all passing:

- `featuresOrStoriesRootDirectoryFallsBackToTestRequirementsBasedir` — the new fallback fires when only `serenity.test.requirements.basedir` is set and the path exists.
- `serenityRequirementsDirTakesPrecedenceOverBasedir` — guards the existing contract: when both properties are set, `serenity.requirements.dir` still wins.
- `basedirFallbackIgnoresNonExistentPaths` — stale basedir values do not leak a non-existent path to callers; the classpath/working-directory scan fallback is retained.

Local run: `./mvnw -pl serenity-model -Dtest='WhenFindingTheRootDirectoryForFeatureFiles' -Dsurefire.failIfNoSpecifiedTests=false test` → `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`.

## Side effects

None expected.

- When `serenity.requirements.dir` is set, behaviour is unchanged (the new branch is unreachable).
- When neither property is set, behaviour is unchanged (the existing classpath/working-directory scan still runs).
- When only `serenity.test.requirements.basedir` is set and points at a directory that does not exist, the fallback is skipped and behaviour again matches the pre-patch code path.

The only observable change is the case the bug report targets: only `serenity.test.requirements.basedir` is set and points at a real directory. Previously that configuration quietly resolved to the wrong path; now it resolves correctly.

## Documentation changes

No changes required. `serenity.test.requirements.basedir` is already documented as the companion of the Gradle plugin's `requirementsBaseDir` DSL field; this PR makes the runtime behaviour match that documented expectation.

## Relevant tickets

- Fixes #3733

## Checklist

- [x] Tests added (`WhenFindingTheRootDirectoryForFeatureFiles`, 3 new cases)
- [x] `./mvnw -pl serenity-model test` passes locally
- [x] `git diff --check` clean
- [x] Commit message follows the `<type>: <message>` convention
