### PR TITLE
feat: show ignored tests count in console

### DIFF
--- a/serenity-model/src/main/java/net/thucydides/model/reports/TestOutcomes.java
+++ b/serenity-model/src/main/java/net/thucydides/model/reports/TestOutcomes.java
@@ -836,6 +836,8 @@ public class TestOutcomes {
         return this.withResult(TestResult.ABORTED);
     }
 
+    public TestOutcomes getIgnoredTests() { return this.withResult(TestResult.IGNORED); }
+
     public TestOutcomes getErrorTests() {
         return this.withResult(TestResult.ERROR);
     }

--- a/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
+++ b/serenity-reports/src/main/java/net/thucydides/core/reports/html/HtmlAggregateStoryReporter.java
@@ -186,14 +186,15 @@ public class HtmlAggregateStoryReporter extends HtmlReporter implements UserStor
             LOGGER.info("------------------------------------------------------------------------");
             LOGGER.info("Serenity BDD Test Results");
             LOGGER.info("  - Report guide: {}", DOCS_URL);
-            LOGGER.info("  - Results: {} tests | {} passed | {} failed | {} errors | {} compromised | {} pending | {} aborted",
+            LOGGER.info("  - Results: {} tests | {} passed | {} failed | {} errors | {} compromised | {} pending | {} aborted | {} ignored",
                 testOutcomes.getTestCount(),
                 testOutcomes.getPassingTests().getTestCount(),
                 testOutcomes.getFailingTests().getTestCount(),
                 testOutcomes.getErrorTests().getTestCount(),
                 testOutcomes.getCompromisedTests().getTestCount(),
                 testOutcomes.getPendingTests().getTestCount(),
-                testOutcomes.getAbortedTests().getTestCount());
+                testOutcomes.getAbortedTests().getTestCount(),
+                testOutcomes.getIgnoredTests().getTestCount());
 
             // Only show expanded details if something needs attention
             boolean hasIssues =
@@ -210,6 +211,7 @@ public class HtmlAggregateStoryReporter extends HtmlReporter implements UserStor
                 logIfNonZero("Compromised ", testOutcomes.getCompromisedTests().getTestCount());
                 logIfNonZero("Pending     ", testOutcomes.getPendingTests().getTestCount());
                 logIfNonZero("Aborted     ", testOutcomes.getAbortedTests().getTestCount());
+                logIfNonZero("Ignored     ", testOutcomes.getIgnoredTests().getTestCount());
             }
             LOGGER.info("------------------------------------------------------------------------");
             LOGGER.info("");


### PR DESCRIPTION
Fixes https://github.com/serenity-bdd/serenity-core/issues/3736

Added ignored tests count to console output

```
13:49:05.821 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter -- ------------------------------------------------------------------------
13:49:05.821 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter -- Serenity BDD Test Results
13:49:05.821 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter --   - Report guide: https://serenity-bdd.github.io
13:49:05.822 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter --   - Results: 25 tests | 19 passed | 0 failed | 0 errors | 0 compromised | 6 pending | 0 aborted | 0 ignored
13:49:05.822 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter --   - Issues detected:
13:49:05.822 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter --     - Pending     : 6
13:49:05.822 [main] INFO net.thucydides.core.reports.html.HtmlAggregateStoryReporter -- ------------------------------------------------------------------------
```