### PR TITLE
fix: SerenityReporterParallel fails to attach screenshots FOR_FAILURES

### DIFF
--- a/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/core/plugin/SerenityReporterParallel.java
+++ b/serenity-cucumber/src/main/java/net/serenitybdd/cucumber/core/plugin/SerenityReporterParallel.java
@@ -1002,7 +1002,7 @@ public class SerenityReporterParallel implements Plugin, ConcurrentEventListener
 
     private void recordStepResult(URI featurePath, Result result, io.cucumber.messages.types.Step currentStep, TestStep currentTestStep, boolean isInDataDrivenTest) {
         ZonedDateTime endTime = ZonedDateTime.now();
-        List<ScreenshotAndHtmlSource> screenshotList = getContext(featurePath).stepEventBus().takeScreenshots();
+        List<ScreenshotAndHtmlSource> screenshotList = getContext(featurePath).stepEventBus().takeScreenshots(serenityTestResultFrom(result.getStatus()));
         getContext(featurePath).addStepEventBusEvent(new StepFinishedWithResultEvent(result, currentStep, currentTestStep, screenshotList, endTime, isInDataDrivenTest));
     }
 


### PR DESCRIPTION
#### Summary of this PR
Fixes a bug in `SerenityReporterParallel` where screenshots are never attached to the report when `serenity.take.screenshots=FOR_FAILURES` is configured. A one-line change passes the actual step result to the screenshot capture call so the screenshot policy is evaluated against the real outcome.

#### Intended effect
Before this fix, `SerenityReporterParallel` never captured screenshots on step failure when using the `FOR_FAILURES` screenshot policy — the report would contain no screenshots even for failed steps. After this fix, screenshots are correctly captured when a step fails and correctly skipped when a step passes, matching the behaviour of the (deprecated) `SerenityReporter`.

There is no behavioural change for `BEFORE_AND_AFTER_EACH_STEP` or `AFTER_EACH_STEP` policies — those capture on every step regardless of result and are unaffected.

#### How should this be manually tested?
1. Configure a Cucumber/Serenity project to use `SerenityReporterParallel` with `serenity.take.screenshots=FOR_FAILURES`.
2. Write a scenario that contains at least one failing step and one passing step.
3. Run the tests and inspect the generated Serenity report.
4. **Expected (after fix):** the failing step has a screenshot attached; the passing step does not.
5. **Expected (before fix):** no screenshots are attached to any step.

This can be reproduced using the [serenity-demos](https://github.com/serenity-bdd/serenity-demos) project or any Appium/mobile test suite where per-step screenshot capture is disabled for performance reasons.

#### Side effects
None expected. The two building blocks used — `serenityTestResultFrom(Status)` and the `StepEventBus.takeScreenshots(TestResult)` overload — already existed in the codebase. No new infrastructure was introduced.

#### Documentation
This is a bug fix restoring already-documented behaviour for the `FOR_FAILURES` screenshot policy. No documentation changes are required. Users relying on `SerenityReporterParallel` with `FOR_FAILURES` (common for Appium/mobile suites) will benefit automatically.

#### Screenshots (if appropriate)
Before this fix, the Serenity HTML report shows **no screenshots** on failed steps when using `SerenityReporterParallel` + `FOR_FAILURES`. After the fix, failed steps display the captured screenshot as expected. Screenshots of the report output before/after would be valuable to include here.