### PR TITLE
fix: fixes skipped Scenario Outlines with tagged examples in report

### DIFF
--- a/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
+++ b/serenity-core/src/main/java/net/thucydides/core/steps/BaseStepListener.java
@@ -713,8 +713,13 @@ public class BaseStepListener implements StepListener, StepPublisher {
     }
 
     private void testAndTopLevelStepsShouldBeIgnored() {
-        getCurrentTestOutcome().setResult(IGNORED);
         if (getCurrentTestOutcome().isDataDriven()) {
+            getCurrentTestOutcome().updateCurrentRowResult(IGNORED);
+            if (getCurrentTestOutcome().getResult() == null || getCurrentTestOutcome().getResult() == TestResult.UNDEFINED) {
+                getCurrentTestOutcome().setResult(IGNORED);
+            }
+        } else {
+            getCurrentTestOutcome().setResult(IGNORED);
             getCurrentTestOutcome().updateTopLevelStepResultsTo(IGNORED);
         }
 


### PR DESCRIPTION
# fix: Scenario Outline examples reported as skipped when separated by tags

#### Summary of this PR
Fixes a reporting bug mentioned in #3691 in `BaseStepListener.testAndTopLevelStepsShouldBeIgnored()` where passed example rows of a Cucumber `Scenario Outline` with multiple tag-separated `Examples` blocks were incorrectly rendered as skipped in the Serenity report.

#### Intended effect
- **Before:** When one `Examples` block was filtered/ignored via tags, all previously passed rows of the same outline were retroactively marked as `IGNORED`. Failed rows were correct.
- **After:** Only the actually filtered/ignored rows are marked as `IGNORED`. Passed rows stay `SUCCESS`, failed rows stay `FAILURE`, and the overall outline result is no longer downgraded when prior rows already produced a result.
- Non-data-driven (regular) ignored tests behave exactly as before.

#### How should this be manually tested?
1. In any Serenity + Cucumber project (e.g. `serenity-demos`), create a `Scenario Outline` with two `Examples` blocks, one tagged `@skip`.
2. Run with `-Dcucumber.filter.tags="not @skip"`.
3. Open the Serenity report and verify:
   - non-skipped rows render as **passed**,
   - the `@skip` row renders as **ignored**,
   - the outline overall is **passed**.
4. Re-run with one passing row changed to fail and confirm passed/failed/ignored rows are all reported correctly.

Before the fix, step 3 would show all rows as skipped.

#### Side effects
- For data-driven outcomes, `updateTopLevelStepResultsTo(IGNORED)` is no longer called — the `IGNORED` marker is now scoped to the current row via `updateCurrentRowResult(IGNORED)`.
- The overall `TestOutcome` result is set to `IGNORED` only when it is still `null` / `UNDEFINED`, preserving results from earlier rows.
- No public API changes (modified method is `private`).

#### Relevant tickets
- Fixes: _#3691_

Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>"